### PR TITLE
PLAT-487 Configurable Repository Proxy

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,16 @@ buildscript {
 			allowInsecureProtocol true
 			url project['com.softicar.ivy.repository.url']
 		}
-		maven { url 'https://plugins.gradle.org/m2/' }
+		if(project.hasProperty('com.softicar.maven.proxies')) {
+			for(proxy: project['com.softicar.maven.proxies'].split("\\s")) {
+				maven {
+					allowInsecureProtocol true
+					url proxy
+				}
+			}
+		} else {
+			maven { url 'https://plugins.gradle.org/m2/' }
+		}
 	}
 	dependencies.classpath "com.softicar:com.softicar.gradle.plugin:3.1.3"
 }
@@ -55,7 +64,16 @@ project.ext {
 
 subprojects {
 	repositories {
-		mavenCentral()
+		if(project.hasProperty('com.softicar.maven.proxies')) {
+			for(proxy: project['com.softicar.maven.proxies'].split("\\s")) {
+				maven {
+					allowInsecureProtocol true
+					url proxy
+				}
+			}
+		} else {
+			mavenCentral()
+		}
 	}
 
 	configurations.all {


### PR DESCRIPTION
- extended build.gradle to support Maven proxies via build.properties
