### PR TITLE
PLAT-744 Let IDomAutoCompleteInput extend IDomValueInput

### DIFF
--- a/platform-ajax/src/test/java/com/softicar/platform/ajax/input/auto/complete/AbstractAjaxAutoCompleteStringTest.java
+++ b/platform-ajax/src/test/java/com/softicar/platform/ajax/input/auto/complete/AbstractAjaxAutoCompleteStringTest.java
@@ -42,7 +42,7 @@ public abstract class AbstractAjaxAutoCompleteStringTest extends AbstractAjaxAut
 	protected boolean isValueSubmitted() {
 
 		String clientValue = Optional.ofNullable(getAttributeValue(inputField, "value")).orElse("");
-		String serverValue = Optional.ofNullable(inputDiv.getSelection().getValueOrThrow()).map(item -> item.getName()).orElse("");
+		String serverValue = inputDiv.getValue().map(item -> item.getName()).orElse("");
 		return clientValue.equals(serverValue);
 	}
 

--- a/platform-ajax/src/test/java/com/softicar/platform/ajax/input/auto/complete/AjaxAutoCompleteChangeEventTest.java
+++ b/platform-ajax/src/test/java/com/softicar/platform/ajax/input/auto/complete/AjaxAutoCompleteChangeEventTest.java
@@ -55,7 +55,7 @@ public class AjaxAutoCompleteChangeEventTest extends AbstractAjaxAutoCompleteStr
 		waitForAutoCompletePopup();
 		send(inputField, Key.ESCAPE);
 
-		assertEventAndNullValue();
+		assertEvent();
 		indicator.assertValueIllegal(true);
 	}
 
@@ -276,27 +276,25 @@ public class AjaxAutoCompleteChangeEventTest extends AbstractAjaxAutoCompleteStr
 	// -------------------- private -------------------- //
 
 	/**
-	 * asserts that change event was triggered and checks value of input
+	 * Asserts that a change event was triggered.
+	 */
+	private void assertEvent() {
+
+		waitForServer();
+		inputDiv.assertOneEvent();
+	}
+
+	/**
+	 * Asserts that a change event was triggered, and the value of the input.
 	 */
 	private void assertEventAndValue(AjaxAutoCompleteTestItem item) {
 
-		waitForServer();
-		inputDiv.assertOneEvent();
-		assertSame(item, inputDiv.getSelection().getValueOrThrow());
+		assertEvent();
+		assertSame(item, inputDiv.getValueOrNull());
 	}
 
 	/**
-	 * asserts that no change event was triggered and checks input is empty
-	 */
-	private void assertEventAndNullValue() {
-
-		waitForServer();
-		inputDiv.assertOneEvent();
-		assertNull(inputDiv.getSelection().getValueOrNull());
-	}
-
-	/**
-	 * enters the name of the given item and waits for the pop-up
+	 * Enters the name of the given item and waits for the pop-up.
 	 */
 	private void openPopup() {
 
@@ -306,7 +304,7 @@ public class AjaxAutoCompleteChangeEventTest extends AbstractAjaxAutoCompleteStr
 	}
 
 	/**
-	 * un-focuses the input and re-focuses it
+	 * Un-focuses the input and re-focuses it.
 	 */
 	private void unfocusAndRefocusInput() {
 

--- a/platform-ajax/src/test/java/com/softicar/platform/ajax/input/auto/complete/entity/AjaxAutoCompleteEntityInputCreatedTest.java
+++ b/platform-ajax/src/test/java/com/softicar/platform/ajax/input/auto/complete/entity/AjaxAutoCompleteEntityInputCreatedTest.java
@@ -197,8 +197,8 @@ public class AjaxAutoCompleteEntityInputCreatedTest extends AbstractAjaxAutoComp
 			.execute();
 
 		asserter//
-			.expectServerValueNone()
 			.expectClientValue(UNAVAILABLE_ENTITY.toDisplayStringWithId())
+			.expectServerValueExceptionMessage()
 			.expectIndicatorValueValid()
 			.expectPopupNotDisplayed()
 			.expectNoFocus()
@@ -216,8 +216,8 @@ public class AjaxAutoCompleteEntityInputCreatedTest extends AbstractAjaxAutoComp
 			.execute();
 
 		asserter//
-			.expectServerValueNone()
 			.expectClientValue(UNAVAILABLE_ENTITY.toDisplayStringWithId())
+			.expectServerValueExceptionMessage()
 			.expectIndicatorValueValid()
 			.expectPopupNotDisplayed()
 			.expectNoFocus()
@@ -456,7 +456,7 @@ public class AjaxAutoCompleteEntityInputCreatedTest extends AbstractAjaxAutoComp
 
 		asserter//
 			.expectClientValue(INVALID_ITEM_NAME)
-			.expectServerValueNone()
+			.expectServerValueExceptionMessage()
 			.expectIndicatorValueValid()
 			.expectPopupNotDisplayed()
 			.expectNoFocus()

--- a/platform-ajax/src/test/java/com/softicar/platform/ajax/input/auto/complete/entity/AjaxAutoCompleteEntityInputFocusedPopupClosedTest.java
+++ b/platform-ajax/src/test/java/com/softicar/platform/ajax/input/auto/complete/entity/AjaxAutoCompleteEntityInputFocusedPopupClosedTest.java
@@ -6,8 +6,7 @@ import org.junit.Test;
 
 /**
  * Contains unit tests for {@link DomAutoCompleteEntityInput} interaction phase
- * <b>"2.3 Popup Closed"</b> (see
- * {@link AbstractAjaxAutoCompleteEntityTest}).
+ * <b>"2.3 Popup Closed"</b> (see {@link AbstractAjaxAutoCompleteEntityTest}).
  * <p>
  * Note that, for passive input elements, the value is not transferred to the
  * server until the next arbitrary event is handled.
@@ -272,7 +271,7 @@ public class AjaxAutoCompleteEntityInputFocusedPopupClosedTest extends AbstractA
 		asserter//
 			.expectClientValue(AMBIGUOUS_ITEM_NAME_CHUNK)
 			.expectServerValueNone()
-			.expectIndicatorValueAmbiguous() // TODO if input is active, "illegal" indicator is displayed. this is kind of inconsistent.
+			.expectIndicatorValueAmbiguous()
 			.expectPopupNotDisplayed()
 			.expectFocus()
 			.expectOverlayNotDisplayed()
@@ -296,8 +295,8 @@ public class AjaxAutoCompleteEntityInputFocusedPopupClosedTest extends AbstractA
 
 		asserter//
 			.expectClientValue(AMBIGUOUS_ITEM_NAME_CHUNK)
-			.expectServerValueNone()
-			.expectIndicatorValueIllegal() // TODO if input is passive, "ambiguous" indicator is displayed. this is kind of inconsistent.
+			.expectServerValueExceptionMessage()
+			.expectIndicatorValueIllegal()
 			.expectPopupNotDisplayed()
 			.expectFocus()
 			.expectOverlayNotDisplayed()
@@ -345,7 +344,7 @@ public class AjaxAutoCompleteEntityInputFocusedPopupClosedTest extends AbstractA
 
 		asserter//
 			.expectClientValue(INVALID_ITEM_NAME)
-			.expectServerValueNone()
+			.expectServerValueExceptionMessage()
 			.expectIndicatorValueIllegal()
 			.expectPopupNotDisplayed()
 			.expectFocus()
@@ -492,7 +491,7 @@ public class AjaxAutoCompleteEntityInputFocusedPopupClosedTest extends AbstractA
 
 		asserter//
 			.expectClientValue(AMBIGUOUS_ITEM_NAME_CHUNK)
-			.expectServerValueNone()
+			.expectServerValueExceptionMessage()
 			.expectIndicatorValueIllegal()
 			.expectPopupNotDisplayed()
 			.expectFocus()
@@ -912,7 +911,7 @@ public class AjaxAutoCompleteEntityInputFocusedPopupClosedTest extends AbstractA
 
 		asserter//
 			.expectClientValue(INVALID_ITEM_NAME)
-			.expectServerValueNone()
+			.expectServerValueExceptionMessage()
 			.expectIndicatorValueIllegal()
 			.expectPopupNotDisplayed()
 			.expectFocus()
@@ -968,7 +967,7 @@ public class AjaxAutoCompleteEntityInputFocusedPopupClosedTest extends AbstractA
 
 		asserter//
 			.expectClientValue(INVALID_ITEM_NAME)
-			.expectServerValueNone()
+			.expectServerValueExceptionMessage()
 			.expectIndicatorValueIllegal()
 			.expectPopupNotDisplayed()
 			.expectFocus()

--- a/platform-ajax/src/test/java/com/softicar/platform/ajax/input/auto/complete/entity/AjaxAutoCompleteEntityInputFocusedPopupOpenedTest.java
+++ b/platform-ajax/src/test/java/com/softicar/platform/ajax/input/auto/complete/entity/AjaxAutoCompleteEntityInputFocusedPopupOpenedTest.java
@@ -8,8 +8,7 @@ import org.junit.Test;
 
 /**
  * Contains unit tests for {@link DomAutoCompleteEntityInput} interaction phase
- * <b>"2.2 Popup Opened"</b> (see
- * {@link AbstractAjaxAutoCompleteEntityTest}).
+ * <b>"2.2 Popup Opened"</b> (see {@link AbstractAjaxAutoCompleteEntityTest}).
  *
  * @author Alexander Schmidt
  */
@@ -303,7 +302,7 @@ public class AjaxAutoCompleteEntityInputFocusedPopupOpenedTest extends AbstractA
 
 		asserter//
 			.expectClientValue(UNAVAILABLE_ENTITY)
-			.expectServerValueNone()
+			.expectServerValueExceptionMessage()
 			.expectIndicatorValueValid()
 			.expectPopupNotDisplayed()
 			.expectFocus()
@@ -369,8 +368,8 @@ public class AjaxAutoCompleteEntityInputFocusedPopupOpenedTest extends AbstractA
 			.pressDownArrowAndWaitForPopup();
 
 		asserter//
-			.expectServerValueNone()
 			.expectClientValue(UNAVAILABLE_ENTITY)
+			.expectServerValueExceptionMessage()
 			.expectIndicatorValueValid()
 			.expectPopupDisplayed()
 			.expectPopupEntitiesNone()
@@ -437,8 +436,8 @@ public class AjaxAutoCompleteEntityInputFocusedPopupOpenedTest extends AbstractA
 			.pressUpArrowAndWaitForPopup();
 
 		asserter//
-			.expectServerValueNone()
 			.expectClientValue(UNAVAILABLE_ENTITY)
+			.expectServerValueExceptionMessage()
 			.expectIndicatorValueValid()
 			.expectPopupDisplayed()
 			.expectPopupEntitiesNone()

--- a/platform-ajax/src/test/java/com/softicar/platform/ajax/input/auto/complete/entity/AjaxAutoCompleteEntityInputFocusedPopupReclosedTest.java
+++ b/platform-ajax/src/test/java/com/softicar/platform/ajax/input/auto/complete/entity/AjaxAutoCompleteEntityInputFocusedPopupReclosedTest.java
@@ -5,8 +5,7 @@ import org.junit.Test;
 
 /**
  * Contains unit tests for {@link DomAutoCompleteEntityInput} interaction phase
- * <b>"2.3 Popup Closed"</b> (see
- * {@link AbstractAjaxAutoCompleteEntityTest}).
+ * <b>"2.3 Popup Closed"</b> (see {@link AbstractAjaxAutoCompleteEntityTest}).
  *
  * @author Alexander Schmidt
  */
@@ -100,7 +99,7 @@ public class AjaxAutoCompleteEntityInputFocusedPopupReclosedTest extends Abstrac
 
 		asserter//
 			.expectClientValue(INVALID_ITEM_NAME)
-			.expectServerValueNone()
+			.expectServerValueExceptionMessage()
 			.expectIndicatorValueIllegal()
 			.expectPopupNotDisplayed()
 			.expectFocus()
@@ -135,7 +134,7 @@ public class AjaxAutoCompleteEntityInputFocusedPopupReclosedTest extends Abstrac
 
 		asserter//
 			.expectClientValue("other invalid item name")
-			.expectServerValueNone()
+			.expectServerValueExceptionMessage()
 			.expectIndicatorValueIllegal()
 			.expectPopupNotDisplayed()
 			.expectFocus()

--- a/platform-ajax/src/test/java/com/softicar/platform/ajax/input/auto/complete/entity/AjaxAutoCompleteEntityInputFocusedPopupUnopenedTest.java
+++ b/platform-ajax/src/test/java/com/softicar/platform/ajax/input/auto/complete/entity/AjaxAutoCompleteEntityInputFocusedPopupUnopenedTest.java
@@ -108,7 +108,7 @@ public class AjaxAutoCompleteEntityInputFocusedPopupUnopenedTest extends Abstrac
 
 		asserter//
 			.expectClientValue(UNAVAILABLE_ENTITY)
-			.expectServerValueNone()
+			.expectServerValueExceptionMessage()
 			.expectIndicatorValueValid()
 			.expectPopupNotDisplayed()
 			.expectNoFocus()

--- a/platform-ajax/src/test/java/com/softicar/platform/ajax/input/auto/complete/entity/AjaxAutoCompleteEntityInputFocusedTest.java
+++ b/platform-ajax/src/test/java/com/softicar/platform/ajax/input/auto/complete/entity/AjaxAutoCompleteEntityInputFocusedTest.java
@@ -173,8 +173,8 @@ public class AjaxAutoCompleteEntityInputFocusedTest extends AbstractAjaxAutoComp
 		input.focusWithClick();
 
 		asserter//
-			.expectServerValueNone()
 			.expectClientValue(UNAVAILABLE_ENTITY.toDisplayStringWithId())
+			.expectServerValueExceptionMessage()
 			.expectIndicatorValueValid()
 			.expectPopupNotDisplayed()
 			.expectFocus()
@@ -193,8 +193,8 @@ public class AjaxAutoCompleteEntityInputFocusedTest extends AbstractAjaxAutoComp
 		input.focusWithTab();
 
 		asserter//
-			.expectServerValueNone()
 			.expectClientValue(UNAVAILABLE_ENTITY.toDisplayStringWithId())
+			.expectServerValueExceptionMessage()
 			.expectIndicatorValueValid()
 			.expectPopupNotDisplayed()
 			.expectFocus()
@@ -214,8 +214,8 @@ public class AjaxAutoCompleteEntityInputFocusedTest extends AbstractAjaxAutoComp
 		input.focusWithClick();
 
 		asserter//
-			.expectServerValueNone()
 			.expectClientValue(UNAVAILABLE_ENTITY.toDisplayStringWithId())
+			.expectServerValueExceptionMessage()
 			.expectIndicatorValueValid()
 			.expectPopupNotDisplayed()
 			.expectFocus()
@@ -235,8 +235,8 @@ public class AjaxAutoCompleteEntityInputFocusedTest extends AbstractAjaxAutoComp
 		input.focusWithTab();
 
 		asserter//
-			.expectServerValueNone()
 			.expectClientValue(UNAVAILABLE_ENTITY.toDisplayStringWithId())
+			.expectServerValueExceptionMessage()
 			.expectIndicatorValueValid()
 			.expectPopupNotDisplayed()
 			.expectFocus()

--- a/platform-ajax/src/test/java/com/softicar/platform/ajax/input/auto/complete/entity/AjaxAutoCompleteEntityInputRefocusedTest.java
+++ b/platform-ajax/src/test/java/com/softicar/platform/ajax/input/auto/complete/entity/AjaxAutoCompleteEntityInputRefocusedTest.java
@@ -28,8 +28,8 @@ public class AjaxAutoCompleteEntityInputRefocusedTest extends AbstractAjaxAutoCo
 			.focusWithClick();
 
 		asserter//
-			.expectServerValueNone()
 			.expectClientValue(INVALID_ITEM_NAME)
+			.expectServerValueNone()
 			.expectIndicatorValueIllegal()
 			.expectPopupNotDisplayed()
 			.expectFocus()
@@ -53,8 +53,8 @@ public class AjaxAutoCompleteEntityInputRefocusedTest extends AbstractAjaxAutoCo
 			.focusWithClick();
 
 		asserter//
-			.expectServerValueNone()
 			.expectClientValue(INVALID_ITEM_NAME)
+			.expectServerValueNone()
 			.expectIndicatorValueIllegal()
 			.expectPopupNotDisplayed()
 			.expectFocus()

--- a/platform-ajax/src/test/java/com/softicar/platform/ajax/input/auto/complete/entity/AjaxAutoCompleteEntityInputUnfocusedTest.java
+++ b/platform-ajax/src/test/java/com/softicar/platform/ajax/input/auto/complete/entity/AjaxAutoCompleteEntityInputUnfocusedTest.java
@@ -60,7 +60,7 @@ public class AjaxAutoCompleteEntityInputUnfocusedTest extends AbstractAjaxAutoCo
 
 		asserter//
 			.expectClientValue(AMBIGUOUS_ITEM_NAME_CHUNK)
-			.expectServerValueNone()
+			.expectServerValueExceptionMessage()
 			.expectIndicatorNotOkay()
 			.expectPopupNotDisplayed()
 			.expectNoFocus()
@@ -302,7 +302,7 @@ public class AjaxAutoCompleteEntityInputUnfocusedTest extends AbstractAjaxAutoCo
 
 		asserter//
 			.expectClientValue("fo")
-			.expectServerValueNone()
+			.expectServerValueExceptionMessage()
 			.expectIndicatorNotOkay()
 			.expectPopupNotDisplayed()
 			.expectNoFocus()

--- a/platform-dom/src/main/java/com/softicar/platform/dom/elements/input/auto/DomAutoCompleteInput.java
+++ b/platform-dom/src/main/java/com/softicar/platform/dom/elements/input/auto/DomAutoCompleteInput.java
@@ -115,6 +115,12 @@ public class DomAutoCompleteInput<T> extends DomDiv implements IDomAutoCompleteI
 	}
 
 	@Override
+	public Optional<T> getValue() {
+
+		return getSelection().getValue();
+	}
+
+	@Override
 	public void setValue(T value) {
 
 		String valueString = Optional//

--- a/platform-dom/src/main/java/com/softicar/platform/dom/input/IDomValueInput.java
+++ b/platform-dom/src/main/java/com/softicar/platform/dom/input/IDomValueInput.java
@@ -27,12 +27,30 @@ public interface IDomValueInput<V> extends IDomNode {
 	 * <li>If an invalid value is entered, an exception is thrown.</li>
 	 * </ul>
 	 *
-	 * @return the entered value as an {@link Optional} (never <i>null</i>)
+	 * @return the entered value as an {@link Optional}
 	 * @throws DomInputException
 	 *             if the user entered something into this input element which
 	 *             does not represent a valid value
 	 */
 	Optional<V> getValue();
+
+	/**
+	 * Returns the value of this input element, as follows:
+	 * <ul>
+	 * <li>If a valid value was entered, the value is returned.</li>
+	 * <li>If no value is entered, <i>null</i> is returned.</li>
+	 * <li>If an invalid value is entered, an exception is thrown.</li>
+	 * </ul>
+	 *
+	 * @return the entered value (may be <i>null</i>)
+	 * @throws DomInputException
+	 *             if the user entered something into this input element which
+	 *             does not represent a valid value
+	 */
+	default V getValueOrNull() {
+
+		return getValue().orElse(null);
+	}
 
 	/**
 	 * Same as {@link #getValue()} but never throws an {@link Exception}.

--- a/platform-dom/src/main/java/com/softicar/platform/dom/input/auto/IDomAutoCompleteInput.java
+++ b/platform-dom/src/main/java/com/softicar/platform/dom/input/auto/IDomAutoCompleteInput.java
@@ -1,6 +1,7 @@
 package com.softicar.platform.dom.input.auto;
 
 import com.softicar.platform.dom.input.IDomTextualInput;
+import com.softicar.platform.dom.input.IDomValueInput;
 import com.softicar.platform.dom.parent.IDomParentElement;
 
 /**
@@ -9,7 +10,7 @@ import com.softicar.platform.dom.parent.IDomParentElement;
  * @author Oliver Richers
  * @author Alexander Schmidt
  */
-public interface IDomAutoCompleteInput<T> extends IDomParentElement {
+public interface IDomAutoCompleteInput<T> extends IDomParentElement, IDomValueInput<T> {
 
 	/**
 	 * Returns the native input field that is contained in the auto-complete
@@ -46,14 +47,6 @@ public interface IDomAutoCompleteInput<T> extends IDomParentElement {
 	 *         represents the current selection (never null)
 	 */
 	IDomAutoCompleteInputSelection<T> getSelection();
-
-	/**
-	 * Sets the selected value for this input element.
-	 *
-	 * @param value
-	 *            the value to be set for this input element (may be null)
-	 */
-	void setValue(T value);
 
 	/**
 	 * Sets the selected value for this input element and triggers a

--- a/platform-dom/src/main/java/com/softicar/platform/dom/input/auto/IDomAutoCompleteInputSelection.java
+++ b/platform-dom/src/main/java/com/softicar/platform/dom/input/auto/IDomAutoCompleteInputSelection.java
@@ -11,59 +11,79 @@ import java.util.Optional;
 public interface IDomAutoCompleteInputSelection<T> {
 
 	/**
-	 * Validates the selected value. Returns the selected value if validation
-	 * passes. Throws if validation fails.
+	 * Returns the optional value of this input element, as follows:
+	 * <ul>
+	 * <li>If the entered text can be mapped to a value, that value is
+	 * returned.</li>
+	 * <li>If the entered text is blank, {@link Optional#empty()} is
+	 * returned.</li>
+	 * <li>If the entered text cannot be mapped to a value, an exception is
+	 * thrown.</li>
+	 * </ul>
 	 *
-	 * @return The validated selected value. May be null (if not selecting a
-	 *         value is considered valid).
-	 * @see #isValid()
-	 * @see #assertValid()
-	 */
-	T getValueOrThrow();
-
-	/**
-	 * Validates the selected value. Returns the selected value if validation
-	 * passes. Returns null if validation fails.
-	 *
-	 * @return The validated selected value. May be null (if not selecting a
-	 *         value is considered valid). Null if validation fails.
-	 * @see #isValid()
-	 * @see #assertValid()
-	 */
-	T getValueOrNull();
-
-	/**
-	 * Validates the selected value. Returns an Optional that contains the
-	 * selected value if validation passes. Returns an empty Optional if
-	 * validation fails.
-	 *
-	 * @return An Optional that contains the validated selected value. May be
-	 *         empty (if not selecting a value is considered valid). Empty if
-	 *         validation fails.
-	 * @see #isValid()
-	 * @see #assertValid()
+	 * @return the value as an {@link Optional} (never <i>null</i>)
 	 */
 	Optional<T> getValue();
 
 	/**
-	 * Validates the selected value. Throws an Exception if validation fails
-	 * (i.e. if {@link #isValid()} would return false).
+	 * Returns the value of this input element, as follows:
+	 * <ul>
+	 * <li>If the entered text can be mapped to a value, that value is
+	 * returned.</li>
+	 * <li>If the entered text is blank, <i>null</i> is returned.</li>
+	 * <li>If the entered text cannot be mapped to a value, an exception is
+	 * thrown.</li>
+	 * </ul>
 	 *
-	 * @see #isValid()
+	 * @return the value (may be <i>null</i>)
 	 */
-	void assertValid();
+	T getValueOrNull();
 
 	/**
-	 * Validates the selected value. Returns a boolean value to indicate the
-	 * result of the validation.
+	 * Returns the value of this input element, as follows:
+	 * <ul>
+	 * <li>If the entered text can be mapped to a value, that value is
+	 * returned.</li>
+	 * <li>If the entered text is blank, or if the entered text cannot be mapped
+	 * to a value, an exception is thrown.</li>
+	 * </ul>
 	 *
-	 * @return true if validation passes. false if validation fails.
-	 * @see #assertValid()
+	 * @return the value (never <i>null</i>)
+	 */
+	T getValueOrThrow();
+
+	/**
+	 * Determines whether the entered text can be mapped to a value.
+	 * <p>
+	 * Returns <i>true</i> if the entered text can be mapped to a value, or if
+	 * the entered text is blank.
+	 *
+	 * @return <i>true</i> if the selected value is valid; <i>false</i>
+	 *         otherwise
+	 */
+
+	/**
+	 * Determines the validity of the entered text, as follows:
+	 * <ul>
+	 * <li>If the entered text can be mapped to a value, <i>true</i> is
+	 * returned.</li>
+	 * <li>If the entered text is blank, <i>true</i> is returned.</li>
+	 * <li>Otherwise, <i>false</i> is returned.</li>
+	 * </ul>
+	 *
+	 * @return <i>true</i> if the entered text is valid; <i>false</i> otherwise
 	 */
 	boolean isValid();
 
 	/**
-	 * @return true if the trimmed pattern is empty. false otherwise.
+	 * Asserts the validity of the entered text.
+	 * <p>
+	 * If {@link #isValid()} would return <i>false</i>, an exception is thrown.
+	 */
+	void assertValid();
+
+	/**
+	 * @return <i>true</i> if the entered text is blank; <i>false</i> otherwise
 	 */
 	boolean isBlankPattern();
 }

--- a/platform-emf/src/main/java/com/softicar/platform/emf/attribute/field/enums/table/row/EmfEnumTableRowInput.java
+++ b/platform-emf/src/main/java/com/softicar/platform/emf/attribute/field/enums/table/row/EmfEnumTableRowInput.java
@@ -27,9 +27,7 @@ public class EmfEnumTableRowInput<R extends IDbEnumTableRow<R, E>, E extends IDb
 	@Override
 	public Optional<R> getValue() {
 
-		return Optional//
-			.ofNullable(input.getSelection().getValueOrThrow())
-			.map(EmfEnumTableRowEntityWrapper::getRow);
+		return input.getValue().map(EmfEnumTableRowEntityWrapper::getRow);
 	}
 
 	@Override

--- a/platform-emf/src/main/java/com/softicar/platform/emf/attribute/field/foreign/entity/input/EmfEntityInput.java
+++ b/platform-emf/src/main/java/com/softicar/platform/emf/attribute/field/foreign/entity/input/EmfEntityInput.java
@@ -6,7 +6,6 @@ import com.softicar.platform.dom.elements.input.auto.entity.DomAutoCompleteEntit
 import com.softicar.platform.emf.attribute.input.IEmfInput;
 import com.softicar.platform.emf.entity.IEmfEntity;
 import com.softicar.platform.emf.entity.table.IEmfEntityTable;
-import java.util.Optional;
 
 public class EmfEntityInput<E extends IEmfEntity<E, ?>> extends DomAutoCompleteEntityInput<E> implements IEmfInput<E> {
 
@@ -34,12 +33,6 @@ public class EmfEntityInput<E extends IEmfEntity<E, ?>> extends DomAutoCompleteE
 	public void refreshInputConstraints() {
 
 		refreshFilters();
-	}
-
-	@Override
-	public Optional<E> getValue() {
-
-		return Optional.ofNullable(getSelection().getValueOrThrow());
 	}
 
 	@Override

--- a/platform-emf/src/main/java/com/softicar/platform/emf/management/prefilter/AbstractEmfPrefilterRow.java
+++ b/platform-emf/src/main/java/com/softicar/platform/emf/management/prefilter/AbstractEmfPrefilterRow.java
@@ -5,11 +5,11 @@ import com.softicar.platform.db.runtime.data.table.DbTableBasedDataTableValueFil
 import com.softicar.platform.db.runtime.field.IDbField;
 import com.softicar.platform.db.runtime.field.IDbStringField;
 import com.softicar.platform.db.sql.ISqlBooleanExpression;
-import com.softicar.platform.dom.element.IDomElement;
 import com.softicar.platform.dom.elements.DomDiv;
 import com.softicar.platform.dom.elements.button.DomButton;
+import com.softicar.platform.dom.input.IDomValueInput;
+import com.softicar.platform.dom.node.IDomNode;
 import com.softicar.platform.emf.EmfCssClasses;
-import com.softicar.platform.emf.attribute.input.IEmfInput;
 import com.softicar.platform.emf.table.row.IEmfTableRow;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -18,7 +18,7 @@ import java.util.Optional;
 public abstract class AbstractEmfPrefilterRow<E extends IEmfTableRow<E, ?>> extends DomDiv {
 
 	private final DomDiv contentElement;
-	private final Collection<IEmfInput<?>> inputElements;
+	private final Collection<IDomValueInput<?>> inputElements;
 
 	public AbstractEmfPrefilterRow() {
 
@@ -36,16 +36,16 @@ public abstract class AbstractEmfPrefilterRow<E extends IEmfTableRow<E, ?>> exte
 
 	public abstract ISqlBooleanExpression<E> getFilterExpression();
 
-	protected <I extends IEmfInput<?>> I appendInputElement(I inputElement) {
+	protected <I extends IDomValueInput<?>> I appendInputElement(I inputElement) {
 
-		appendElement(inputElement);
+		appendNode(inputElement);
 		this.inputElements.add(inputElement);
 		return inputElement;
 	}
 
-	protected void appendElement(IDomElement element) {
+	protected void appendNode(IDomNode node) {
 
-		this.contentElement.appendChild(element);
+		this.contentElement.appendChild(node);
 	}
 
 	protected <V> Optional<ISqlBooleanExpression<E>> createFilterExpressionWithOperator(IDbField<E, V> field, DataTableValueFilterOperator operator,


### PR DESCRIPTION
- Let `IDomAutoCompleteInput` extend `IDomValueInput`, and adopt recent changes to the `IDomValueInput` API.
- Reworked `IDomAutoCompleteInputSelection`, and the return values in its implementation.
- Adopted expected behavior changes in unit tests.
- Fixed permissive mode.
