### PR TITLE
PLAT-688 Fix AGProgram Actions refreshing transient fields

### DIFF
--- a/platform-core-module/src/main/java/com/softicar/platform/core/module/ajax/exception/cleanup/AjaxExceptionCleanupProgram.java
+++ b/platform-core-module/src/main/java/com/softicar/platform/core/module/ajax/exception/cleanup/AjaxExceptionCleanupProgram.java
@@ -25,7 +25,7 @@ public class AjaxExceptionCleanupProgram implements IProgram {
 		int remove = AGAjaxException.createSelect().where(AGAjaxException.EXCEPTION_DATE.less(minDayTime)).count();
 		int keep = AGAjaxException.createSelect().where(AGAjaxException.EXCEPTION_DATE.greaterEqual(minDayTime)).count();
 
-		Log.finfo("will remove %d entries and keep %d entries\n", remove, keep);
+		Log.finfo("Will remove %d entries and keep %d entries\n", remove, keep);
 
 		AGAjaxException.TABLE.createDelete().where(AGAjaxException.EXCEPTION_DATE.less(minDayTime)).execute();
 	}

--- a/platform-core-module/src/main/java/com/softicar/platform/core/module/ajax/exception/cleanup/AjaxExceptionCleanupProgram.java
+++ b/platform-core-module/src/main/java/com/softicar/platform/core/module/ajax/exception/cleanup/AjaxExceptionCleanupProgram.java
@@ -1,5 +1,6 @@
 package com.softicar.platform.core.module.ajax.exception.cleanup;
 
+import com.softicar.platform.common.core.logging.Log;
 import com.softicar.platform.common.date.Day;
 import com.softicar.platform.common.date.DayTime;
 import com.softicar.platform.core.module.ajax.exception.AGAjaxException;
@@ -24,7 +25,7 @@ public class AjaxExceptionCleanupProgram implements IProgram {
 		int remove = AGAjaxException.createSelect().where(AGAjaxException.EXCEPTION_DATE.less(minDayTime)).count();
 		int keep = AGAjaxException.createSelect().where(AGAjaxException.EXCEPTION_DATE.greaterEqual(minDayTime)).count();
 
-		System.out.printf("will remove %d entries and keep %d entries\n", remove, keep);
+		Log.finfo("will remove %d entries and keep %d entries\n", remove, keep);
 
 		AGAjaxException.TABLE.createDelete().where(AGAjaxException.EXCEPTION_DATE.less(minDayTime)).execute();
 	}

--- a/platform-core-module/src/main/java/com/softicar/platform/core/module/program/abort/ProgramAbortAction.java
+++ b/platform-core-module/src/main/java/com/softicar/platform/core/module/program/abort/ProgramAbortAction.java
@@ -6,6 +6,7 @@ import com.softicar.platform.core.module.CoreI18n;
 import com.softicar.platform.core.module.CoreImages;
 import com.softicar.platform.core.module.CoreRoles;
 import com.softicar.platform.core.module.program.AGProgram;
+import com.softicar.platform.dom.document.CurrentDomDocument;
 import com.softicar.platform.emf.action.IEmfSecondaryAction;
 import com.softicar.platform.emf.authorization.role.IEmfRole;
 import com.softicar.platform.emf.predicate.EmfPredicate;
@@ -43,5 +44,6 @@ public class ProgramAbortAction implements IEmfSecondaryAction<AGProgram> {
 	public void handleClick(AGProgram program) {
 
 		new ProgramAbortRequester(program).requestAbort();
+		CurrentDomDocument.get().getRefreshBus().setChanged(program);
 	}
 }

--- a/platform-core-module/src/main/java/com/softicar/platform/core/module/program/enqueue/ProgramEnqueueAction.java
+++ b/platform-core-module/src/main/java/com/softicar/platform/core/module/program/enqueue/ProgramEnqueueAction.java
@@ -10,6 +10,7 @@ import com.softicar.platform.core.module.program.AGProgram;
 import com.softicar.platform.core.module.program.ProgramPredicates;
 import com.softicar.platform.core.module.user.CurrentUser;
 import com.softicar.platform.db.core.transaction.DbTransaction;
+import com.softicar.platform.dom.document.CurrentDomDocument;
 import com.softicar.platform.emf.action.IEmfSecondaryAction;
 import com.softicar.platform.emf.authorization.role.IEmfRole;
 import com.softicar.platform.emf.predicate.IEmfPredicate;
@@ -52,6 +53,7 @@ public class ProgramEnqueueAction implements IEmfSecondaryAction<AGProgram> {
 					.save();
 			}
 			transaction.commit();
+			CurrentDomDocument.get().getRefreshBus().setChanged(program);
 		}
 	}
 }

--- a/platform-core-module/src/main/java/com/softicar/platform/core/module/program/unqueue/ProgramUnqueueAction.java
+++ b/platform-core-module/src/main/java/com/softicar/platform/core/module/program/unqueue/ProgramUnqueueAction.java
@@ -6,6 +6,7 @@ import com.softicar.platform.core.module.CoreI18n;
 import com.softicar.platform.core.module.CoreImages;
 import com.softicar.platform.core.module.CoreRoles;
 import com.softicar.platform.core.module.program.AGProgram;
+import com.softicar.platform.dom.document.CurrentDomDocument;
 import com.softicar.platform.emf.action.IEmfSecondaryAction;
 import com.softicar.platform.emf.authorization.role.IEmfRole;
 import com.softicar.platform.emf.predicate.EmfPredicate;
@@ -43,5 +44,6 @@ public class ProgramUnqueueAction implements IEmfSecondaryAction<AGProgram> {
 	public void handleClick(AGProgram program) {
 
 		new ProgramUnqueuer(program).removeFromQueue();
+		CurrentDomDocument.get().getRefreshBus().setChanged(program);
 	}
 }


### PR DESCRIPTION
Open the `Programs` page in a test servlet
Click `Enqueue` and observe the `queued at` field properly refreshing
![image](https://user-images.githubusercontent.com/90852097/153159347-7ef14491-3a1b-45cf-9fa6-d7504b0868e1.png)
![image](https://user-images.githubusercontent.com/90852097/153159378-f3a05702-c343-4c69-b599-4dcf95b4f3b7.png)
Do the same with Abort and Unqueue and observe the same behavior
Unrelated: `AjaxExceptionCleanupProgram` now properly shows log output instead of console Ouput