### PR TITLE
PLAT-744 Temporarily disable DbTableConfigurationCodeValidator

### DIFF
--- a/platform-db-runtime/src/main/java/com/softicar/platform/db/runtime/table/configuration/DbTableConfigurationCodeValidator.java
+++ b/platform-db-runtime/src/main/java/com/softicar/platform/db/runtime/table/configuration/DbTableConfigurationCodeValidator.java
@@ -23,7 +23,7 @@ import java.util.function.Predicate;
  *
  * @author Alexander Schmidt
  */
-//@JavaCodeValidator // FIXME Fix and re-enable this.
+//@JavaCodeValidator // FIXME Fix and re-enable this. (PLAT-754)
 public class DbTableConfigurationCodeValidator implements IJavaCodeValidator {
 
 	@Override

--- a/platform-db-runtime/src/main/java/com/softicar/platform/db/runtime/table/configuration/DbTableConfigurationCodeValidator.java
+++ b/platform-db-runtime/src/main/java/com/softicar/platform/db/runtime/table/configuration/DbTableConfigurationCodeValidator.java
@@ -51,7 +51,7 @@ public class DbTableConfigurationCodeValidator implements IJavaCodeValidator {
 
 	private Predicate<File> isRelevantJarFile() {
 
-		// TODO Find a better solution to determine the JAR file that contains IDbTable and IDbTableRow.
+		// TODO Find a better solution to determine the JAR file that contains IDbTable and IDbTableRow. (PLAT-754)
 		return jarFile -> jarFile.getName().equals("platform-db-runtime.jar");
 	}
 }

--- a/platform-db-runtime/src/main/java/com/softicar/platform/db/runtime/table/configuration/DbTableConfigurationCodeValidator.java
+++ b/platform-db-runtime/src/main/java/com/softicar/platform/db/runtime/table/configuration/DbTableConfigurationCodeValidator.java
@@ -19,7 +19,7 @@ import java.util.function.Predicate;
  * Validates the configuration of every {@link IDbTable} in this repository.
  * <p>
  * FIXME This is too inefficient. The same tables are checked over and over
- * again.
+ * again. (PLAT-754).
  *
  * @author Alexander Schmidt
  */

--- a/platform-db-runtime/src/main/java/com/softicar/platform/db/runtime/table/configuration/DbTableConfigurationCodeValidator.java
+++ b/platform-db-runtime/src/main/java/com/softicar/platform/db/runtime/table/configuration/DbTableConfigurationCodeValidator.java
@@ -4,31 +4,54 @@ import com.softicar.platform.common.code.classpath.iterable.ClasspathFileIterabl
 import com.softicar.platform.common.code.classpath.metadata.ClasspathFilesMetadata;
 import com.softicar.platform.common.core.java.code.validation.JavaCodeValidationEnvironment;
 import com.softicar.platform.common.core.java.code.validator.IJavaCodeValidator;
-import com.softicar.platform.common.core.java.code.validator.JavaCodeValidator;
+import com.softicar.platform.db.core.database.DbDatabaseScope;
+import com.softicar.platform.db.core.test.DbTestDatabase;
 import com.softicar.platform.db.runtime.table.IDbTable;
+import com.softicar.platform.db.runtime.table.creator.DbAutomaticTableCreator;
 import com.softicar.platform.db.runtime.table.finder.DbTableFinder;
 import com.softicar.platform.db.runtime.table.row.IDbTableRow;
+import com.softicar.platform.db.runtime.test.DbRandomAutoIncrementSupplier;
+import java.io.File;
 import java.util.Collection;
+import java.util.function.Predicate;
 
 /**
- * Validates the configuration of every {@link IDbTable}.
+ * Validates the configuration of every {@link IDbTable} in this repository.
+ * <p>
+ * FIXME This is too inefficient. The same tables are checked over and over
+ * again.
  *
  * @author Alexander Schmidt
  */
-@JavaCodeValidator
+//@JavaCodeValidator // FIXME Fix and re-enable this.
 public class DbTableConfigurationCodeValidator implements IJavaCodeValidator {
 
 	@Override
 	public void validate(JavaCodeValidationEnvironment environment) {
 
-		for (IDbTable<?, ?> table: findAllTables(IDbTable.class, IDbTableRow.class)) {
-			table.assertValidConfigurationOrThrow();
+		try (var databaseScope = new DbDatabaseScope(createTestDatabase())) {
+			for (IDbTable<?, ?> table: findAllTables(IDbTable.class, IDbTableRow.class)) {
+				table.assertValidConfigurationOrThrow();
+			}
 		}
+	}
+
+	private DbTestDatabase createTestDatabase() {
+
+		var testDatabase = new DbTestDatabase();
+		testDatabase.addListener(new DbAutomaticTableCreator(new DbRandomAutoIncrementSupplier()));
+		return testDatabase;
 	}
 
 	private <T, R> Collection<T> findAllTables(Class<T> tableClass, Class<R> tableRowClass) {
 
-		ClasspathFilesMetadata metadata = new ClasspathFilesMetadata(new ClasspathFileIterable());
+		ClasspathFilesMetadata metadata = new ClasspathFilesMetadata(new ClasspathFileIterable().setJarFileFilter(isRelevantJarFile()));
 		return new DbTableFinder<>(metadata, tableClass, tableRowClass).findAllTables();
+	}
+
+	private Predicate<File> isRelevantJarFile() {
+
+		// TODO Find a better solution to determine the JAR file that contains IDbTable and IDbTableRow.
+		return jarFile -> jarFile.getName().equals("platform-db-runtime.jar");
 	}
 }


### PR DESCRIPTION
Temporarily disabled `DbTableConfigurationCodeValidator`, until after Platform-17 was released.
