### PR TITLE
PLAT-612 Use flex layout for button labels

### DIFF
--- a/platform-dom/src/main/resources/com/softicar/platform/dom/elements/dom-button-style.css
+++ b/platform-dom/src/main/resources/com/softicar/platform/dom/elements/dom-button-style.css
@@ -87,8 +87,8 @@
 }
 
 .DomButtonLabel {
-	align-content: center;
-	display: inline-grid;
+	justify-content: center;
+	display: inline-flex;
 	max-width: 300px;
 	min-height: var(--DOM_BUTTON_ICON_SIZE);
 	overflow: hidden;


### PR DESCRIPTION
Eliminates another widespread (and unnecessary) use of `display: grid`.

Test Plan:
Ensure that buttons look exactly like before this PR.
