### PR TITLE
PLAT-514 Using Gradle Plugins from Gradle Repository

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,30 +1,13 @@
-// -------------------- build script -------------------- //
-
-buildscript {
-	repositories {
-		ivy {
-			allowInsecureProtocol true
-			url project['com.softicar.ivy.repository.url']
-		}
-		if(project.hasProperty('com.softicar.maven.proxies')) {
-			for(proxy: project['com.softicar.maven.proxies'].split("\\s")) {
-				maven {
-					allowInsecureProtocol true
-					url proxy
-				}
-			}
-		} else {
-			maven { url 'https://plugins.gradle.org/m2/' }
-		}
-	}
-	dependencies.classpath "com.softicar:com.softicar.gradle.plugin:3.1.3"
-}
 
 // -------------------- plug-ins -------------------- //
 
-apply plugin: 'com.softicar.gradle.java.library' 
-apply plugin: 'com.softicar.gradle.release' 
-apply plugin: 'com.softicar.gradle.selenium.grid'
+plugins {
+	id 'com.softicar.gradle.java.library' version '4.0.1'
+	id 'com.softicar.gradle.code.validation' version '4.0.1' apply false
+	id 'com.softicar.gradle.dependency.validation' version '4.0.1' apply false
+	id 'com.softicar.gradle.selenium.grid' version '4.0.1'
+	id 'com.softicar.gradle.test.logger' version '4.0.1' apply false
+}
 
 // -------------------- dependencies -------------------- //
 
@@ -58,20 +41,27 @@ project.ext {
 	]
 }
 
-subprojects {
-	repositories {
-		if(project.hasProperty('com.softicar.maven.proxies')) {
-			for(proxy: project['com.softicar.maven.proxies'].split("\\s")) {
+if(project.hasProperty('dependencyProxy')) {
+	println "Using dependency proxy: $dependencyProxy"
+	subprojects {
+		repositories {
+			for(proxy: project['dependencyProxy'].split("\\s")) {
 				maven {
 					allowInsecureProtocol true
 					url proxy
 				}
 			}
-		} else {
+		}
+	}
+} else {
+	subprojects {
+		repositories {
 			mavenCentral()
 		}
 	}
+}
 
+subprojects {
 	configurations.all {
 		resolutionStrategy {
 			failOnVersionConflict()
@@ -139,24 +129,6 @@ subprojects {
 	}
 
 	check.dependsOn softicarCodeValidation
-}
-
-// -------------------- publish -------------------- //
-
-if(project.hasProperty('com.softicar.ivy.repository.upload.url')) {
-	subprojects {
-		apply plugin: 'com.softicar.gradle.ivy.publish'
-	
-		softicarIvyPublishSettings {
-			ivyUploadUrl = project['com.softicar.ivy.repository.upload.url']
-			if(project.hasProperty('com.softicar.ivy.repository.upload.username')) {
-				ivyUploadUsername = project['com.softicar.ivy.repository.upload.username']
-				ivyUploadPassword = project['com.softicar.ivy.repository.upload.password']
-			}
-		}
-	
-		rootProject.afterReleaseBuild.dependsOn publish
-	}
 }
 
 // -------------------- access rules -------------------- //

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,3 +1,13 @@
+if(hasProperty('pluginProxy')) {
+	println "Using plugin proxy: $pluginProxy"
+	pluginManagement {
+		repositories.maven {
+			allowInsecureProtocol true
+			url "${pluginProxy}"
+		}
+	}
+}
+
 rootProject.name='com.softicar.platform'
 include 'com.softicar.platform.ajax'
 include 'com.softicar.platform.common.code'


### PR DESCRIPTION
Test Plan:
- execute this:
```
./gradlew clean assemble -PpluginProxy=http://192.168.9.161:8081/repository/gradle-plugins/ -PdependencyProxy=http://192.168.9.161:8081/repository/maven-central/
```
- observe this output:
```
To honour the JVM settings for this build a single-use Daemon process will be forked. See https://docs.gradle.org/7.1.1/userguide/gradle_daemon.html#sec:disabling_the_daemon.
Daemon will be stopped at the end of the build
Using plugin proxy: http://192.168.9.161:8081/repository/gradle-plugins/

> Configure project :
Using dependency proxy: http://192.168.9.161:8081/repository/maven-central/

> Task :com.softicar.platform.ajax:compileJava
Note: /mnt/home/richers/workspace/com.softicar.platform/com.softicar.platform.ajax/src/main/java/com/softicar/platform/ajax/simple/SimpleServletResponse.java uses or overrides a deprecated API.
Note: Recompile with -Xlint:deprecation for details.

BUILD SUCCESSFUL in 15s
82 actionable tasks: 82 executed
```
