### PR TITLE
PLAT-762 Create AbstractEmfAdjacentNodeForm

### DIFF
--- a/platform-demo-module/src/main/java/com/softicar/platform/demo/module/invoice/DemoInvoiceForm.java
+++ b/platform-demo-module/src/main/java/com/softicar/platform/demo/module/invoice/DemoInvoiceForm.java
@@ -1,39 +1,38 @@
 package com.softicar.platform.demo.module.invoice;
 
+import com.softicar.platform.common.core.exceptions.SofticarUnknownEnumConstantException;
 import com.softicar.platform.demo.module.DemoI18n;
-import com.softicar.platform.dom.elements.DomDiv;
-import com.softicar.platform.dom.elements.bar.DomBar;
 import com.softicar.platform.dom.elements.message.DomMessageDiv;
 import com.softicar.platform.dom.elements.message.style.DomMessageType;
+import com.softicar.platform.dom.node.IDomNode;
 import com.softicar.platform.emf.form.EmfFormMode;
 import com.softicar.platform.emf.form.IEmfFormFrame;
-import com.softicar.platform.emf.form.delegator.AbstractEmfFormDelegator;
+import com.softicar.platform.emf.form.delegator.AbstractEmfAdjacentNodeForm;
 
-public class DemoInvoiceForm extends AbstractEmfFormDelegator<AGDemoInvoice> {
-
-	private final DomDiv container;
+public class DemoInvoiceForm extends AbstractEmfAdjacentNodeForm<AGDemoInvoice> {
 
 	public DemoInvoiceForm(IEmfFormFrame<AGDemoInvoice> frame, AGDemoInvoice tableRow) {
 
 		super(frame, tableRow);
-		this.container = appendChild(new DomBar());
-		form.setModeChangeCallback(this::handleModeChange);
 	}
 
-	private void handleModeChange(EmfFormMode mode) {
+	@Override
+	protected IDomNode createAdjacentNode(EmfFormMode mode, AGDemoInvoice tableRow) {
 
-		container.removeChildren();
 		switch (mode) {
 		case CREATION:
-			container.appendChild(new DomMessageDiv(DomMessageType.INFO, DemoI18n.CREATE));
-			break;
+			return new DomMessageDiv(DomMessageType.INFO, DemoI18n.CREATE);
 		case EDIT:
-			container.appendChild(new DomMessageDiv(DomMessageType.INFO, DemoI18n.EDIT));
-			break;
+			return new DomMessageDiv(DomMessageType.INFO, DemoI18n.EDIT);
 		case VIEW:
-			container.appendChild(new DomMessageDiv(DomMessageType.INFO, DemoI18n.VIEW));
-			break;
+			return new DomMessageDiv(DomMessageType.INFO, DemoI18n.VIEW);
 		}
-		container.appendChild(form);
+		throw new SofticarUnknownEnumConstantException(mode);
+	}
+
+	@Override
+	protected AdjacentNodeSide getAdjacentNodeSide() {
+
+		return AdjacentNodeSide.LEFT;
 	}
 }

--- a/platform-demo-module/src/main/java/com/softicar/platform/demo/module/invoice/DemoInvoiceForm.java
+++ b/platform-demo-module/src/main/java/com/softicar/platform/demo/module/invoice/DemoInvoiceForm.java
@@ -5,11 +5,11 @@ import com.softicar.platform.dom.elements.DomDiv;
 import com.softicar.platform.dom.elements.bar.DomBar;
 import com.softicar.platform.dom.elements.message.DomMessageDiv;
 import com.softicar.platform.dom.elements.message.style.DomMessageType;
-import com.softicar.platform.emf.form.EmfFormDelegator;
 import com.softicar.platform.emf.form.EmfFormMode;
 import com.softicar.platform.emf.form.IEmfFormFrame;
+import com.softicar.platform.emf.form.delegator.AbstractEmfFormDelegator;
 
-public class DemoInvoiceForm extends EmfFormDelegator<AGDemoInvoice> {
+public class DemoInvoiceForm extends AbstractEmfFormDelegator<AGDemoInvoice> {
 
 	private final DomDiv container;
 

--- a/platform-demo-module/src/main/java/com/softicar/platform/demo/module/invoice/paid/DemoInvoicePaymentForm.java
+++ b/platform-demo-module/src/main/java/com/softicar/platform/demo/module/invoice/paid/DemoInvoicePaymentForm.java
@@ -4,11 +4,11 @@ import com.softicar.platform.demo.module.DemoI18n;
 import com.softicar.platform.dom.elements.DomDiv;
 import com.softicar.platform.dom.elements.message.DomMessageDiv;
 import com.softicar.platform.dom.elements.message.style.DomMessageType;
-import com.softicar.platform.emf.form.EmfFormDelegator;
 import com.softicar.platform.emf.form.EmfFormMode;
 import com.softicar.platform.emf.form.IEmfFormFrame;
+import com.softicar.platform.emf.form.delegator.AbstractEmfFormDelegator;
 
-public class DemoInvoicePaymentForm extends EmfFormDelegator<AGDemoInvoicePayment> {
+public class DemoInvoicePaymentForm extends AbstractEmfFormDelegator<AGDemoInvoicePayment> {
 
 	private final DomDiv container;
 

--- a/platform-demo-module/src/main/java/com/softicar/platform/demo/module/invoice/paid/DemoInvoicePaymentForm.java
+++ b/platform-demo-module/src/main/java/com/softicar/platform/demo/module/invoice/paid/DemoInvoicePaymentForm.java
@@ -1,38 +1,38 @@
 package com.softicar.platform.demo.module.invoice.paid;
 
+import com.softicar.platform.common.core.exceptions.SofticarUnknownEnumConstantException;
 import com.softicar.platform.demo.module.DemoI18n;
-import com.softicar.platform.dom.elements.DomDiv;
 import com.softicar.platform.dom.elements.message.DomMessageDiv;
 import com.softicar.platform.dom.elements.message.style.DomMessageType;
+import com.softicar.platform.dom.node.IDomNode;
 import com.softicar.platform.emf.form.EmfFormMode;
 import com.softicar.platform.emf.form.IEmfFormFrame;
-import com.softicar.platform.emf.form.delegator.AbstractEmfFormDelegator;
+import com.softicar.platform.emf.form.delegator.AbstractEmfAdjacentNodeForm;
 
-public class DemoInvoicePaymentForm extends AbstractEmfFormDelegator<AGDemoInvoicePayment> {
-
-	private final DomDiv container;
+public class DemoInvoicePaymentForm extends AbstractEmfAdjacentNodeForm<AGDemoInvoicePayment> {
 
 	public DemoInvoicePaymentForm(IEmfFormFrame<AGDemoInvoicePayment> frame, AGDemoInvoicePayment tableRow) {
 
 		super(frame, tableRow);
-		this.container = appendChild(new DomDiv());
-		form.setModeChangeCallback(this::handleModeChange);
 	}
 
-	private void handleModeChange(EmfFormMode mode) {
+	@Override
+	protected IDomNode createAdjacentNode(EmfFormMode mode, AGDemoInvoicePayment tableRow) {
 
-		container.removeChildren();
 		switch (mode) {
 		case CREATION:
-			container.appendChild(new DomMessageDiv(DomMessageType.INFO, DemoI18n.CREATE_TRAIT));
-			break;
+			return new DomMessageDiv(DomMessageType.INFO, DemoI18n.CREATE_TRAIT);
 		case EDIT:
-			container.appendChild(new DomMessageDiv(DomMessageType.INFO, DemoI18n.EDIT_TRAIT));
-			break;
+			return new DomMessageDiv(DomMessageType.INFO, DemoI18n.EDIT_TRAIT);
 		case VIEW:
-			container.appendChild(new DomMessageDiv(DomMessageType.INFO, DemoI18n.VIEW_TRAIT));
-			break;
+			return new DomMessageDiv(DomMessageType.INFO, DemoI18n.VIEW_TRAIT);
 		}
-		container.appendChild(form);
+		throw new SofticarUnknownEnumConstantException(mode);
+	}
+
+	@Override
+	protected AdjacentNodeSide getAdjacentNodeSide() {
+
+		return AdjacentNodeSide.TOP;
 	}
 }

--- a/platform-emf/src/main/java/com/softicar/platform/emf/form/EmfFormMode.java
+++ b/platform-emf/src/main/java/com/softicar/platform/emf/form/EmfFormMode.java
@@ -1,5 +1,8 @@
 package com.softicar.platform.emf.form;
 
+/**
+ * Enumerates the distinct modes of an {@link EmfForm}.
+ */
 public enum EmfFormMode {
 
 	CREATION,

--- a/platform-emf/src/main/java/com/softicar/platform/emf/form/delegator/AbstractEmfAdjacentNodeForm.java
+++ b/platform-emf/src/main/java/com/softicar/platform/emf/form/delegator/AbstractEmfAdjacentNodeForm.java
@@ -1,0 +1,111 @@
+package com.softicar.platform.emf.form.delegator;
+
+import com.softicar.platform.dom.elements.DomDiv;
+import com.softicar.platform.dom.elements.bar.DomBar;
+import com.softicar.platform.dom.node.IDomNode;
+import com.softicar.platform.dom.parent.IDomParentElement;
+import com.softicar.platform.emf.form.EmfForm;
+import com.softicar.platform.emf.form.EmfFormMode;
+import com.softicar.platform.emf.form.IEmfForm;
+import com.softicar.platform.emf.form.IEmfFormFrame;
+import com.softicar.platform.emf.table.row.IEmfTableRow;
+
+/**
+ * An {@link IEmfForm} that can be supplemented by an adjacent {@link IDomNode},
+ * e.g. an image that is displayed next to a regular {@link EmfForm}.
+ *
+ * @author Alexander Schmidt
+ */
+public abstract class AbstractEmfAdjacentNodeForm<R extends IEmfTableRow<R, ?>> extends AbstractEmfFormDelegator<R> {
+
+	private final IDomParentElement container;
+
+	public AbstractEmfAdjacentNodeForm(IEmfFormFrame<R> frame, R tableRow) {
+
+		super(frame, tableRow);
+		this.container = appendChild(createContainer());
+		this.form.setModeChangeCallback(this::handleModeChange);
+	}
+
+	/**
+	 * Creates an {@link IDomNode} to be displayed next to the {@link EmfForm}.
+	 * <p>
+	 * If <i>null</i> is returned, only the {@link EmfForm} will be displayed.
+	 * <p>
+	 * This method gets invoked whenever the {@link EmfFormMode} of the
+	 * {@link EmfForm} changes.
+	 *
+	 * @param mode
+	 *            the current {@link EmfFormMode} (never <i>null</i>)
+	 * @param tableRow
+	 *            the current table row (never <i>null</i>)
+	 * @return the adjacent {@link IDomNode} (may be <i>null</i>)
+	 */
+	protected abstract IDomNode createAdjacentNode(EmfFormMode mode, R tableRow);
+
+	/**
+	 * The side, relative to the {@link EmfForm}, on which the adjacent
+	 * {@link IDomNode} shall be displayed.
+	 *
+	 * @return the side (never <i>null</i>)
+	 */
+	protected abstract AdjacentNodeSide getAdjacentNodeSide();
+
+	private IDomParentElement createContainer() {
+
+		if (getAdjacentNodeSide().isHorizontal()) {
+			return new DomBar();
+		} else {
+			return new DomDiv();
+		}
+	}
+
+	protected void handleModeChange(EmfFormMode mode) {
+
+		IDomNode node = createAdjacentNode(mode, getTableRow());
+		container.removeChildren();
+		if (getAdjacentNodeSide().isBefore()) {
+			appendNodeIfNonNull(node);
+			appendForm();
+		} else {
+			appendForm();
+			appendNodeIfNonNull(node);
+		}
+	}
+
+	private void appendForm() {
+
+		container.appendChildren(form);
+	}
+
+	private void appendNodeIfNonNull(IDomNode additionalNode) {
+
+		if (additionalNode != null) {
+			container.appendChildren(additionalNode);
+		}
+	}
+
+	/**
+	 * Represents the side on which the adjacent {@link IDomNode} shall be
+	 * displayed, relative to the {@link EmfForm}.
+	 *
+	 * @author Alexander Schmidt
+	 */
+	public static enum AdjacentNodeSide {
+
+		BOTTOM,
+		LEFT,
+		RIGHT,
+		TOP;
+
+		public boolean isHorizontal() {
+
+			return this == LEFT || this == RIGHT;
+		}
+
+		public boolean isBefore() {
+
+			return this == LEFT || this == TOP;
+		}
+	}
+}

--- a/platform-emf/src/main/java/com/softicar/platform/emf/form/delegator/AbstractEmfAdjacentNodeForm.java
+++ b/platform-emf/src/main/java/com/softicar/platform/emf/form/delegator/AbstractEmfAdjacentNodeForm.java
@@ -65,23 +65,18 @@ public abstract class AbstractEmfAdjacentNodeForm<R extends IEmfTableRow<R, ?>> 
 		IDomNode node = createAdjacentNode(mode, getTableRow());
 		container.removeChildren();
 		if (getAdjacentNodeSide().isBefore()) {
-			appendNodeIfNonNull(node);
-			appendForm();
+			appendToContainer(node, form);
 		} else {
-			appendForm();
-			appendNodeIfNonNull(node);
+			appendToContainer(form, node);
 		}
 	}
 
-	private void appendForm() {
+	private void appendToContainer(IDomNode...nodes) {
 
-		container.appendChildren(form);
-	}
-
-	private void appendNodeIfNonNull(IDomNode additionalNode) {
-
-		if (additionalNode != null) {
-			container.appendChildren(additionalNode);
+		for (IDomNode node: nodes) {
+			if (node != null) {
+				container.appendChildren(node);
+			}
 		}
 	}
 

--- a/platform-emf/src/main/java/com/softicar/platform/emf/form/delegator/AbstractEmfFormDelegator.java
+++ b/platform-emf/src/main/java/com/softicar/platform/emf/form/delegator/AbstractEmfFormDelegator.java
@@ -1,17 +1,28 @@
-package com.softicar.platform.emf.form;
+package com.softicar.platform.emf.form.delegator;
 
 import com.softicar.platform.dom.elements.DomDiv;
 import com.softicar.platform.emf.EmfCssClasses;
+import com.softicar.platform.emf.form.EmfForm;
+import com.softicar.platform.emf.form.IEmfForm;
+import com.softicar.platform.emf.form.IEmfFormFrame;
 import com.softicar.platform.emf.table.row.IEmfTableRow;
 import com.softicar.platform.emf.validation.IEmfValidator;
 import java.util.Collection;
 import java.util.function.Consumer;
 
-public abstract class EmfFormDelegator<R extends IEmfTableRow<R, ?>> extends DomDiv implements IEmfForm<R> {
+/**
+ * An implementation of {@link IEmfForm} that delegates interface calls to an
+ * internal {@link #form} field.
+ * <p>
+ * Should be used as a base class for custom {@link IEmfForm} implementations.
+ *
+ * @author Daniel Klose
+ */
+public abstract class AbstractEmfFormDelegator<R extends IEmfTableRow<R, ?>> extends DomDiv implements IEmfForm<R> {
 
 	protected EmfForm<R> form;
 
-	public EmfFormDelegator(IEmfFormFrame<R> frame, R tableRow) {
+	public AbstractEmfFormDelegator(IEmfFormFrame<R> frame, R tableRow) {
 
 		this.form = new EmfForm<>(frame, tableRow);
 		addCssClass(EmfCssClasses.EMF_FORM_DELEGATOR);


### PR DESCRIPTION
Added `AbstractEmfAdjacentNodeForm` to facilitate displaying an additional node next to an `EmfForm` (without having to write the same code over and over again).

Untelated: Minor renaming and Javadoc improvement.
