### PR TITLE
PLAT-629 Upgrade guava to 31.0.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,6 +22,7 @@ project.ext {
 		commonsLang3: "3.11",
 		commonsNet: "3.7.2",
 		commonsText: "1.9",
+		guava: "31.0.1-jre",
 		gson: "2.8.7",
 		h2: "2.1.210",
 		hikariCp: "3.4.5",
@@ -62,6 +63,8 @@ subprojects {
 	configurations.all {
 		resolutionStrategy {
 			failOnVersionConflict()
+			// versions below 30.0 have known vulnerabilities
+			force "com.google.guava:guava:$versions.guava";
 			force "commons-codec:commons-codec:$versions.commonsCodec"
 			force "javax.servlet:javax.servlet-api:$versions.javaxServletApi"
 			force "net.bytebuddy:byte-buddy:$versions.byteBuddy"

--- a/platform-core-module/src/main/java/com/softicar/platform/core/module/component/external/license/rule/ExternalComponentLicensePredefinedRules.java
+++ b/platform-core-module/src/main/java/com/softicar/platform/core/module/component/external/license/rule/ExternalComponentLicensePredefinedRules.java
@@ -25,6 +25,11 @@ public class ExternalComponentLicensePredefinedRules {
 
 		// Artifact does not contain license information.
 		// License defined at:
+		// https://github.com/google/guava/blob/master/COPYING
+		addLibrary("listenablefuture", ".*", License.APACHE_2_0);
+
+		// Artifact does not contain license information.
+		// License defined at:
 		// https://github.com/typetools/checker-framework/blob/master/checker-qual/LICENSE.txt
 		addLibrary("checker-compat-qual", ".*", License.MIT);
 


### PR DESCRIPTION
Note: guava 27+ has an artificial dependency on `com.google.guava:listenablefuture`. We had to add a license matcher rule for that.
