### PR TITLE
PLAT-622 Upgrade jetty to 9.4.44

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,7 +27,7 @@ project.ext {
 		imgscalr: "4.2", // no longer maintained - this version dates back to 2012
 		javaxServletApi: "4.0.1",
 		jcifs: "1.3.17",
-		jetty: "9.4.34.v20201102",
+		jetty: "9.4.44.v20210927",
 		jsch: "0.1.55",
 		junit: "4.13.1",
 		mockito: "3.6.0",


### PR DESCRIPTION
- All `9.x` series Jetty versions up to `9.4.40` have known vulnerabilities.
- `9.4.44` does not. It is also the latest release in the `9.x` series. So we upgrade to that.

Test Plan:
- Ensure that this generates no output: `./gradlew allDependencies | grep FAIL`
- Ensure that all tests are green: `./gradlew clean check`
  - Note that a Jetty server is used during Selenium test execution.
- Start a local test servlet (which also uses Jetty). Ensure that you can log in, and access and use pages as usual.
