### PR TITLE
PLAT-612 Fix abysmal performance in Firefox

### DIFF
--- a/platform-core-module/src/main/java/com/softicar/platform/core/module/page/PageCssClasses.java
+++ b/platform-core-module/src/main/java/com/softicar/platform/core/module/page/PageCssClasses.java
@@ -5,7 +5,9 @@ import com.softicar.platform.dom.style.ICssClass;
 
 public interface PageCssClasses {
 
+	ICssClass PAGE_DIV = new CssClass("PageDiv", PageResources.PAGE_STYLE);
 	ICssClass PAGE_CONTENT_DIV = new CssClass("PageContentDiv", PageResources.PAGE_STYLE);
+	ICssClass PAGE_HEADER_AND_CONTENT_DIV = new CssClass("PageHeaderAndContentDiv", PageResources.PAGE_STYLE);
 	ICssClass PAGE_HEADER_DIV = new CssClass("PageHeaderDiv", PageResources.PAGE_STYLE);
 	ICssClass PAGE_HEADER_PATH_DIV = new CssClass("PageHeaderPathDiv", PageResources.PAGE_STYLE);
 	ICssClass PAGE_HEADER_PAGE_NAME = new CssClass("PageHeaderPageName", PageResources.PAGE_STYLE);

--- a/platform-core-module/src/main/java/com/softicar/platform/core/module/page/PageDiv.java
+++ b/platform-core-module/src/main/java/com/softicar/platform/core/module/page/PageDiv.java
@@ -20,6 +20,8 @@ public class PageDiv extends DomDiv {
 		appendChild(pageHeaderAndContentDiv);
 
 		checkDocumentParameters(documentParameters);
+
+		setCssClass(PageCssClasses.PAGE_DIV);
 	}
 
 	private void checkDocumentParameters(IAjaxDocumentParameters documentParameters) {

--- a/platform-core-module/src/main/java/com/softicar/platform/core/module/page/PageHeaderAndContentDiv.java
+++ b/platform-core-module/src/main/java/com/softicar/platform/core/module/page/PageHeaderAndContentDiv.java
@@ -32,6 +32,8 @@ public class PageHeaderAndContentDiv extends DomDiv {
 		changeBrowserUrl(link);
 		appendChild(new PageHeaderDiv<>(link, navigationToggleFunction));
 		appendChild(new PageContentDiv(link));
+
+		setCssClass(PageCssClasses.PAGE_HEADER_AND_CONTENT_DIV);
 	}
 
 	private void closeRemainingPopupFrames() {

--- a/platform-core-module/src/main/java/com/softicar/platform/core/module/page/navigation/PageNavigationCssClasses.java
+++ b/platform-core-module/src/main/java/com/softicar/platform/core/module/page/navigation/PageNavigationCssClasses.java
@@ -10,6 +10,7 @@ public interface PageNavigationCssClasses {
 	ICssClass PAGE_NAVIGATION_FOLDER_DIV = new CssClass("PageNavigationFolderDiv", PageNavigationResources.PAGE_NAVIGATION_STYLE);
 	ICssClass PAGE_NAVIGATION_FOLDER_CHEVRON = new CssClass("PageNavigationFolderChevron", PageNavigationResources.PAGE_NAVIGATION_STYLE);
 	ICssClass PAGE_NAVIGATION_FOLDER_CONTENT_DIV = new CssClass("PageNavigationFolderContentDiv", PageNavigationResources.PAGE_NAVIGATION_STYLE);
+	ICssClass PAGE_NAVIGATION_FOLDER_TITLE = new CssClass("PageNavigationFolderTitle", PageNavigationResources.PAGE_NAVIGATION_STYLE);
 	ICssClass PAGE_NAVIGATION_FOLDER_TITLE_DIV = new CssClass("PageNavigationFolderTitleDiv", PageNavigationResources.PAGE_NAVIGATION_STYLE);
 	ICssClass PAGE_NAVIGATION_LOGO_DIV = new CssClass("PageNavigationLogoDiv", PageNavigationResources.PAGE_NAVIGATION_STYLE);
 	ICssClass PAGE_NAVIGATION_PAGE_LINK_DIV = new CssClass("PageNavigationPageLinkDiv", PageNavigationResources.PAGE_NAVIGATION_STYLE);

--- a/platform-core-module/src/main/java/com/softicar/platform/core/module/page/navigation/link/display/PageNavigationFolderTitleDiv.java
+++ b/platform-core-module/src/main/java/com/softicar/platform/core/module/page/navigation/link/display/PageNavigationFolderTitleDiv.java
@@ -45,6 +45,7 @@ class PageNavigationFolderTitleDiv extends DomDiv implements IDomClickEventHandl
 		public TitleSpan() {
 
 			appendText(link.getTitle());
+			setCssClass(PageNavigationCssClasses.PAGE_NAVIGATION_FOLDER_TITLE);
 		}
 	}
 

--- a/platform-core-module/src/main/resources/com/softicar/platform/core/module/page/navigation/page-navigation-style.css
+++ b/platform-core-module/src/main/resources/com/softicar/platform/core/module/page/navigation/page-navigation-style.css
@@ -7,7 +7,6 @@
 /* -------------------- PageNavigationDiv -------------------- */
 
 .PageNavigationDiv {
-
 	/* position */
 	box-sizing: border-box;
 	position: fixed;
@@ -29,41 +28,37 @@
 
 /* Hide scroll-bar for IE, Edge and Firefox */
 .PageNavigationDiv {
-
  	scrollbar-width: none;
 	-ms-overflow-style: none;
 }
 
 /* Hide scroll-bar for Chrome, Safari and Opera */
 .PageNavigationDiv::-webkit-scrollbar {
-
 	display: none;
 }
 
 .PageNavigationCollapsed > .PageNavigationDiv {
-
 	width: 0px;
 }
 
 /* -------------------- PageNavigationFolderContentDiv -------------------- */
 
 .PageNavigationFolderDiv {
-	gap: 0;
+	display: block;
 }
 
 .PageNavigationFolderDiv > .PageNavigationFolderContentDiv {
-
 	padding-left: 20px; 
 }
 
 .PageNavigationFolderContentDiv {
-	gap: 0;
+	display: block;
 }
 
 /* -------------------- PageNavigationFolderChevron -------------------- */
 
 .PageNavigationFolderChevron {
-	
+	display: block;
 	margin-left: auto;
 	transition: transform 0.1s;
 	margin-right: 4px;
@@ -72,20 +67,23 @@
 }
 
 .selected > .PageNavigationFolderTitleDiv > .PageNavigationFolderChevron {
-	
 	transform: rotate(90deg);
 	color: var(--PRIMARY_COLOR);
+}
+
+/* -------------------- PageNavigationFolderTitle -------------------- */
+
+.PageNavigationFolderTitle {
+	display: block;
 }
 
 /* -------------------- PageNavigationFolderTitleDiv -------------------- */
 
 .PageNavigationFolderTitleDiv {
-	
+	display: flex;
 	min-height: 32px;
 	
 	/* content */
-	grid-auto-flow: column;
-	grid-auto-columns: max-content auto;
 	align-items: center;
 	align-content: center;
 	padding: 0 4px;
@@ -98,17 +96,14 @@
 }
 
 .PageNavigationFolderTitleDiv:hover {
-
 	background-color: var(--SELECTION_BACKGROUND_COLOR);
 }
 
 .selected > .PageNavigationFolderTitleDiv {
-	
 	font-weight: bold;
 }
 
 .PageNavigationFolderTitleDiv > img {
-
 	margin-right: var(--MODULE_ICON_MARGIN);
 	height: var(--MODULE_ICON_SIZE);
 	width: var(--MODULE_ICON_SIZE);
@@ -119,7 +114,6 @@
 /* -------------------- PageNavigationLogoDiv -------------------- */
 
 .PageNavigationLogoDiv {
-	
 	align-content: center;
 	height: 50px;
 	padding: 5px 20px;
@@ -127,7 +121,6 @@
 }
 
 .PageNavigationLogoDiv > img {
-	
 	max-height: 50px;
 	max-width: calc(var(--PAGE_NAVIGATION_WIDTH) - 40px);
 }
@@ -135,13 +128,12 @@
 /* -------------------- PageNavigationPageLinkDiv -------------------- */
 
 .PageNavigationPageLinkDiv {
-
+	display: flex;
 	min-height: 32px;
 	
 	/* content */
 	gap: 0;
 	align-content: center;
-	grid-template-columns: auto min-content;
 	padding: 0 4px;
 	
 	/* looks */
@@ -153,29 +145,30 @@
 
 .PageNavigationPageLinkDiv:hover,
 .PageNavigationPageLinkDiv.selected {
-	
 	background-color: var(--SELECTION_BACKGROUND_COLOR);
 }
 
 .PageNavigationPageLinkDiv > .PageNavigationPageLinkTitle {
-
 	align-content: center;
 	min-height: inherit;
 	transition: font-weight 0.1s;
 }
 
 .PageNavigationPageLinkDiv.selected > .PageNavigationPageLinkTitle {
-
 	font-weight: bold;
 }
 
 .PageNavigationPageLinkDiv > .DomButton {
-
 	opacity: 0;
 	transition: opacity 0.2s;
 }
 
 .PageNavigationPageLinkDiv > .DomButton:hover {
-
 	opacity: 1;
+}
+
+.PageNavigationPageLinkTitle {
+	display: flex;
+	align-items: center;
+	flex-grow: 1;
 }

--- a/platform-core-module/src/main/resources/com/softicar/platform/core/module/page/page-style.css
+++ b/platform-core-module/src/main/resources/com/softicar/platform/core/module/page/page-style.css
@@ -7,7 +7,6 @@
 /* -------------------- PageContentDiv -------------------- */
 
 .PageContentDiv {
-
 	/* position */
 	box-sizing: border-box;
 	bottom: 0;
@@ -19,7 +18,7 @@
 
 	/* content layout */
 	align-items: start;
-	display: grid;
+	display: flex;
 	justify-items: start;
 	padding: 20px;
 
@@ -33,24 +32,32 @@
 }
 
 .PageContentDiv::-webkit-scrollbar {
-	
 	width: 6px;
 }
 
 .PageContentDiv::-webkit-scrollbar-thumb {
-	
 	background: var(--PRIMARY_COLOR);
 }
 
 .PageNavigationCollapsed .PageContentDiv {
-	
 	left: 0px;
+}
+
+/* -------------------- PageDiv -------------------- */
+
+.PageDiv {
+	display: block;
+}
+
+/* -------------------- PageHeaderAndContentDiv -------------------- */
+
+.PageHeaderAndContentDiv {
+	display: block;
 }
 
 /* -------------------- PageHeaderDiv -------------------- */
 
 .PageHeaderDiv {
-	
 	/* position */
 	box-sizing: border-box;
 	height: var(--PAGE_HEADER_HEIGHT);
@@ -75,12 +82,10 @@
 }
 
 .PageNavigationCollapsed .PageHeaderDiv {
-
 	left: 0px;
 }
 
 .PageHeaderDiv > .DomButton img {
-
 	max-height: var(--PAGE_HEADER_BUTTON_SIZE);
 	max-width: var(--PAGE_HEADER_BUTTON_SIZE);
 
@@ -89,7 +94,6 @@
 }
 
 .PageHeaderPathDiv {
-
 	/* content layout */
 	align-items: center;
 	display: grid;
@@ -100,12 +104,10 @@
 }
 
 .PageHeaderSeparator {
-	
 	font-weight: bold;
 }
 
 .PageHeaderPageName {
-	
 	font-size: var(--FONT_SIZE_BIGGER);
 	font-weight: bold;
 }
@@ -113,7 +115,6 @@
 /* -------------------- PageServiceLoginDiv -------------------- */
 
 .PageServiceLoginDiv {
-	
 	/* position */
 	box-sizing: border-box;
 	bottom: 0;
@@ -132,7 +133,6 @@
 }
 
 .PageServiceLoginDiv form {
-
 	/* content layout */
 	display: grid;
 	justify-items: center;
@@ -146,14 +146,12 @@
 }
 
 .PageServiceLoginErrorDiv {
-	
 	display: grid;
 	justify-content: center;
 	padding-top: 5px;
 }
 
 .TestSystem {
-	
 	background: repeating-linear-gradient(
 		135deg, 
 		var(--GRAY_BACKGROUND_COLOR), 

--- a/platform-dom/src/main/java/com/softicar/platform/dom/elements/DomElementsCssClasses.java
+++ b/platform-dom/src/main/java/com/softicar/platform/dom/elements/DomElementsCssClasses.java
@@ -61,6 +61,7 @@ public interface DomElementsCssClasses {
 
 	ICssClass DOM_SEPARATOR_CELL = new CssClass("DomSeparatorCell", DomElementsCssFiles.DOM_SEPARATOR_CELL_STYLE);
 
+	ICssClass DOM_TAB = new CssClass("DomTab", DomElementsCssFiles.DOM_TAB_BAR_STYLE);
 	ICssClass DOM_TAB_BAR = new CssClass("DomTabBar", DomElementsCssFiles.DOM_TAB_BAR_STYLE);
 	ICssClass DOM_TAB_BAR_CONTENT_CONTAINER = new CssClass("DomTabBarContentContainer", DomElementsCssFiles.DOM_TAB_BAR_STYLE);
 	ICssClass DOM_TAB_BAR_HEADER = new CssClass("DomTabBarHeader", DomElementsCssFiles.DOM_TAB_BAR_STYLE);

--- a/platform-dom/src/main/java/com/softicar/platform/dom/elements/tab/DomTab.java
+++ b/platform-dom/src/main/java/com/softicar/platform/dom/elements/tab/DomTab.java
@@ -4,6 +4,7 @@ import com.softicar.platform.common.core.i18n.IDisplayString;
 import com.softicar.platform.common.core.interfaces.INullaryVoidFunction;
 import com.softicar.platform.common.core.interfaces.IStaticObject;
 import com.softicar.platform.dom.elements.DomDiv;
+import com.softicar.platform.dom.elements.DomElementsCssClasses;
 import java.util.Optional;
 
 /**
@@ -29,6 +30,8 @@ public class DomTab extends DomDiv {
 
 		this.label = label;
 		this.headerMarker = Optional.empty();
+
+		setCssClass(DomElementsCssClasses.DOM_TAB);
 	}
 
 	/**

--- a/platform-dom/src/main/resources/com/softicar/platform/dom/elements/dom-bar-style.css
+++ b/platform-dom/src/main/resources/com/softicar/platform/dom/elements/dom-bar-style.css
@@ -1,7 +1,6 @@
 
 .DomBar {
+	display: flex;
 	align-content: center;
 	align-items: center;
-	grid-auto-columns: max-content;
-	grid-auto-flow: column;
 }

--- a/platform-dom/src/main/resources/com/softicar/platform/dom/elements/dom-button-style.css
+++ b/platform-dom/src/main/resources/com/softicar/platform/dom/elements/dom-button-style.css
@@ -16,7 +16,7 @@
 	/* position and layout */
 	align-items: center;
 	column-gap: var(--COLUMN_GAP);
-	display: inline-grid;
+	display: inline-flex;
 	grid-auto-flow: column;
 	padding: 0;
 	position: relative;
@@ -87,8 +87,8 @@
 }
 
 .DomButtonLabel {
-	align-content: center;
-	display: inline-grid;
+	display: flex;
+	align-items: center;
 	max-width: 300px;
 	min-height: var(--DOM_BUTTON_ICON_SIZE);
 	overflow: hidden;

--- a/platform-dom/src/main/resources/com/softicar/platform/dom/elements/dom-pageable-table-style.css
+++ b/platform-dom/src/main/resources/com/softicar/platform/dom/elements/dom-pageable-table-style.css
@@ -4,6 +4,7 @@
 }
 
 .DomPageableTableNavigation {
+	display: flex;
 	padding: 0 1em 1em 1em;
 }
 

--- a/platform-dom/src/main/resources/com/softicar/platform/dom/elements/dom-tab-bar-style.css
+++ b/platform-dom/src/main/resources/com/softicar/platform/dom/elements/dom-tab-bar-style.css
@@ -1,37 +1,39 @@
 
+.DomTab {
+	display: flex;
+}
+
 .DomTabBar {
-	
 	display: inline-grid;
 	gap: 4px;
 }
 
-.DomTabBarVertical {
-	
-	grid-auto-flow: column;
+.DomTabBarContentContainer {
+	display: block;
 }
 
 .DomTabBarHorizontal {
-	
 	grid-auto-flow: row;
+}
+
+.DomTabBarVertical {
+	grid-auto-flow: column;
 }
 
 /* -------------------- Tab Bar Header -------------------- */
 
 .DomTabBarHeader {
-	
 	display: grid;
 	gap: 2px;
 }
 
 .DomTabBarVertical .DomTabBarHeader {
-	
 	grid-auto-flow: row;
 	align-content: start;
 	border-right: 2px solid var(--PRIMARY_COLOR);
 } 
 
 .DomTabBarHorizontal .DomTabBarHeader {
-
 	grid-auto-flow: column;
 	justify-content: start;
 	border-bottom: 2px solid var(--PRIMARY_COLOR);
@@ -40,7 +42,6 @@
 /* -------------------- Tab Header -------------------- */
 
 .DomTabHeader {
-	
 	display: flex;
 	cursor: pointer;
 	align-items: center;
@@ -54,25 +55,21 @@
 }
 
 .DomTabHeader.selected {
-
 	background: var(--PRIMARY_COLOR);
 	color: var(--PRIMARY_CONTRAST_COLOR);
 }
 
 .DomTabHeader:not(.selected) {
-
 	background: var(--PRIMARY_DISABLED_COLOR);
 	color: var(--PRIMARY_COLOR);
 }
 
 .DomTabBarVertical .DomTabHeader {
-	
 	border-radius: var(--BORDER_RADIUS) 0px 0px var(--BORDER_RADIUS);
 	padding: 5px 9px 5px 11px;
 }
 
 .DomTabBarHorizontal .DomTabHeader {
-	
 	border-radius: var(--BORDER_RADIUS) var(--BORDER_RADIUS) 0px 0px;
 	padding: 6px 10px 4px 10px;
 }

--- a/platform-emf/src/main/java/com/softicar/platform/emf/EmfCssClasses.java
+++ b/platform-emf/src/main/java/com/softicar/platform/emf/EmfCssClasses.java
@@ -8,6 +8,8 @@ public interface EmfCssClasses {
 	ICssClass OPEN = new CssClass("open");
 	ICssClass INVISIBLE = new CssClass("invisible");
 
+	ICssClass EMF_ATTRIBUTES_TABLE_CONTAINER = new CssClass("EmfAttributesTableContainer", EmfCssFiles.EMF_ATTRIBUTE_DISPLAY_STYLE);
+
 	ICssClass EMF_BOOLEAN_DISPLAY = new CssClass("EmfBooleanDisplay", EmfCssFiles.EMF_ATTRIBUTE_DISPLAY_STYLE);
 	ICssClass EMF_BOOLEAN_DISPLAY_TRUE = new CssClass("EmfBooleanDisplayTrue", EmfCssFiles.EMF_ATTRIBUTE_DISPLAY_STYLE);
 	ICssClass EMF_BOOLEAN_DISPLAY_FALSE = new CssClass("EmfBooleanDisplayFalse", EmfCssFiles.EMF_ATTRIBUTE_DISPLAY_STYLE);
@@ -35,6 +37,9 @@ public interface EmfCssClasses {
 	ICssClass EMF_EXTERNAL_PAGE_FRAME_CONTAINER = new CssClass("EmfExternalPageFrameContainer", EmfCssFiles.EMF_EXTERNAL_PAGE_STYLE);
 
 	ICssClass EMF_FORM = new CssClass("EmfForm", EmfCssFiles.EMF_FORM_STYLE);
+	ICssClass EMF_FORM_ATTRIBUTES_DIV = new CssClass("EmfFormAttributesDiv", EmfCssFiles.EMF_FORM_STYLE);
+	ICssClass EMF_FORM_BODY_LOWER_PART = new CssClass("EmfFormBodyLowerPart", EmfCssFiles.EMF_FORM_STYLE);
+	ICssClass EMF_FORM_BODY_UPPER_PART = new CssClass("EmfFormBodyUpperPart", EmfCssFiles.EMF_FORM_STYLE);
 	ICssClass EMF_FORM_COMMON_ACTIONS_DIV = new CssClass("EmfFormCommonActionsDiv", EmfCssFiles.EMF_FORM_STYLE);
 	ICssClass EMF_FORM_FRAME = new CssClass("EmfFormFrame", EmfCssFiles.EMF_FORM_STYLE);
 	ICssClass EMF_FORM_FRAME_HEADER = new CssClass("EmfFormFrameHeader", EmfCssFiles.EMF_FORM_STYLE);
@@ -46,6 +51,7 @@ public interface EmfCssClasses {
 	ICssClass EMF_FORM_PRIMARY_ACTIONS_SECTION_DIV = new CssClass("EmfFormPrimaryActionSectionDiv", EmfCssFiles.EMF_FORM_STYLE);
 	ICssClass EMF_FORM_SAVE_OR_CANCEL_ACTIONS_INPUT = new CssClass("EmfFormSaveOrCancelActionsInput", EmfCssFiles.EMF_FORM_STYLE);
 	ICssClass EMF_FORM_SECTION_CONTENT_DIV = new CssClass("EmfFormSectionContentDiv", EmfCssFiles.EMF_FORM_SECTION_STYLE);
+	ICssClass EMF_FORM_SECTION_CONTENT_DIV_CONTAINER = new CssClass("EmfFormSectionContentDivContainer", EmfCssFiles.EMF_FORM_SECTION_STYLE);
 	ICssClass EMF_FORM_SECTION_DIV = new CssClass("EmfFormSectionDiv", EmfCssFiles.EMF_FORM_SECTION_STYLE);
 	ICssClass EMF_FORM_SECTION_HEADER_CONTENT = new CssClass("EmfFormSectionHeaderContent", EmfCssFiles.EMF_FORM_SECTION_STYLE);
 	ICssClass EMF_FORM_SECTION_HEADER_DIV = new CssClass("EmfFormSectionHeaderDiv", EmfCssFiles.EMF_FORM_SECTION_STYLE);
@@ -53,7 +59,6 @@ public interface EmfCssClasses {
 	ICssClass EMF_FORM_SECTION_HEADER_OPEN_INDICATOR = new CssClass("EmfFormSectionHeaderOpenIndicator", EmfCssFiles.EMF_FORM_SECTION_STYLE);
 	ICssClass EMF_FORM_SECTION_HEADER_TITLE = new CssClass("EmfFormSectionHeaderTitle", EmfCssFiles.EMF_FORM_SECTION_STYLE);
 	ICssClass EMF_FORM_SECTION_NO_CONTENT = new CssClass("EmfFormSectionNoContent", EmfCssFiles.EMF_FORM_SECTION_STYLE);
-	ICssClass EMF_FORM_UPPER_BODY_PART = new CssClass("EmfFormBodyUpperPart", EmfCssFiles.EMF_FORM_STYLE);
 	ICssClass EMF_FORM_WIZARD_ACTION_HEADER_DISABLED = new CssClass("EmfFormWizardActionHeaderDisabled", EmfCssFiles.EMF_FORM_STYLE);
 	ICssClass EMF_FORM_WIZARD_ACTION_TITLE_MODIFIER = new CssClass("EmfFormWizardActionTitleModifier", EmfCssFiles.EMF_FORM_STYLE);
 

--- a/platform-emf/src/main/java/com/softicar/platform/emf/form/EmfAttributesTableContainer.java
+++ b/platform-emf/src/main/java/com/softicar/platform/emf/form/EmfAttributesTableContainer.java
@@ -1,6 +1,7 @@
 package com.softicar.platform.emf.form;
 
 import com.softicar.platform.dom.elements.DomDiv;
+import com.softicar.platform.emf.EmfCssClasses;
 import com.softicar.platform.emf.table.row.IEmfTableRow;
 import com.softicar.platform.emf.validation.IEmfValidator;
 import java.util.Collection;
@@ -14,6 +15,8 @@ class EmfAttributesTableContainer<R extends IEmfTableRow<R, ?>> extends DomDiv {
 		this.attributesDiv = new EmfFormAttributesDiv<>(tableRow, editMode);
 
 		appendChild(attributesDiv);
+
+		setCssClass(EmfCssClasses.EMF_ATTRIBUTES_TABLE_CONTAINER);
 	}
 
 	public EmfAttributesTableContainer<R> addAdditionalValidators(Collection<IEmfValidator<R>> validators) {

--- a/platform-emf/src/main/java/com/softicar/platform/emf/form/EmfFormAttributesDiv.java
+++ b/platform-emf/src/main/java/com/softicar/platform/emf/form/EmfFormAttributesDiv.java
@@ -1,5 +1,6 @@
 package com.softicar.platform.emf.form;
 
+import com.softicar.platform.emf.EmfCssClasses;
 import com.softicar.platform.emf.attribute.IEmfAttribute;
 import com.softicar.platform.emf.editor.EmfAttributeValueInputFrame;
 import com.softicar.platform.emf.editor.EmfAttributesDiv;
@@ -19,6 +20,8 @@ public class EmfFormAttributesDiv<R extends IEmfTableRow<R, ?>> extends EmfAttri
 
 		this.tableRow = tableRow;
 		this.editMode = editMode;
+
+		setCssClass(EmfCssClasses.EMF_FORM_ATTRIBUTES_DIV);
 
 		refresh();
 	}

--- a/platform-emf/src/main/java/com/softicar/platform/emf/form/EmfFormBodyLowerPart.java
+++ b/platform-emf/src/main/java/com/softicar/platform/emf/form/EmfFormBodyLowerPart.java
@@ -1,6 +1,7 @@
 package com.softicar.platform.emf.form;
 
 import com.softicar.platform.dom.elements.DomDiv;
+import com.softicar.platform.emf.EmfCssClasses;
 import com.softicar.platform.emf.form.refresh.EmfFormInteractiveRefreshSectionDiv;
 import com.softicar.platform.emf.form.section.IEmfFormSectionContainer;
 import com.softicar.platform.emf.table.row.IEmfTableRow;
@@ -19,6 +20,8 @@ class EmfFormBodyLowerPart<R extends IEmfTableRow<R, ?>> extends DomDiv {
 	public EmfFormBodyLowerPart(IEmfFormBody<R> formBody) {
 
 		this.formBody = formBody;
+
+		setCssClass(EmfCssClasses.EMF_FORM_BODY_LOWER_PART);
 	}
 
 	public void showSectionContainer(IEmfFormSectionContainer sectionContainer) {

--- a/platform-emf/src/main/java/com/softicar/platform/emf/form/EmfFormBodyUpperPart.java
+++ b/platform-emf/src/main/java/com/softicar/platform/emf/form/EmfFormBodyUpperPart.java
@@ -27,7 +27,7 @@ class EmfFormBodyUpperPart<R extends IEmfTableRow<R, ?>> extends DomDiv {
 		this.commonActionsDiv = null;
 		this.editMode = false;
 
-		setCssClass(EmfCssClasses.EMF_FORM_UPPER_BODY_PART);
+		setCssClass(EmfCssClasses.EMF_FORM_BODY_UPPER_PART);
 	}
 
 	public boolean isEditMode() {

--- a/platform-emf/src/main/java/com/softicar/platform/emf/form/section/EmfFormSectionDiv.java
+++ b/platform-emf/src/main/java/com/softicar/platform/emf/form/section/EmfFormSectionDiv.java
@@ -50,6 +50,7 @@ public class EmfFormSectionDiv<R extends IEmfTableRow<R, ?>> extends DomDiv impl
 		this.open = false;
 		this.headerDiv = appendChild(new EmfFormSectionHeaderDiv()).setClickCallback(this::toggleOpen);
 		this.contentDiv = appendChild(new DomDiv());
+		this.contentDiv.setCssClass(EmfCssClasses.EMF_FORM_SECTION_CONTENT_DIV_CONTAINER);
 		this.elementSuppliers = new ArrayList<>();
 		setCssClass(EmfCssClasses.EMF_FORM_SECTION_DIV);
 		refreshHeaderAndContent();

--- a/platform-emf/src/main/resources/com/softicar/platform/emf/emf-attribute-display-style.css
+++ b/platform-emf/src/main/resources/com/softicar/platform/emf/emf-attribute-display-style.css
@@ -1,3 +1,7 @@
+.EmfAttributesTableContainer {
+	display: block;
+}
+
 .EmfBooleanDisplay {
 	display: grid;
 }

--- a/platform-emf/src/main/resources/com/softicar/platform/emf/emf-data-table-style.css
+++ b/platform-emf/src/main/resources/com/softicar/platform/emf/emf-data-table-style.css
@@ -1,8 +1,9 @@
 .EmfDataTableHeaderCellDiv {
-	gap: 2px;
+	display: block;
 }
 
 .EmfDataTableHeaderCellDiv .DomBar {
+	display: flex;
 	gap: 2px;
 }
 
@@ -34,8 +35,9 @@
 	background-color: #fff;
 	border-radius: var(--BORDER_RADIUS);
 	box-shadow: var(--BOX_SHADOW_OVERLAY);
-	display: inline-grid;
-	row-gap: 8px;
+	display: inline-flex;
+	flex-direction: column;
+	gap: 8px;
 	justify-self: start;
 }
 

--- a/platform-emf/src/main/resources/com/softicar/platform/emf/emf-form-section-style.css
+++ b/platform-emf/src/main/resources/com/softicar/platform/emf/emf-form-section-style.css
@@ -1,11 +1,9 @@
 
 .EmfFormSectionDiv {
-	
 	white-space: initial;
 }
 
 .EmfFormSectionHeaderDiv {
-	
 	display: flex;
 	position: relative;
 	align-items: center;
@@ -23,23 +21,19 @@
 }
 
 .EmfFormSectionHeaderDiv.invisible {
-	
 	display: none;
 }
 
 .EmfFormSectionHeaderDiv.disabled {
-	
 	cursor: default;
 }
 
 .EmfFormSectionHeaderOpenIndicator {
-	
 	display: inline-block;
 	pointer-events: none;
 }
 
 .EmfFormSectionHeaderOpenIndicator.open {
-	
 	border-top: var(--BORDER_RADIUS) solid #888;
 	border-bottom: 0px solid #888;
 	border-right: var(--BORDER_RADIUS) solid transparent;
@@ -53,7 +47,6 @@
 }
 /*TODO Replace the OpenIndicator with a Image that is rotated to reduce style complexity*/
 .EmfFormSectionHeaderOpenIndicator:not(.open) {
-	
 	margin-left: 6px;
 	
 	border-top: var(--BORDER_RADIUS) solid transparent;
@@ -63,13 +56,11 @@
 }
 
 .EmfFormSectionHeaderOpenIndicator:not(.open).invisible {
-
 	border-right: 0px solid transparent;
 	border-left: var(--BORDER_RADIUS) solid transparent;
 }
 
 .EmfFormSectionHeaderIcon {
-	
 	display: flex;
 	width: 24px;
 	height: 24px;
@@ -78,24 +69,20 @@
 }
 
 .EmfFormSectionHeaderTitle {
-	
 	pointer-events: none;
 	user-select: none;
 }
 
 .EmfFormSectionHeaderContent {
-	
 	margin-left: auto;
 	pointer-events: auto;
 }
 
 .EmfFormSectionContentDiv {
-	
 	overflow: auto;
 }
 
 .EmfFormSectionContentDiv:not(.invisible) {
-	
 	/* TODO replace hard-coded size of margin and padding with derived values */
 	border: 1px solid var(--INPUT_BORDER_COLOR);
 	border-radius: var(--BORDER_RADIUS);
@@ -104,7 +91,10 @@
 	background: var(--PAGE_CONTENT_BACKGROUND);
 }
 
+.EmfFormSectionContentDivContainer {
+	display: block;
+}
+
 .EmfFormSectionNoContent {
-	
 	font-style: italic;
 }

--- a/platform-emf/src/main/resources/com/softicar/platform/emf/emf-form-style.css
+++ b/platform-emf/src/main/resources/com/softicar/platform/emf/emf-form-style.css
@@ -3,6 +3,25 @@
 	min-width: 320px;
 }
 
+.EmfFormAttributesDiv {
+	display: block;
+}
+
+.EmfFormBodyLowerPart {
+	display: block;
+}
+
+.EmfFormBodyUpperPart {
+	align-items: start;
+	display: grid;
+	grid-template-columns: auto min-content;
+	gap: 0.5em;
+}
+
+.EmfFormBodyUpperPart > *:only-child {
+	grid-column: 1/3;
+}
+
 .EmfFormFrame {
 	background-color: #fff;
 	border-radius: var(--BORDER_RADIUS);
@@ -61,17 +80,6 @@
 	height: 24px;
 }
 
-.EmfFormBodyUpperPart {
-	align-items: start;
-	display: grid;
-	grid-template-columns: auto min-content;
-	gap: 0.5em;
-}
-
-.EmfFormBodyUpperPart > *:only-child {
-	grid-column: 1/3;
-}
-
 .EmfFormCommonActionsDiv {
 	gap: 4px;
 	grid-auto-flow: row;
@@ -112,6 +120,10 @@
 .EmfFormPrimaryActionSectionDiv .EmfFormSectionContentDiv:not(.invisible) .DomButton > .DomButtonLabel {
 	min-height: var(--DOM_BUTTON_DECORATED_ICON_SIZE);
 	text-transform: var(--DOM_BUTTON_LABEL_DECORATION_TEXT_TRANSFORM);
+}
+
+.EmfFormSaveOrCancelActionsInput {
+	display: block;
 }
 
 /* ------------------------------ Form Actions ------------------------------ */

--- a/platform-emf/src/main/resources/com/softicar/platform/emf/emf-management-style.css
+++ b/platform-emf/src/main/resources/com/softicar/platform/emf/emf-management-style.css
@@ -1,6 +1,7 @@
 
 .EmfManagementDiv {
-	display: inline-grid;
+	display: inline-flex;
+	flex-direction: column;
 }
 
 .EmfManagementActionsButton {


### PR DESCRIPTION
- Avoid `grid` layout in various DOM and EMF components, and in the page navigation.
  - Prefer `flow` layout or single-column `flex` layout instead.
  - All major browsers seem to support `gap` in single-column `flex` layouts, by now (cf. [caniuse.com](https://caniuse.com/?search=gap)).
- This mitigates significant performance issues of Firefox with deeply-nested grid layouts.
  - Also, it makes the Firefox DOM inspector usable, once again.

Firefox performance **with this PR** _(watch this first!)_
![firefox-performance-after](https://user-images.githubusercontent.com/15086658/146834587-1e2cc42b-0308-4822-83e1-160b2d1f1df3.gif)

Firefox performance **before this PR** _(watch out for glitches and slowness... there's plenty of both)_
![firefox-performance-before](https://user-images.githubusercontent.com/15086658/146834599-82d00379-cd98-4454-b036-d6597658abac.gif)

