### PR TITLE
PLAT-692 Fix Chaotic Row Order of Table of Program Page

### DIFF
--- a/platform-core-module/src/main/java/com/softicar/platform/core/module/program/AGProgram.java
+++ b/platform-core-module/src/main/java/com/softicar/platform/core/module/program/AGProgram.java
@@ -16,6 +16,7 @@ import java.util.UUID;
 
 public class AGProgram extends AGProgramGenerated implements IEmfObject<AGProgram> {
 
+	public static final ProgramField PROGRAM = new ProgramField();
 	public static final ProgramAbortRequestedField ABORT_REQUESTED = new ProgramAbortRequestedField();
 	public static final ProgramQueuedAtField QUEUED_AT = new ProgramQueuedAtField();
 	public static final ProgramQueuedByField QUEUED_BY = new ProgramQueuedByField();

--- a/platform-core-module/src/main/java/com/softicar/platform/core/module/program/AGProgramTable.java
+++ b/platform-core-module/src/main/java/com/softicar/platform/core/module/program/AGProgramTable.java
@@ -30,13 +30,13 @@ public class AGProgramTable extends EmfObjectTable<AGProgram, SystemModuleInstan
 	public void customizeAttributeProperties(IEmfAttributeList<AGProgram> attributes) {
 
 		attributes//
-			.editAttribute(AGProgram.ID)
-			.setConcealed(true);
+			.addTransientAttribute(AGProgram.PROGRAM);
 
 		attributes//
 			.editIndirectEntityAttribute(AGProgram.PROGRAM_UUID)
 			.setEntityLoader(Programs::getAllProgramsAsIndirectEntities)
 			.setTitle(CoreI18n.PROGRAM)
+			.setConcealed(true)
 			.setImmutable(true)
 			.setPredicateMandatory(EmfPredicates.always())
 			.setPredicateEditable(EmfPredicates.never());

--- a/platform-core-module/src/main/java/com/softicar/platform/core/module/program/AGProgramTable.java
+++ b/platform-core-module/src/main/java/com/softicar/platform/core/module/program/AGProgramTable.java
@@ -8,6 +8,7 @@ import com.softicar.platform.core.module.program.enqueue.ProgramEnqueueAction;
 import com.softicar.platform.core.module.program.unqueue.ProgramUnqueueAction;
 import com.softicar.platform.db.runtime.object.IDbObjectTableBuilder;
 import com.softicar.platform.emf.action.EmfActionSet;
+import com.softicar.platform.emf.attribute.EmfAttributeReorderer;
 import com.softicar.platform.emf.attribute.IEmfAttributeList;
 import com.softicar.platform.emf.attribute.field.bool.EmfBooleanDisplay;
 import com.softicar.platform.emf.attribute.field.daytime.EmfDayTimeDisplay;
@@ -101,4 +102,9 @@ public class AGProgramTable extends EmfObjectTable<AGProgram, SystemModuleInstan
 			.addMapping(AGProgram.EXECUTION_RETENTION_DAYS, AGProgramLog.EXECUTION_RETENTION_DAYS);
 	}
 
+	@Override
+	public void customizeAttributeOrdering(EmfAttributeReorderer<AGProgram> reorderer) {
+
+		reorderer.moveAttribute(AGProgram.PROGRAM).behind(AGProgram.ID);
+	}
 }

--- a/platform-core-module/src/main/java/com/softicar/platform/core/module/program/ProgramAbortRequestedField.java
+++ b/platform-core-module/src/main/java/com/softicar/platform/core/module/program/ProgramAbortRequestedField.java
@@ -7,7 +7,7 @@ import com.softicar.platform.db.runtime.transients.AbstractTransientBooleanField
 import com.softicar.platform.db.runtime.transients.IValueSetter;
 import java.util.Set;
 
-public class ProgramAbortRequestedField extends AbstractTransientBooleanField<AGProgram> {
+class ProgramAbortRequestedField extends AbstractTransientBooleanField<AGProgram> {
 
 	@Override
 	public IDisplayString getTitle() {

--- a/platform-core-module/src/main/java/com/softicar/platform/core/module/program/ProgramCurrentExecutionField.java
+++ b/platform-core-module/src/main/java/com/softicar/platform/core/module/program/ProgramCurrentExecutionField.java
@@ -8,7 +8,7 @@ import com.softicar.platform.db.runtime.transients.AbstractTransientObjectField;
 import com.softicar.platform.db.runtime.transients.IValueSetter;
 import java.util.Set;
 
-public class ProgramCurrentExecutionField extends AbstractTransientObjectField<AGProgram, AGProgramExecution> {
+class ProgramCurrentExecutionField extends AbstractTransientObjectField<AGProgram, AGProgramExecution> {
 
 	public ProgramCurrentExecutionField() {
 

--- a/platform-core-module/src/main/java/com/softicar/platform/core/module/program/ProgramField.java
+++ b/platform-core-module/src/main/java/com/softicar/platform/core/module/program/ProgramField.java
@@ -1,0 +1,36 @@
+package com.softicar.platform.core.module.program;
+
+import com.softicar.platform.common.core.i18n.IDisplayString;
+import com.softicar.platform.core.module.CoreI18n;
+import com.softicar.platform.db.runtime.transients.AbstractTransientObjectField;
+import com.softicar.platform.db.runtime.transients.IValueSetter;
+import java.util.Set;
+
+class ProgramField extends AbstractTransientObjectField<AGProgram, String> {
+
+	public ProgramField() {
+
+		super(String.class);
+	}
+
+	@Override
+	public IDisplayString getTitle() {
+
+		return CoreI18n.PROGRAM;
+	}
+
+	@Override
+	protected void loadValues(Set<AGProgram> programs, IValueSetter<AGProgram, String> setter) {
+
+		AGProgram.TABLE//
+			.createSelect()
+			.where(AGProgram.ID.isIn(programs))
+			.forEach(record -> setter.set(record, record.toDisplayWithoutId().toString()));
+	}
+
+	@Override
+	protected String getDefaultValue() {
+
+		return "";
+	}
+}

--- a/platform-core-module/src/main/java/com/softicar/platform/core/module/program/ProgramQueuedAtField.java
+++ b/platform-core-module/src/main/java/com/softicar/platform/core/module/program/ProgramQueuedAtField.java
@@ -8,7 +8,7 @@ import com.softicar.platform.db.runtime.transients.AbstractTransientDayTimeField
 import com.softicar.platform.db.runtime.transients.IValueSetter;
 import java.util.Set;
 
-public class ProgramQueuedAtField extends AbstractTransientDayTimeField<AGProgram> {
+class ProgramQueuedAtField extends AbstractTransientDayTimeField<AGProgram> {
 
 	@Override
 	public IDisplayString getTitle() {

--- a/platform-core-module/src/main/java/com/softicar/platform/core/module/program/ProgramQueuedByField.java
+++ b/platform-core-module/src/main/java/com/softicar/platform/core/module/program/ProgramQueuedByField.java
@@ -8,7 +8,7 @@ import com.softicar.platform.db.runtime.transients.AbstractTransientObjectField;
 import com.softicar.platform.db.runtime.transients.IValueSetter;
 import java.util.Set;
 
-public class ProgramQueuedByField extends AbstractTransientObjectField<AGProgram, AGUser> {
+class ProgramQueuedByField extends AbstractTransientObjectField<AGProgram, AGUser> {
 
 	public ProgramQueuedByField() {
 


### PR DESCRIPTION
#### Summary
- PLAT-692 Add `ProgramField` to `AGProgram` to be able to sort table by name
- Put program column behind ID column
- Reduce visibility of *Field classes (unrelated to PLAT-692)

#### Test Plan
See Program Page, it shows ID column, too, now, and therefore looks like other pages.
The bug was fixed: You can sort by Program column, now.
Filtering by program is also possible.
![Screenshot_2022-02-15_09-33-16](https://user-images.githubusercontent.com/74466399/154024309-20c0bb19-ddda-4a39-bea0-c64ffb142b83.png)

