### PR TITLE
PLAT-638 DomButton: Use ellipsis for long button labels

### DIFF
--- a/platform-dom/src/main/resources/com/softicar/platform/dom/elements/dom-action-bar-style.css
+++ b/platform-dom/src/main/resources/com/softicar/platform/dom/elements/dom-action-bar-style.css
@@ -5,12 +5,14 @@
 	padding: var(--DOM_BUTTON_DECORATION_PADDING);
 	background-color: var(--DOM_BUTTON_DECORATION_BACKGROUND_COLOR);
 	color: var(--DOM_BUTTON_DECORATION_COLOR);
+	height: var(--DOM_BUTTON_DECORATION_HEIGHT);
 }
 
 td .DomActionBar > .DomButton {
 	padding: unset;
 	background-color: unset;
 	color: unset;
+	height: unset;
 }
 
 /* ---------------- DomButton: hover and focus ---------------- */
@@ -43,8 +45,8 @@ td .DomActionBar > .DomButton.selected {
 }
 
 td .DomActionBar > .DomButton > .DomButtonIcon {
-	width: unset;
-	height: unset;
+	width: var(--DOM_BUTTON_ICON_SIZE);
+	height: var(--DOM_BUTTON_ICON_SIZE);
 }
 
 /* ---------------- DomButton: icon color ---------------- */
@@ -60,7 +62,6 @@ td .DomActionBar > .DomButton > .DomButtonIcon:not(.precolored) {
 /* ---------------- DomButton: label ---------------- */
 
 .DomActionBar > .DomButton > .DomButtonLabel {
-	min-height: var(--DOM_BUTTON_DECORATED_ICON_SIZE);
 	text-transform: var(--DOM_BUTTON_LABEL_DECORATION_TEXT_TRANSFORM);
 }
 

--- a/platform-dom/src/main/resources/com/softicar/platform/dom/elements/dom-button-style.css
+++ b/platform-dom/src/main/resources/com/softicar/platform/dom/elements/dom-button-style.css
@@ -2,8 +2,9 @@
 :root {
 	--DOM_BUTTON_DECORATION_BACKGROUND_COLOR: var(--PRIMARY_COLOR);
 	--DOM_BUTTON_DECORATION_COLOR: var(--PRIMARY_CONTRAST_COLOR);
+	--DOM_BUTTON_DECORATION_HEIGHT: 30px;
 	--DOM_BUTTON_DECORATION_INTERACTION_BOX_SHADOW: var(--BOX_SHADOW_FOCUS);
-	--DOM_BUTTON_DECORATION_PADDING: 3px 16px;
+	--DOM_BUTTON_DECORATION_PADDING: 0px 16px;
 
 	--DOM_BUTTON_ICON_DECORATION_FILTER: var(--PRIMARY_CONTRAST_COLOR_FILTER);
 	--DOM_BUTTON_ICON_SIZE: 20px;
@@ -88,10 +89,8 @@
 }
 
 .DomButtonLabel {
-	justify-content: center;
-	display: inline-flex;
+	display: inline;
 	max-width: 300px;
-	min-height: var(--DOM_BUTTON_ICON_SIZE);
 	overflow: hidden;
 	text-overflow: ellipsis;
 }

--- a/platform-emf/src/main/resources/com/softicar/platform/emf/emf-form-style.css
+++ b/platform-emf/src/main/resources/com/softicar/platform/emf/emf-form-style.css
@@ -97,17 +97,11 @@
 	box-shadow: var(--DOM_BUTTON_DECORATION_INTERACTION_BOX_SHADOW);
 }
 
-.EmfFormPrimaryActionSectionDiv .EmfFormSectionContentDiv:not(.invisible) .DomButton > .DomButtonIcon {
-	width: var(--DOM_BUTTON_DECORATED_ICON_SIZE);
-	height: var(--DOM_BUTTON_DECORATED_ICON_SIZE);
-}
-
 .EmfFormPrimaryActionSectionDiv .EmfFormSectionContentDiv:not(.invisible) .DomButton > .DomButtonIcon:not(.precolored) {
 	filter: var(--DOM_BUTTON_ICON_DECORATION_FILTER);
 }
 
 .EmfFormPrimaryActionSectionDiv .EmfFormSectionContentDiv:not(.invisible) .DomButton > .DomButtonLabel {
-	min-height: var(--DOM_BUTTON_DECORATED_ICON_SIZE);
 	text-transform: var(--DOM_BUTTON_LABEL_DECORATION_TEXT_TRANSFORM);
 }
 


### PR DESCRIPTION
- The height of a decorated button is no longer determined as the result of the min-height of the label element, and a vertical padding.
- Instead, it's now a fixed height on the button itself.
- This paved the way to use `display: inline` on `DomButtonLabel` which in turn fixes the previously-broken `text-overflow: ellipsis` for long button labels.

Test Plan:
see screenshots

![image](https://user-images.githubusercontent.com/15086658/148781475-f924d0bd-0c69-47bb-9895-d801d104af72.png)

![image](https://user-images.githubusercontent.com/15086658/148781493-c8d9ceef-4466-46b9-bb81-664958dcd509.png)
