### PR TITLE
PLAT-685 DbConnection: Fix a wrong assumption about ResultSet metadata

### DIFF
--- a/platform-db-core/src/main/java/com/softicar/platform/db/core/connection/DbConnection.java
+++ b/platform-db-core/src/main/java/com/softicar/platform/db/core/connection/DbConnection.java
@@ -232,7 +232,7 @@ public class DbConnection implements IDbConnection {
 
 		try (ResultSet resultSet = statementCache.getCurrentPreparedStatement().getGeneratedKeys()) {
 			List<Integer> ids = new ArrayList<>();
-			if (resultSet != null && hasNumericFirstColumn(resultSet)) {
+			if (resultSet != null && hasIntegerFirstColumn(resultSet)) {
 				// read all generated keys
 				while (resultSet.next()) {
 					ids.add(resultSet.getInt(1));
@@ -249,7 +249,7 @@ public class DbConnection implements IDbConnection {
 		}
 	}
 
-	private boolean hasNumericFirstColumn(ResultSet resultSet) throws SQLException {
+	private boolean hasIntegerFirstColumn(ResultSet resultSet) throws SQLException {
 
 		var metaData = resultSet.getMetaData();
 		if (metaData.getColumnCount() > 0) {


### PR DESCRIPTION
Contracy to the H2 driver, the MariaDB driver seems to not flag an RS column as auto-increment if, during an insert, a value was explicitly defined for that column.

Test Plan:
- Create a local snapshot release of the platform.
- Use that release in an EAS checkout.
- Create a war file from that EAS checkout.
- Deploy the war file on the Tomcat server of a SoftiCAR machine with persistent MariaDB.
- Open the login URL, and use your credentials to log in.
- Note that the login works (results in an error message w/o this PR).
