### PR TITLE
PLAT-517 Improved Reading and Checking of Release Properties

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -133,6 +133,10 @@ subprojects {
 
 // -------------------- publishing -------------------- //
 
+def OSSRH_URL = findProperty('ossrhUrl')
+def OSSRH_USERNAME = findProperty('ossrhUsername')
+def OSSRH_PASSWORD = findProperty('ossrhPassword')
+
 subprojects {
 	apply plugin: 'maven-publish'
 	apply plugin: 'signing'
@@ -147,10 +151,10 @@ subprojects {
 	publishing {
 		repositories {
 			maven {
-				if(hasProperty("ossrhUrl")) {
-					url = ossrhUrl
-					if(hasProperty("ossrhUsername")) {
-						authentication(ossrhUsername, ossrhPassword)
+				if(OSSRH_URL != null) {
+					url = OSSRH_URL
+					if(OSSRH_USERNAME != null) {
+						authentication(OSSRH_USERNAME, OSSRH_PASSWORD)
 					}
 				}
 			}
@@ -189,8 +193,11 @@ subprojects {
 		sign publishing.publications.mavenJava
 	}
 	publishMavenJavaPublicationToMavenRepository.doFirst {
-		if(!hasProperty("ossrhUrl")) {
+		if(OSSRH_URL == null) {
 			throw new GradleException("Please specify the variable 'ossrhUrl' in '~/.gradle/gradle.properties'.")
+		}
+		if(version == "unspecified") {
+			throw new GradleException("Please specify the version to release with '-Pversion=X.Y.Z'.")
 		}
 	}
 }

--- a/build.gradle
+++ b/build.gradle
@@ -147,10 +147,11 @@ subprojects {
 	publishing {
 		repositories {
 			maven {
-//				url = 'https://s01.oss.sonatype.org/content/repositories/snapshots/'
-				url = System.properties['user.home'] + '/local-plugin-repository/'
-				if(hasProperty("ossrhUsername")) {
-					authentication(ossrhUsername, ossrhPassword)
+				if(hasProperty("ossrhUrl")) {
+					url = ossrhUrl
+					if(hasProperty("ossrhUsername")) {
+						authentication(ossrhUsername, ossrhPassword)
+					}
 				}
 			}
 		}

--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,6 @@
 // -------------------- plug-ins -------------------- //
 
 plugins {
-	id 'maven-publish'
 	id 'signing'
 
 	id 'com.softicar.gradle.java.library' version '4.0.3'
@@ -137,6 +136,7 @@ subprojects {
 // -------------------- publishing -------------------- //
 
 subprojects {
+	apply plugin: 'maven-publish'
 	javadoc {
 		options.encoding = 'UTF-8'
 	}
@@ -156,6 +156,7 @@ subprojects {
 		}
 		publications {
 			mavenJava(MavenPublication) {
+				from components.java
 				pom {
 					name = 'SoftiCAR Platform'
 					description = 'The SoftiCAR Platform is a lightweight, Java-based library to create interactive business web applications.'

--- a/build.gradle
+++ b/build.gradle
@@ -2,6 +2,9 @@
 // -------------------- plug-ins -------------------- //
 
 plugins {
+	id 'maven-publish'
+	id 'signing'
+
 	id 'com.softicar.gradle.java.library' version '4.0.3'
 	id 'com.softicar.gradle.code.validation' version '4.0.3' apply false
 	id 'com.softicar.gradle.dependency.validation' version '4.0.3' apply false
@@ -131,7 +134,56 @@ subprojects {
 	check.dependsOn softicarCodeValidation
 }
 
-// -------------------- access rules -------------------- //
+// -------------------- publishing -------------------- //
+
+subprojects {
+	java {
+		withJavadocJar()
+		withSourcesJar()
+	}
+	
+	publishing {
+		repositories {
+			maven {
+//				url = 'https://s01.oss.sonatype.org/content/repositories/snapshots/'
+				url = System.properties['user.home'] + '/local-plugin-repository/'
+				if(hasProperty("ossrhUsername")) {
+					authentication(ossrhUsername, ossrhPassword)
+				}
+			}
+		}
+		publications {
+			mavenJava(MavenPublication) {
+				pom {
+					name = 'SoftiCAR Platform'
+					description = 'The SoftiCAR Platform is a lightweight, Java-based library to create interactive business web applications.'
+					url = 'https://github.com/softicar/platform'
+					developers {
+						developer {
+							name = 'SoftiCAR'
+							email = 'opensource@softicar.com'
+							organization = 'SoftiCAR'
+							organizationUrl = 'https://github.com/softicar'
+						}
+					}
+					licenses {
+						license {
+							name = 'MIT License'
+							url = 'https://github.com/softicar/platform/blob/main/LICENSE'
+						}
+					}
+					scm {
+						connection = 'scm:git:git://github.com/softicar/platform.git'
+						developerConnection = 'scm:git:ssh://github.com:softicar/platform.git'
+						url = 'https://github.com/softicar/platform/tree/main'
+					}
+				}
+			}
+		}
+	}
+}
+
+// -------------------- Eclipse access rules -------------------- //
 
 import org.gradle.plugins.ide.eclipse.model.AccessRule
 

--- a/build.gradle
+++ b/build.gradle
@@ -137,11 +137,13 @@ subprojects {
 // -------------------- publishing -------------------- //
 
 subprojects {
+	javadoc {
+		options.encoding = 'UTF-8'
+	}
 	java {
 		withJavadocJar()
 		withSourcesJar()
 	}
-	
 	publishing {
 		repositories {
 			maven {

--- a/build.gradle
+++ b/build.gradle
@@ -188,6 +188,11 @@ subprojects {
 	signing {
 		sign publishing.publications.mavenJava
 	}
+	publishMavenJavaPublicationToMavenRepository.doFirst {
+		if(!hasProperty("ossrhUrl")) {
+			throw new GradleException("Please specify the variable 'ossrhUrl' in '~/.gradle/gradle.properties'.")
+		}
+	}
 }
 
 // -------------------- Eclipse access rules -------------------- //

--- a/build.gradle
+++ b/build.gradle
@@ -2,8 +2,6 @@
 // -------------------- plug-ins -------------------- //
 
 plugins {
-	id 'signing'
-
 	id 'com.softicar.gradle.java.library' version '4.0.3'
 	id 'com.softicar.gradle.code.validation' version '4.0.3' apply false
 	id 'com.softicar.gradle.dependency.validation' version '4.0.3' apply false
@@ -137,6 +135,8 @@ subprojects {
 
 subprojects {
 	apply plugin: 'maven-publish'
+	apply plugin: 'signing'
+
 	javadoc {
 		options.encoding = 'UTF-8'
 	}
@@ -183,6 +183,9 @@ subprojects {
 				}
 			}
 		}
+	}
+	signing {
+		sign publishing.publications.mavenJava
 	}
 }
 


### PR DESCRIPTION
- PLAT-517 Prepared Gradle Publication Settings
- set encoding for javadoc to UTF-8
- fixed applying of publish-plug-in and added components
- enabled signing of artifacts on publish
- removed hard-coded URL and commented file
- added validation for ossrhUrl
- PLAT-517 Improved Reading and Checking of Release Properties
