### PR TITLE
PLAT-707 Module Instances Page: Column "Module Class" must not be sortable anymore

### DIFF
--- a/platform-core-module/src/main/java/com/softicar/platform/core/module/access/module/instance/AGModuleInstanceTable.java
+++ b/platform-core-module/src/main/java/com/softicar/platform/core/module/access/module/instance/AGModuleInstanceTable.java
@@ -11,6 +11,7 @@ import com.softicar.platform.db.runtime.object.IDbObjectTableBuilder;
 import com.softicar.platform.emf.action.EmfActionSet;
 import com.softicar.platform.emf.attribute.IEmfAttributeList;
 import com.softicar.platform.emf.authorizer.EmfAuthorizer;
+import com.softicar.platform.emf.data.table.column.handler.EmfDataTableNonSortableColumnHandler;
 import com.softicar.platform.emf.log.EmfChangeLoggerSet;
 import com.softicar.platform.emf.module.IEmfModule;
 import com.softicar.platform.emf.object.table.EmfObjectTable;
@@ -56,7 +57,8 @@ public class AGModuleInstanceTable extends EmfObjectTable<AGModuleInstance, Syst
 			.setEntityLoader(() -> AGUuidBasedSourceCodeReferencePoints.getAll(IEmfModule.class))
 			.setTitle(CoreI18n.MODULE_CLASS)
 			.setImmutable(true)
-			.setPredicateMandatory(EmfPredicates.always());
+			.setPredicateMandatory(EmfPredicates.always())
+			.setColumnHandlerFactory(EmfDataTableNonSortableColumnHandler::new);
 		attributes//
 			.addTransientAttribute(AGModuleInstance.TITLE_FIELD);
 	}

--- a/platform-emf/src/main/java/com/softicar/platform/emf/data/table/column/handler/EmfDataTableNonSortableColumnHandler.java
+++ b/platform-emf/src/main/java/com/softicar/platform/emf/data/table/column/handler/EmfDataTableNonSortableColumnHandler.java
@@ -1,0 +1,12 @@
+package com.softicar.platform.emf.data.table.column.handler;
+
+import com.softicar.platform.emf.data.table.column.IEmfDataTableColumn;
+
+public class EmfDataTableNonSortableColumnHandler<R, T> extends EmfDataTableRowBasedColumnHandler<R, T> {
+
+	@Override
+	public boolean isSortable(IEmfDataTableColumn<?, T> column) {
+
+		return false;
+	}
+}

--- a/platform-emf/src/main/java/com/softicar/platform/emf/data/table/column/handler/EmfDataTableNonSortableNonFilterableColumnHandler.java
+++ b/platform-emf/src/main/java/com/softicar/platform/emf/data/table/column/handler/EmfDataTableNonSortableNonFilterableColumnHandler.java
@@ -3,17 +3,11 @@ package com.softicar.platform.emf.data.table.column.handler;
 import com.softicar.platform.emf.data.table.column.IEmfDataTableColumn;
 import com.softicar.platform.emf.data.table.column.handler.filtering.IEmfDataTableRowBasedColumnFilterNodeFactory;
 
-public class EmfDataTableNonSortableNonFilterableColumnHandler<R, T> extends EmfDataTableRowBasedColumnHandler<R, T> {
+public class EmfDataTableNonSortableNonFilterableColumnHandler<R, T> extends EmfDataTableNonSortableColumnHandler<R, T> {
 
 	@Override
 	public IEmfDataTableRowBasedColumnFilterNodeFactory<R> getFilterNodeFactory(IEmfDataTableColumn<R, T> column) {
 
 		return null;
-	}
-
-	@Override
-	public boolean isSortable(IEmfDataTableColumn<?, T> column) {
-
-		return false;
 	}
 }


### PR DESCRIPTION
#### Summary

- Add `EmfDataTableNonSortableColumnHandler`
- `EmfDataTableNonSortableNonFilterableColumnHandler` extends `EmfDataTableNonSortableColumnHandler` now
- Use `EmfDataTableNonSortableColumnHandler` for column "Module Class"


#### Test Plan

No option to sort column "Module Class" anymore, but filter option is still available:

![Module Instances Page](https://user-images.githubusercontent.com/74466399/154280144-60fde932-8687-41ad-aaca-73f027a8a351.png)


