### PR TITLE
PLAT-488 Fix exception in WorklowEditor

### DIFF
--- a/platform-workflow-module/src/main/java/com/softicar/platform/workflow/module/workflow/transition/WorkflowTransitionValidator.java
+++ b/platform-workflow-module/src/main/java/com/softicar/platform/workflow/module/workflow/transition/WorkflowTransitionValidator.java
@@ -26,8 +26,10 @@ public class WorkflowTransitionValidator extends AbstractEmfValidator<AGWorkflow
 			}
 		}
 
-		if (!tableRow.isAutoTransition() && !requiredVotesStringIsValid(tableRow.getRequiredVotes())) {
-			addError(AGWorkflowTransition.REQUIRED_VOTES, WorkflowI18n.REQUIRED_VOTES_NOT_VALID);
+		if (!tableRow.isAutoTransition() && tableRow.getRequiredVotes() != null) {
+			if (!requiredVotesStringIsValid(tableRow.getRequiredVotes())) {
+				addError(AGWorkflowTransition.REQUIRED_VOTES, WorkflowI18n.REQUIRED_VOTES_NOT_VALID);
+			}
 		}
 
 		if (tableRow.isAutoTransition()) {


### PR DESCRIPTION
  - added check of non-null before validating requiredVote string﻿
![image](https://user-images.githubusercontent.com/90852097/141128985-1411cc05-cd7a-42d2-90a7-8909da49f771.png)
