### PR TITLE
PLAT-571 Enable local publishing of unsigned artifacts

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -131,10 +131,14 @@ subprojects {
 
 // -------------------- publishing -------------------- //
 
+// TODO Replace "ossrh" with "publish" or "publish_remote"
 def OSSRH_TARGET = findProperty('ossrhTarget')
 def OSSRH_URL = findProperty('ossrhUrl')
 def OSSRH_USERNAME = findProperty('ossrhUsername')
 def OSSRH_PASSWORD = findProperty('ossrhPassword')
+def SIGNING_KEY_ID = findProperty('signing.keyId')
+def SIGNING_PASSWORD = findProperty('signing.password')
+def SIGNING_SECRET_KEY_RING_FILE = findProperty('signing.secretKeyRingFile')
 
 subprojects {
 	apply plugin: 'maven-publish'
@@ -208,13 +212,51 @@ subprojects {
 		if(OSSRH_TARGET != 'remote' && OSSRH_TARGET != 'local') {
 			throw new GradleException("Please specify the publication target with '-PossrhTarget=[remote|local]'.")
 		}
-		if(OSSRH_TARGET == 'remote') {
-			if(OSSRH_URL == null) {
-				throw new GradleException("Please specify the remote publication URL with 'ossrhUrl' in '~/.gradle/gradle.properties'.")
-			}
-		}
 		if(version == "unspecified") {
 			throw new GradleException("Please specify the version to publish with '-Pversion=X.Y.Z'.")
+		}
+	}
+
+	// This task is created dynamically, upon a valid 'signing' definition.
+	if(tasks.findByName('signMavenJavaPublication')) {
+		signMavenJavaPublication.doFirst {
+			if(OSSRH_TARGET == 'remote') {
+				if(SIGNING_KEY_ID == null) {
+					throw new GradleException("Please specify the PGP signing key ID with 'signing.keyId' in '~/.gradle/gradle.properties'.")
+				}
+				// TODO Fix inconsistent naming:
+				// (1) In a PGP context, the term of "passphrase" is preferred over "password"
+				// (2) Should be named "signing KEY passphrase", instead of "signing passphrase", because the passphrase strongly relates to the key.
+				if(SIGNING_PASSWORD == null) {
+					throw new GradleException("Please specify the PGP signing key passphrase with 'signing.password' in '~/.gradle/gradle.properties'.")
+				}
+				if(SIGNING_SECRET_KEY_RING_FILE == null) {
+					throw new GradleException("Please specify the PGP secret key ring file with 'signing.secretKeyRingFile' in '~/.gradle/gradle.properties'.")
+				}
+			}
+		}
+	}
+
+	// This task is created dynamically, upon a valid 'publishing' definition.
+	if(tasks.findByName('publishMavenJavaPublicationToMavenRepository')) {
+		publishMavenJavaPublicationToMavenRepository.doFirst {
+			if(OSSRH_TARGET != 'remote' && OSSRH_TARGET != 'local') {
+				throw new GradleException("Please specify the publication target with '-PossrhTarget=[remote|local]'.")
+			}
+			if(version == "unspecified") {
+				throw new GradleException("Please specify the version to publish with '-Pversion=X.Y.Z'.")
+			}
+			if(OSSRH_TARGET == 'remote') {
+				if(OSSRH_URL == null) {
+					throw new GradleException("Please specify the remote publication URL with 'ossrhUrl' in '~/.gradle/gradle.properties'.")
+				}
+				if(OSSRH_USERNAME == null) {
+					throw new GradleException("Please specify the remote publication username with 'ossrhUsername' in '~/.gradle/gradle.properties'.")
+				}
+				if(OSSRH_PASSWORD == null) {
+					throw new GradleException("Please specify the remote publication password with 'ossrhPassword' in '~/.gradle/gradle.properties'.")
+				}
+			}
 		}
 	}
 }

--- a/build.gradle
+++ b/build.gradle
@@ -131,10 +131,10 @@ subprojects {
 
 // -------------------- publishing -------------------- //
 
+def OSSRH_TARGET = findProperty('ossrhTarget')
 def OSSRH_URL = findProperty('ossrhUrl')
 def OSSRH_USERNAME = findProperty('ossrhUsername')
 def OSSRH_PASSWORD = findProperty('ossrhPassword')
-def OSSRH_TARGET = findProperty('ossrhTarget')
 
 subprojects {
 	apply plugin: 'maven-publish'
@@ -149,7 +149,7 @@ subprojects {
 	}
 	publishing {
 		repositories {
-			if(OSSRH_TARGET == 'public') {
+			if(OSSRH_TARGET == 'remote') {
 				maven {
 					if(OSSRH_URL != null) {
 						url = OSSRH_URL
@@ -198,23 +198,23 @@ subprojects {
 		}
 	}
 
+	signing {
+		if(OSSRH_TARGET == 'remote') {
+			sign publishing.publications.mavenJava
+		}
+	}
+
 	publish.doFirst {
-		if(OSSRH_TARGET == 'public') {
-			signing {
-					sign publishing.publications.mavenJava
+		if(OSSRH_TARGET != 'remote' && OSSRH_TARGET != 'local') {
+			throw new GradleException("Please specify the publication target with '-PossrhTarget=[remote|local]'.")
+		}
+		if(OSSRH_TARGET == 'remote') {
+			if(OSSRH_URL == null) {
+				throw new GradleException("Please specify the remote publication URL with 'ossrhUrl' in '~/.gradle/gradle.properties'.")
 			}
-			publishMavenJavaPublicationToMavenRepository.doFirst {
-				if(OSSRH_URL == null) {
-					throw new GradleException("Please specify the variable 'ossrhUrl' in '~/.gradle/gradle.properties'.")
-				}
-				if(version == "unspecified") {
-					throw new GradleException("Please specify the version to release with '-Pversion=X.Y.Z'.")
-				}
-			}
-		} else if(OSSRH_TARGET == 'local') {
-			// nothing
-		} else {
-			throw new GradleException("When 'publish' is invoked, '-PossrhTarget=[public|local]' must be specified.")
+		}
+		if(version == "unspecified") {
+			throw new GradleException("Please specify the version to publish with '-Pversion=X.Y.Z'.")
 		}
 	}
 }

--- a/build.gradle
+++ b/build.gradle
@@ -134,6 +134,7 @@ subprojects {
 def OSSRH_URL = findProperty('ossrhUrl')
 def OSSRH_USERNAME = findProperty('ossrhUsername')
 def OSSRH_PASSWORD = findProperty('ossrhPassword')
+def OSSRH_TARGET = findProperty('ossrhTarget')
 
 subprojects {
 	apply plugin: 'maven-publish'
@@ -148,15 +149,21 @@ subprojects {
 	}
 	publishing {
 		repositories {
-			maven {
-				if(OSSRH_URL != null) {
-					url = OSSRH_URL
-					if(OSSRH_USERNAME != null) {
-						credentials(PasswordCredentials) {
-							username OSSRH_USERNAME
-							password OSSRH_PASSWORD
+			if(OSSRH_TARGET == 'public') {
+				maven {
+					if(OSSRH_URL != null) {
+						url = OSSRH_URL
+						if(OSSRH_USERNAME != null) {
+							credentials(PasswordCredentials) {
+								username OSSRH_USERNAME
+								password OSSRH_PASSWORD
+							}
 						}
 					}
+				}
+			} else if(OSSRH_TARGET == 'local') {
+				maven {
+					url = System.properties['user.home'] + '/.softicar/maven-local'
 				}
 			}
 		}
@@ -190,15 +197,24 @@ subprojects {
 			}
 		}
 	}
-	signing {
-		sign publishing.publications.mavenJava
-	}
-	publishMavenJavaPublicationToMavenRepository.doFirst {
-		if(OSSRH_URL == null) {
-			throw new GradleException("Please specify the variable 'ossrhUrl' in '~/.gradle/gradle.properties'.")
-		}
-		if(version == "unspecified") {
-			throw new GradleException("Please specify the version to release with '-Pversion=X.Y.Z'.")
+
+	publish.doFirst {
+		if(OSSRH_TARGET == 'public') {
+			signing {
+					sign publishing.publications.mavenJava
+			}
+			publishMavenJavaPublicationToMavenRepository.doFirst {
+				if(OSSRH_URL == null) {
+					throw new GradleException("Please specify the variable 'ossrhUrl' in '~/.gradle/gradle.properties'.")
+				}
+				if(version == "unspecified") {
+					throw new GradleException("Please specify the version to release with '-Pversion=X.Y.Z'.")
+				}
+			}
+		} else if(OSSRH_TARGET == 'local') {
+			// nothing
+		} else {
+			throw new GradleException("When 'publish' is invoked, '-PossrhTarget=[public|local]' must be specified.")
 		}
 	}
 }


### PR DESCRIPTION
Test Plan:
- Comment everything in `/home/lx/.gradle/gradle.properties`
- Run Gradle tasks with various parameters:
```
$ ./gradlew clean publish
...expect failure, with a message about missing target

$ ./gradlew clean publish -Pversion=10.0.99-SNAPSHOT
...expect failure, with a message about missing target

$ ./gradlew clean publish -PossrhTarget=local
...expect failure, with a message about missing version

$ ./gradlew clean publish -Pversion=10.99.2 -PossrhTarget=local
...expect success, with appropriately-versioned artifacts generated to /home/<user>/.softicar/maven-local

$ ./gradlew clean assemble
...expect success.

$ ./gradlew publish --no-parallel -Pversion=10.99.2 -PossrhTarget=remote
...expect failure, with a message about undefined 'signing.keyId'. Define it, and try again.
...expect failure, with a message about undefined 'signing.password'. Define it, and try again.
...expect failure, with a message about undefined 'signing.secretKeyRingFile'. Define it, and try again.
...expect failure, with a message about undefined 'ossrhUrl'. Define it, and try again.
...expect failure, with a message about undefined 'ossrhUsername'. Define it, and try again.
...expect failure, with a message about undefined 'ossrhPassword'. Define it, and try again.
...expect success, with appropriately-versioned artifacts getting uploaded to the Sonatype staging server.
```
