### PR TITLE
PLAT-646 Adjust Alignment of CommonActions

### DIFF
--- a/platform-emf/src/main/resources/com/softicar/platform/emf/emf-form-style.css
+++ b/platform-emf/src/main/resources/com/softicar/platform/emf/emf-form-style.css
@@ -81,7 +81,8 @@
 
 .EmfFormPopupContainer {
 	align-items: start;
-	display: flex;
+	display: inline;
+	width: 100%;
 }
 
 /* ------------------------------ DomButton decoration ------------------------------ */


### PR DESCRIPTION
The underlying problem was not the CommonActions Div, but the `EmfFormPopupContainer` not using the whole width of the popup. The CommonActions were always aligned to the right, but if the parent isnt wide enough, it would look like its not.
![image](https://user-images.githubusercontent.com/90852097/151788600-7efef062-f57e-42ae-b748-7e73a4718482.png)
![image](https://user-images.githubusercontent.com/90852097/151788689-e6477b68-3a0c-42a1-8437-271e72261c6a.png)
![image](https://user-images.githubusercontent.com/90852097/151788754-d4858596-e732-4716-ac69-0fae3480daac.png)
![image](https://user-images.githubusercontent.com/90852097/151788727-a41aca52-1bd4-4178-b00e-d6df048d19e5.png)