### PR TITLE
PLAT-565 Set systemUser as currentUser before executing programs

### DIFF
--- a/platform-core-module/src/main/java/com/softicar/platform/core/module/program/ProgramStarter.java
+++ b/platform-core-module/src/main/java/com/softicar/platform/core/module/program/ProgramStarter.java
@@ -4,6 +4,8 @@ import com.softicar.platform.common.core.exceptions.SofticarUserException;
 import com.softicar.platform.common.date.ISOCalendar;
 import com.softicar.platform.core.module.CoreI18n;
 import com.softicar.platform.core.module.log.LogDb;
+import com.softicar.platform.core.module.user.AGUser;
+import com.softicar.platform.core.module.user.CurrentUser;
 import com.softicar.platform.emf.source.code.reference.point.EmfSourceCodeReferencePoints;
 import java.util.UUID;
 
@@ -53,5 +55,6 @@ public class ProgramStarter {
 
 		ISOCalendar.setDefaultTimeZone();
 		LogDb.setProcessClass(program.getClass());
+		CurrentUser.set(AGUser.getSystemUser());
 	}
 }

--- a/platform-core-module/src/main/java/com/softicar/platform/core/module/program/ProgramStarter.java
+++ b/platform-core-module/src/main/java/com/softicar/platform/core/module/program/ProgramStarter.java
@@ -45,6 +45,9 @@ public class ProgramStarter {
 		try (var scope = new CurrentUserScope(AGUser.getSystemUser())) {
 			prepareExecution();
 			program.executeProgram();
+		} catch (Exception exception) {
+			LogDb.panic(exception);
+			throw exception;
 		}
 	}
 

--- a/platform-core-module/src/main/java/com/softicar/platform/core/module/program/ProgramStarter.java
+++ b/platform-core-module/src/main/java/com/softicar/platform/core/module/program/ProgramStarter.java
@@ -5,7 +5,7 @@ import com.softicar.platform.common.date.ISOCalendar;
 import com.softicar.platform.core.module.CoreI18n;
 import com.softicar.platform.core.module.log.LogDb;
 import com.softicar.platform.core.module.user.AGUser;
-import com.softicar.platform.core.module.user.CurrentUser;
+import com.softicar.platform.core.module.user.CurrentUserScope;
 import com.softicar.platform.emf.source.code.reference.point.EmfSourceCodeReferencePoints;
 import java.util.UUID;
 
@@ -42,12 +42,9 @@ public class ProgramStarter {
 
 	public void start() {
 
-		try {
+		try (var scope = new CurrentUserScope(AGUser.getSystemUser())) {
 			prepareExecution();
 			program.executeProgram();
-		} catch (Exception exception) {
-			LogDb.panic(exception);
-			throw exception;
 		}
 	}
 
@@ -55,6 +52,5 @@ public class ProgramStarter {
 
 		ISOCalendar.setDefaultTimeZone();
 		LogDb.setProcessClass(program.getClass());
-		CurrentUser.set(AGUser.getSystemUser());
 	}
 }


### PR DESCRIPTION
Test plan:

To reproduce the error add to `BufferedEmailSendProgram` in line 21:

```
System.out.println(CurrentUser.get().getLoginName());
```

When you start `BufferedEmailSendProgram` you will see that the login name of the logged-user is printed on console.

After the patch "system.user" will be printed out instead.
