### PR TITLE
PLAT-179 Fix NPE in AJAX Exceptions Page if no revision exists

### DIFF
--- a/platform-core-module/src/main/java/com/softicar/platform/core/module/ajax/exception/view/InfoPopupCreator.java
+++ b/platform-core-module/src/main/java/com/softicar/platform/core/module/ajax/exception/view/InfoPopupCreator.java
@@ -23,7 +23,7 @@ class InfoPopupCreator {
 			.add(CoreI18n.LOCAL_ADDRESS, session.getLocalAddress())
 			.add(CoreI18n.LOCAL_PORT, session.getLocalPort().toString())
 			.add(CoreI18n.ACCESS_DATE, session.getAccessDate().toGermanString())
-			.add(CoreI18n.REVISION, revision.getRevision());
+			.add(CoreI18n.REVISION, revision == null? "" : revision.getRevision());
 		popup.appendCloseButton();
 		return popup;
 	}


### PR DESCRIPTION
After provoking an exception, open AjaxExceptionsPage (Core >> AJAX >> AJAX Exceptions) and check if you can click the button in column "Session" without getting NPE.

