### PR TITLE
PLAT-563 BufferedEmailSendProgram Must Not Try to Use All Servers

### DIFF
--- a/platform-core-module/src/main/java/com/softicar/platform/core/module/email/buffer/BufferedEmailSendProgram.java
+++ b/platform-core-module/src/main/java/com/softicar/platform/core/module/email/buffer/BufferedEmailSendProgram.java
@@ -37,10 +37,14 @@ public class BufferedEmailSendProgram implements IProgram {
 
 		public void sendForAllServers() {
 
-			AGServer.TABLE
+			AGBufferedEmail.TABLE//
 				.createSelect()
-				.where(AGServer.ACTIVE)//
+				.where(AGBufferedEmail.SENT_AT.isNull())
+				.groupBy(AGBufferedEmail.EMAIL_SERVER)
+				.join(AGBufferedEmail.EMAIL_SERVER)
+				.where(AGServer.ACTIVE)
 				.stream()
+				.map(AGBufferedEmail::getEmailServer)
 				.forEach(this::sendEmails);
 
 			collector.throwExceptionIfNotEmpty();


### PR DESCRIPTION
Summary:

* ﻿`BufferedEmailSendProgram` sends mails only via the (active) servers that
are connected to the unsent mails

Test Plan:

* To test changed SQL select you can temporarily add

```
com.softicar.platform.common.core.logging.LogLevel.VERBOSE.set();
```

to `BufferedEmailSendProgram`, inside method `sendForAllServers()` just before the changed select statement.

