### PR TITLE
PLAT-733 IEmfInput: Add setValueAndHandleChangeCallback

### DIFF
--- a/platform-demo-module/src/main/java/com/softicar/platform/demo/module/moment/AGDemoMomentTable.java
+++ b/platform-demo-module/src/main/java/com/softicar/platform/demo/module/moment/AGDemoMomentTable.java
@@ -2,6 +2,8 @@ package com.softicar.platform.demo.module.moment;
 
 import com.softicar.platform.db.runtime.object.IDbObjectTableBuilder;
 import com.softicar.platform.demo.module.AGDemoModuleInstance;
+import com.softicar.platform.emf.attribute.IEmfAttributeList;
+import com.softicar.platform.emf.attribute.dependency.EmfAttributeDependencyMap;
 import com.softicar.platform.emf.object.table.EmfObjectTable;
 import com.softicar.platform.emf.table.configuration.EmfTableConfiguration;
 
@@ -16,5 +18,24 @@ public class AGDemoMomentTable extends EmfObjectTable<AGDemoMoment, AGDemoModule
 	public void customizeEmfTableConfiguration(EmfTableConfiguration<AGDemoMoment, Integer, AGDemoModuleInstance> configuration) {
 
 		configuration.setScopeField(AGDemoMoment.MODULE_INSTANCE);
+	}
+
+	@Override
+	public void customizeAttributeProperties(IEmfAttributeList<AGDemoMoment> attributes) {
+
+		attributes//
+			.editAttribute(AGDemoMoment.DAY)
+			.setInputFactory(DemoMomentDayInput::new);
+		attributes//
+			.editAttribute(AGDemoMoment.POINT_IN_TIME)
+			.setInputFactoryByEntity(DemoMomentPointInTimeInput::new);
+	}
+
+	@Override
+	public void customizeAttributeDependencies(EmfAttributeDependencyMap<AGDemoMoment> dependencyMap) {
+
+		dependencyMap//
+			.editAttribute(AGDemoMoment.POINT_IN_TIME)
+			.setDependsOn(AGDemoMoment.DAY);
 	}
 }

--- a/platform-demo-module/src/main/java/com/softicar/platform/demo/module/moment/DemoMomentDayInput.java
+++ b/platform-demo-module/src/main/java/com/softicar/platform/demo/module/moment/DemoMomentDayInput.java
@@ -1,0 +1,28 @@
+package com.softicar.platform.demo.module.moment;
+
+import com.softicar.platform.common.date.Day;
+import com.softicar.platform.demo.module.DemoI18n;
+import com.softicar.platform.dom.elements.button.DomButton;
+import com.softicar.platform.emf.attribute.field.day.EmfDayInput;
+
+public class DemoMomentDayInput extends EmfDayInput {
+
+	public DemoMomentDayInput() {
+
+		appendChild(new SetCurrentDayButton());
+	}
+
+	private class SetCurrentDayButton extends DomButton {
+
+		public SetCurrentDayButton() {
+
+			setLabel(DemoI18n.TODAY);
+			setClickCallback(this::setToCurrentDay);
+		}
+
+		private void setToCurrentDay() {
+
+			setValueAndHandleChangeCallback(Day.today());
+		}
+	}
+}

--- a/platform-demo-module/src/main/java/com/softicar/platform/demo/module/moment/DemoMomentPointInTimeInput.java
+++ b/platform-demo-module/src/main/java/com/softicar/platform/demo/module/moment/DemoMomentPointInTimeInput.java
@@ -1,0 +1,21 @@
+package com.softicar.platform.demo.module.moment;
+
+import com.softicar.platform.emf.attribute.field.daytime.EmfDayTimeInput;
+
+public class DemoMomentPointInTimeInput extends EmfDayTimeInput {
+
+	private final AGDemoMoment moment;
+
+	public DemoMomentPointInTimeInput(AGDemoMoment moment) {
+
+		this.moment = moment;
+	}
+
+	@Override
+	public void refreshInputConstraints() {
+
+		if (moment.getDay() != null) {
+			setValue(moment.getDay().toDayTime());
+		}
+	}
+}

--- a/platform-dom/src/main/java/com/softicar/platform/dom/elements/input/auto/DomAutoCompleteInput.java
+++ b/platform-dom/src/main/java/com/softicar/platform/dom/elements/input/auto/DomAutoCompleteInput.java
@@ -85,6 +85,13 @@ public class DomAutoCompleteInput<T> extends DomDiv implements IDomAutoCompleteI
 		}
 	}
 
+	public void applyChangeCallback() {
+
+		Optional//
+			.ofNullable(changeCallback)
+			.ifPresent(INullaryVoidFunction::apply);
+	}
+
 	@Override
 	public IDomAutoCompleteInputConfiguration getConfiguration() {
 

--- a/platform-emf/src/main/java/com/softicar/platform/emf/attribute/field/bool/EmfBooleanInput.java
+++ b/platform-emf/src/main/java/com/softicar/platform/emf/attribute/field/bool/EmfBooleanInput.java
@@ -33,6 +33,7 @@ public class EmfBooleanInput extends AbstractEmfChangeListeningInputDiv<Boolean>
 	@Override
 	public void setValueAndHandleChangeCallback(Boolean value) {
 
+		// FIXME PLAT-756 Should change this behavior
 		// DomCheckbox#setChecked already executes a callback
 		checkBox.setChecked(value);
 	}

--- a/platform-emf/src/main/java/com/softicar/platform/emf/attribute/field/bool/EmfBooleanInput.java
+++ b/platform-emf/src/main/java/com/softicar/platform/emf/attribute/field/bool/EmfBooleanInput.java
@@ -31,6 +31,13 @@ public class EmfBooleanInput extends AbstractEmfChangeListeningInputDiv<Boolean>
 	}
 
 	@Override
+	public void setValueAndHandleChangeCallback(Boolean value) {
+
+		// DomCheckbox#setChecked already executes a callback
+		checkBox.setChecked(value);
+	}
+
+	@Override
 	public void setChangeCallback(INullaryVoidFunction callback) {
 
 		checkBox.setChangeCallback(callback);

--- a/platform-emf/src/main/java/com/softicar/platform/emf/attribute/field/day/EmfDayInput.java
+++ b/platform-emf/src/main/java/com/softicar/platform/emf/attribute/field/day/EmfDayInput.java
@@ -25,6 +25,13 @@ public class EmfDayInput extends AbstractEmfInputDiv<Day> {
 	}
 
 	@Override
+	public void setValueAndHandleChangeCallback(Day value) {
+
+		setValue(value);
+		dayInput.applyCallback();
+	}
+
+	@Override
 	public void setValue(Day value) {
 
 		dayInput.setValue(value);

--- a/platform-emf/src/main/java/com/softicar/platform/emf/attribute/field/decimal/EmfDecimalAttribute.java
+++ b/platform-emf/src/main/java/com/softicar/platform/emf/attribute/field/decimal/EmfDecimalAttribute.java
@@ -69,6 +69,13 @@ public class EmfDecimalAttribute<R extends IEmfTableRow<R, ?>, V extends Number>
 		}
 
 		@Override
+		public void setValueAndHandleChangeCallback(V value) {
+
+			setValue(value);
+			callback.apply();
+		}
+
+		@Override
 		public void setChangeCallback(INullaryVoidFunction callback) {
 
 			this.callback = Objects.requireNonNull(callback);

--- a/platform-emf/src/main/java/com/softicar/platform/emf/attribute/field/enums/EmfEnumInput.java
+++ b/platform-emf/src/main/java/com/softicar/platform/emf/attribute/field/enums/EmfEnumInput.java
@@ -37,7 +37,7 @@ public class EmfEnumInput<E extends Enum<E>> extends AbstractEmfChangeListeningI
 	public void setValueAndHandleChangeCallback(E value) {
 
 		setValue(value);
-		enumInput.getChangeCallback().ifPresent(INullaryVoidFunction::apply);
+		enumInput.applyChangeCallback();
 	}
 
 	@Override
@@ -68,9 +68,11 @@ public class EmfEnumInput<E extends Enum<E>> extends AbstractEmfChangeListeningI
 			this.callback = callback;
 		}
 
-		private Optional<INullaryVoidFunction> getChangeCallback() {
+		public void applyChangeCallback() {
 
-			return Optional.ofNullable(callback);
+			Optional//
+				.ofNullable(callback)
+				.ifPresent(INullaryVoidFunction::apply);
 		}
 
 		@Override

--- a/platform-emf/src/main/java/com/softicar/platform/emf/attribute/field/enums/EmfEnumInput.java
+++ b/platform-emf/src/main/java/com/softicar/platform/emf/attribute/field/enums/EmfEnumInput.java
@@ -34,6 +34,13 @@ public class EmfEnumInput<E extends Enum<E>> extends AbstractEmfChangeListeningI
 	}
 
 	@Override
+	public void setValueAndHandleChangeCallback(E value) {
+
+		setValue(value);
+		enumInput.getChangeCallback().ifPresent(INullaryVoidFunction::apply);
+	}
+
+	@Override
 	public void setValue(E value) {
 
 		enumInput.setSelectedValue(value);
@@ -59,6 +66,11 @@ public class EmfEnumInput<E extends Enum<E>> extends AbstractEmfChangeListeningI
 		public void setChangeCallback(INullaryVoidFunction callback) {
 
 			this.callback = callback;
+		}
+
+		private Optional<INullaryVoidFunction> getChangeCallback() {
+
+			return Optional.ofNullable(callback);
 		}
 
 		@Override

--- a/platform-emf/src/main/java/com/softicar/platform/emf/attribute/field/enums/table/row/EmfEnumTableRowInput.java
+++ b/platform-emf/src/main/java/com/softicar/platform/emf/attribute/field/enums/table/row/EmfEnumTableRowInput.java
@@ -37,6 +37,13 @@ public class EmfEnumTableRowInput<R extends IDbEnumTableRow<R, E>, E extends IDb
 	}
 
 	@Override
+	public void setValueAndHandleChangeCallback(R value) {
+
+		setValue(value);
+		input.applyChangeCallback();
+	}
+
+	@Override
 	public void setValue(R row) {
 
 		input.setValue(EmfEnumTableRowEntityWrapper.wrap(row));

--- a/platform-emf/src/main/java/com/softicar/platform/emf/attribute/field/foreign/entity/input/EmfEntityInput.java
+++ b/platform-emf/src/main/java/com/softicar/platform/emf/attribute/field/foreign/entity/input/EmfEntityInput.java
@@ -30,6 +30,13 @@ public class EmfEntityInput<E extends IEmfEntity<E, ?>> extends DomAutoCompleteE
 	}
 
 	@Override
+	public void setValueAndHandleChangeCallback(E value) {
+
+		setValue(value);
+		applyChangeCallback();
+	}
+
+	@Override
 	public void refreshInputConstraints() {
 
 		refreshFilters();

--- a/platform-emf/src/main/java/com/softicar/platform/emf/attribute/field/integer/EmfIntegerInput.java
+++ b/platform-emf/src/main/java/com/softicar/platform/emf/attribute/field/integer/EmfIntegerInput.java
@@ -12,6 +12,13 @@ public class EmfIntegerInput extends DomIntegerInput implements IEmfInput<Intege
 	private INullaryVoidFunction callback = INullaryVoidFunction.NO_OPERATION;
 
 	@Override
+	public void setValueAndHandleChangeCallback(Integer value) {
+
+		setValue(value);
+		callback.apply();
+	}
+
+	@Override
 	public void setChangeCallback(INullaryVoidFunction callback) {
 
 		this.callback = Objects.requireNonNull(callback);

--- a/platform-emf/src/main/java/com/softicar/platform/emf/attribute/field/longs/EmfLongInput.java
+++ b/platform-emf/src/main/java/com/softicar/platform/emf/attribute/field/longs/EmfLongInput.java
@@ -12,6 +12,13 @@ public class EmfLongInput extends DomLongInput implements IEmfInput<Long>, IDomC
 	private INullaryVoidFunction callback = INullaryVoidFunction.NO_OPERATION;
 
 	@Override
+	public void setValueAndHandleChangeCallback(Long value) {
+
+		setValue(value);
+		callback.apply();
+	}
+
+	@Override
 	public void setChangeCallback(INullaryVoidFunction callback) {
 
 		this.callback = Objects.requireNonNull(callback);

--- a/platform-emf/src/main/java/com/softicar/platform/emf/attribute/input/IEmfInput.java
+++ b/platform-emf/src/main/java/com/softicar/platform/emf/attribute/input/IEmfInput.java
@@ -8,9 +8,27 @@ import com.softicar.platform.dom.input.IDomValueInput;
 public interface IEmfInput<V> extends IDomValueInput<V>, IDomInputNode {
 
 	/**
+	 * Assigns a value to this input element and triggers the change callback,
+	 * if any.
+	 * <p>
+	 * FIXME Remove default implementation once every {@link IEmfInput} has
+	 * change-handling capabilities, see PLAT-735.
+	 *
+	 * @param value
+	 *            the value to assign or <i>null</i>
+	 */
+	default void setValueAndHandleChangeCallback(V value) {
+
+		setValue(value);
+	}
+
+	/**
 	 * Defines the given callback to be notified when the value changes.
 	 * <p>
 	 * This method is called by the entity framework, don't call it directly.
+	 * <p>
+	 * FIXME Remove default implementation once every {@link IEmfInput} has
+	 * change-handling capabilities, see PLAT-735.
 	 *
 	 * @param callback
 	 *            the callback (never null)


### PR DESCRIPTION
  - `setValueAndHandleChangeCallback` in `IEmfInput` manually executes the change-callback, if present
  - previously, if setting a value of an input with just `setValue`, no change-callback was executed, which lead to some problems
  - added a test implementation in `AGDemoMoment` where a button sets the value of the input with the new method
  - added a dependee of the field that gets its value set programmatically that updates its value via `refreshInputConstraints`
![image](https://user-images.githubusercontent.com/90852097/160424358-ed71204a-d113-4fa6-8efa-70b8d84504e4.png)
![image](https://user-images.githubusercontent.com/90852097/160424401-c81f7f02-af04-4547-8e16-e31c8beca88b.png)
![image](https://user-images.githubusercontent.com/90852097/160424866-9d8161b1-ccb9-4eed-8086-4d974908a79f.png)
