### PR TITLE
PLAT-652 AjaxSeleniumTestEngine: Support context-clicks

### DIFF
--- a/platform-dom/src/main/java/com/softicar/platform/dom/elements/testing/node/tester/AbstractDomNodeTester.java
+++ b/platform-dom/src/main/java/com/softicar/platform/dom/elements/testing/node/tester/AbstractDomNodeTester.java
@@ -153,9 +153,14 @@ public class AbstractDomNodeTester<N extends IDomNode> implements IDomNodeTester
 		return sendEvent(DomEventType.DBLCLICK);
 	}
 
-	public AbstractDomNodeTester<N> rightClick() {
+	public AbstractDomNodeTester<N> contextClick() {
 
 		return sendEvent(DomEventType.CONTEXTMENU);
+	}
+
+	public AbstractDomNodeTester<N> rightClick() {
+
+		return contextClick();
 	}
 
 	private boolean isNodeDisabled() {


### PR DESCRIPTION
Added context-click (i.e. "right-click") support to `AjaxSeleniumTestEngine`.
