### PR TITLE
PLAT-669 Spawn entity popups from table-row display elements

### DIFF
--- a/platform-emf/src/main/java/com/softicar/platform/emf/EmfCssClasses.java
+++ b/platform-emf/src/main/java/com/softicar/platform/emf/EmfCssClasses.java
@@ -86,6 +86,7 @@ public interface EmfCssClasses {
 	ICssClass EMF_PREFILTER_FILTER_TYPE_BUTTON = new CssClass("EmfPrefilterFilterTypeButton", EmfCssFiles.EMF_PREFILTER_ROW_STYLE);
 
 	ICssClass EMF_STRING_DISPLAY = new CssClass("EmfStringDisplay", EmfCssFiles.EMF_DISPLAY_STYLE);
+	ICssClass EMF_TABLE_ROW_DISPLAY = new CssClass("EmfTableRowDisplay", EmfCssFiles.EMF_DISPLAY_STYLE);
 
 	ICssClass EMF_WIKI_TEXT_INPUT = new CssClass("EmfWikiTextInput", EmfCssFiles.EMF_INPUT_STYLE);
 	ICssClass EMF_WIKI_TEXT_INPUT_PREVIEW = new CssClass("EmfWikiTextInputPreview", EmfCssFiles.EMF_INPUT_STYLE);

--- a/platform-emf/src/main/java/com/softicar/platform/emf/table/row/EmfTableRowDisplay.java
+++ b/platform-emf/src/main/java/com/softicar/platform/emf/table/row/EmfTableRowDisplay.java
@@ -1,13 +1,40 @@
 package com.softicar.platform.emf.table.row;
 
+import com.softicar.platform.common.core.i18n.IDisplayString;
 import com.softicar.platform.dom.elements.DomDiv;
+import com.softicar.platform.dom.elements.button.DomButton;
+import com.softicar.platform.dom.elements.popup.manager.DomPopupManager;
+import com.softicar.platform.emf.EmfCssClasses;
+import com.softicar.platform.emf.EmfI18n;
+import com.softicar.platform.emf.form.popup.EmfFormPopup;
 
 public class EmfTableRowDisplay<R extends IEmfTableRow<R, ?>> extends DomDiv {
 
 	public EmfTableRowDisplay(R row) {
 
+		setCssClass(EmfCssClasses.EMF_TABLE_ROW_DISPLAY);
+
 		if (row != null) {
-			appendText(row.toDisplay());
+			appendChild(new ViewButton(row));
+		}
+	}
+
+	private class ViewButton extends DomButton {
+
+		public ViewButton(R row) {
+
+			IDisplayString label = row.toDisplay();
+			setLabel(label);
+			setTitle(EmfI18n.VIEW.concatColon().concatSpace().concat(label));
+			setClickCallback(() -> showEntityFormPopup(row));
+		}
+
+		private void showEntityFormPopup(R row) {
+
+			DomPopupManager//
+				.getInstance()
+				.getPopup(row, EmfFormPopup.class, EmfFormPopup::new)
+				.show();
 		}
 	}
 }

--- a/platform-emf/src/main/resources/com/softicar/platform/emf/emf-display-style.css
+++ b/platform-emf/src/main/resources/com/softicar/platform/emf/emf-display-style.css
@@ -4,3 +4,11 @@
 	white-space: pre-wrap;
 	overflow-wrap: break-word;
 }
+
+.EmfTableRowDisplay {
+	display: inline;
+}
+
+.EmfTableRowDisplay > .DomButton {
+	user-select: text;
+}


### PR DESCRIPTION
- Changed `EmfTableRowDisplay` to display a popup button for the referenced entity, instead of plain text.
- This way, the user can "follow an FK", and view the referenced entity in a popup.
- Note that this is totally generic. The gif below just provides random examples.

![Peek 2022-02-01 20-51](https://user-images.githubusercontent.com/15086658/152041824-80701607-2c48-47cb-9258-c25f132263c1.gif)

