### PR TITLE
PLAT-639 Fix ScheduledProgramEnqueuer skipping executions

### DIFF
--- a/platform-core-module/src/main/java/com/softicar/platform/core/module/program/execution/AGProgramExecution.java
+++ b/platform-core-module/src/main/java/com/softicar/platform/core/module/program/execution/AGProgramExecution.java
@@ -2,6 +2,7 @@ package com.softicar.platform.core.module.program.execution;
 
 import com.softicar.platform.common.core.i18n.IDisplayString;
 import com.softicar.platform.common.date.DayTime;
+import com.softicar.platform.core.module.program.AGProgram;
 import com.softicar.platform.core.module.program.Programs;
 import com.softicar.platform.core.module.uuid.AGUuid;
 import com.softicar.platform.emf.object.IEmfObject;
@@ -47,18 +48,22 @@ public class AGProgramExecution extends AGProgramExecutionGenerated implements I
 	}
 
 	/**
-	 * Returns all executions that have started since the given {@link DayTime}.
+	 * Returns all executions of the given {@link AGProgram} that have started
+	 * since the given {@link DayTime}.
 	 * <p>
 	 * This includes running and finished executions.
 	 *
+	 * @param program
+	 *            the {@link AGProgram} (never <i>null</i>)
 	 * @param startedAt
 	 *            the minimum started-at (never <i>null</i>)
 	 * @return all matching executions
 	 */
-	public static Collection<AGProgramExecution> getRecentExecutions(DayTime startedAt) {
+	public static Collection<AGProgramExecution> getRecentExecutions(AGProgram program, DayTime startedAt) {
 
 		return AGProgramExecution.TABLE//
 			.createSelect()
+			.where(AGProgramExecution.PROGRAM_UUID.equal(program.getProgramUuid()))
 			.where(AGProgramExecution.STARTED_AT.isGreaterEqual(startedAt))
 			.orderBy(AGProgramExecution.STARTED_AT)
 			.orderBy(AGProgramExecution.ID)

--- a/platform-core-module/src/main/java/com/softicar/platform/core/module/program/execution/scheduled/ScheduledProgramEnqueuer.java
+++ b/platform-core-module/src/main/java/com/softicar/platform/core/module/program/execution/scheduled/ScheduledProgramEnqueuer.java
@@ -39,12 +39,12 @@ class ScheduledProgramEnqueuer {
 
 	private boolean isNotQueuedAndNotRunning(AGProgram program) {
 
-		return !program.isQueued() && !hasRecentExecutions();
+		return !program.isQueued() && !hasRecentExecutions(program);
 	}
 
-	private boolean hasRecentExecutions() {
+	private boolean hasRecentExecutions(AGProgram program) {
 
-		return !AGProgramExecution.getRecentExecutions(currentMinute).isEmpty();
+		return !AGProgramExecution.getRecentExecutions(program, currentMinute).isEmpty();
 	}
 
 	private AGProgram updateQueuedAt(AGProgram program) {

--- a/platform-core-module/src/test/java/com/softicar/platform/core/module/program/execution/scheduled/ScheduledProgramEnqueuerTest.java
+++ b/platform-core-module/src/test/java/com/softicar/platform/core/module/program/execution/scheduled/ScheduledProgramEnqueuerTest.java
@@ -50,6 +50,17 @@ public class ScheduledProgramEnqueuerTest extends AbstractDbTest {
 	}
 
 	@Test
+	public void testWithMatchingScheduleWithoutExistingQueuedAtAndWithRunningOtherProgram() {
+
+		program.setQueuedAt(null).save();
+		insertProgramExecution(noon, UUID.fromString("34fcfe77-e7b3-403f-ae3a-556d848d315a"));
+
+		runEnqueuer(noon);
+
+		assertQueuedAt(noon);
+	}
+
+	@Test
 	public void testWithMatchingScheduleWithExistingQueuedAt() {
 
 		program.setQueuedAt(beforeNoon).save();
@@ -126,8 +137,13 @@ public class ScheduledProgramEnqueuerTest extends AbstractDbTest {
 
 	private AGProgramExecution insertProgramExecution(DayTime startedAt) {
 
+		return insertProgramExecution(startedAt, SOME_UUID);
+	}
+
+	private AGProgramExecution insertProgramExecution(DayTime startedAt, UUID programUuid) {
+
 		return new AGProgramExecution()//
-			.setProgramUuid(SOME_UUID)
+			.setProgramUuid(programUuid)
 			.setStartedAt(startedAt)
 			.save();
 	}


### PR DESCRIPTION
- When processing a program schedule, `ScheduledProgramEnqueuer` now properly ignores other running programs.
- This fixes `ScheduledProgramEnqueuer` erroneously skipping (i.e. not enqueuing) the due execution of a program, in case an arbitrary other program was running during the check.

Test Plan:
see added unit tests
