### PR TITLE
PLAT-824 Popup Compositor: Handle popup hierarchy

### DIFF
--- a/platform-ajax/src/test/java/com/softicar/platform/ajax/dialog/AjaxModalAlertPopupTest.java
+++ b/platform-ajax/src/test/java/com/softicar/platform/ajax/dialog/AjaxModalAlertPopupTest.java
@@ -107,7 +107,7 @@ public class AjaxModalAlertPopupTest extends AbstractAjaxSeleniumLowLevelTest {
 
 			this.button = appendChild(new DomButton())//
 				.setLabel("spawn alert")
-				.setClickCallback(new DomModalAlertPopup(MESSAGE)::show);
+				.setClickCallback(new DomModalAlertPopup(MESSAGE)::open);
 		}
 
 		public DomButton getButton() {

--- a/platform-ajax/src/test/java/com/softicar/platform/ajax/dialog/AjaxModalConfirmPopupTest.java
+++ b/platform-ajax/src/test/java/com/softicar/platform/ajax/dialog/AjaxModalConfirmPopupTest.java
@@ -202,7 +202,7 @@ public class AjaxModalConfirmPopupTest extends AbstractAjaxSeleniumLowLevelTest 
 			this.outputElement = new DomDiv();
 			this.button = new DomButton()//
 				.setLabel("spawn confirm")
-				.setClickCallback(new DomModalConfirmPopup(() -> outputElement.appendText(CONFIRMATION_TEXT), MESSAGE)::show);
+				.setClickCallback(new DomModalConfirmPopup(() -> outputElement.appendText(CONFIRMATION_TEXT), MESSAGE)::open);
 			appendChild(button);
 			appendChild(outputElement);
 		}

--- a/platform-ajax/src/test/java/com/softicar/platform/ajax/dialog/AjaxModalPromptPopupTest.java
+++ b/platform-ajax/src/test/java/com/softicar/platform/ajax/dialog/AjaxModalPromptPopupTest.java
@@ -303,7 +303,7 @@ public class AjaxModalPromptPopupTest extends AbstractAjaxSeleniumLowLevelTest {
 			this.outputElement = new DomDiv();
 			this.button = new DomButton()//
 				.setLabel("spawn prompt")
-				.setClickCallback(new DomModalPromptPopup(outputElement::appendText, MESSAGE, promptInputDefaultValue)::show);
+				.setClickCallback(new DomModalPromptPopup(outputElement::appendText, MESSAGE, promptInputDefaultValue)::open);
 			appendChild(button);
 			appendChild(outputElement);
 		}

--- a/platform-core-module/src/main/java/com/softicar/platform/core/module/user/password/UserPasswordGenerator.java
+++ b/platform-core-module/src/main/java/com/softicar/platform/core/module/user/password/UserPasswordGenerator.java
@@ -59,7 +59,7 @@ public class UserPasswordGenerator {
 				CoreI18n.THE_PASSWORD_FOR_USER_ARG1_IS_NOW_ARG2
 					.toDisplay(user.getLoginName(), password)
 					.concat("\n\n")
-					.concat(CoreI18n.IF_AN_EMAIL_SERVER_IS_CONFIGURED_THE_USER_WILL_RECEIVE_THIS_PASSWORD_VIA_EMAIL)).show();
+					.concat(CoreI18n.IF_AN_EMAIL_SERVER_IS_CONFIGURED_THE_USER_WILL_RECEIVE_THIS_PASSWORD_VIA_EMAIL)).open();
 			transaction.commit();
 		} catch (Exception exception) {
 			throw new SofticarUserException(exception, CoreI18n.COULD_NOT_RESET_USER_PASSWORD);

--- a/platform-dom/src/main/java/com/softicar/platform/dom/DomCssPseudoClasses.java
+++ b/platform-dom/src/main/java/com/softicar/platform/dom/DomCssPseudoClasses.java
@@ -10,6 +10,7 @@ public interface DomCssPseudoClasses {
 	ICssClass DISABLED = new CssClass("disabled");
 	ICssClass DRAGGABLE = new CssClass("draggable");
 	ICssClass ERROR = new CssClass("error");
+	ICssClass HIGHLIGHTED = new CssClass("highlighted");
 	ICssClass INFO = new CssClass("info");
 	ICssClass INVISIBLE = new CssClass("invisible");
 	ICssClass PRECOLORED = new CssClass("precolored");

--- a/platform-dom/src/main/java/com/softicar/platform/dom/DomI18n.java
+++ b/platform-dom/src/main/java/com/softicar/platform/dom/DomI18n.java
@@ -20,6 +20,8 @@ public interface DomI18n extends CommonCoreI18n {
 		.de("Zeitstempel anhängen");
 	I18n0 APPLY = new I18n0("Apply")//
 		.de("Übernehmen");
+	I18n0 ARE_YOU_SURE_TO_CLOSE_THIS_WINDOW_AND_ALL_SUB_WINDOWS_QUESTION = new I18n0("Are you sure to close this window and all sub windows?")//
+		.de("Sollen dieses Fenster und alle Unterfenster wirklich geschlossen werden?");
 	I18n0 ARE_YOU_SURE_TO_CLOSE_THIS_WINDOW_QUESTION = new I18n0("Are you sure to close this window?")//
 		.de("Soll dieses Fenster wirklich geschlossen werden?");
 	I18n0 CANCEL = new I18n0("Cancel")//

--- a/platform-dom/src/main/java/com/softicar/platform/dom/elements/dialog/DomModalAlertPopup.java
+++ b/platform-dom/src/main/java/com/softicar/platform/dom/elements/dialog/DomModalAlertPopup.java
@@ -32,7 +32,7 @@ public class DomModalAlertPopup extends DomModalDialogPopup {
 	}
 
 	@Override
-	public void show() {
+	public void open() {
 
 		super.open();
 		getDomEngine().focus(closeButton);

--- a/platform-dom/src/main/java/com/softicar/platform/dom/elements/dialog/DomModalConfirmPopup.java
+++ b/platform-dom/src/main/java/com/softicar/platform/dom/elements/dialog/DomModalConfirmPopup.java
@@ -7,6 +7,7 @@ import com.softicar.platform.dom.elements.DomElementsCssClasses;
 import com.softicar.platform.dom.elements.DomElementsImages;
 import com.softicar.platform.dom.elements.button.DomButton;
 import java.util.Objects;
+import java.util.Optional;
 
 /**
  * A custom modal dialog that replaces a native "confirm" dialog.
@@ -16,6 +17,9 @@ import java.util.Objects;
 public class DomModalConfirmPopup extends DomModalDialogPopup {
 
 	private final OkayButton okayButton;
+	private final INullaryVoidFunction confirmHandler;
+	private final INullaryVoidFunction cancelHandler;
+	private boolean confirmed;
 
 	/**
 	 * Constructs a new {@link DomModalConfirmPopup} that displays the given
@@ -29,30 +33,55 @@ public class DomModalConfirmPopup extends DomModalDialogPopup {
 	 */
 	public DomModalConfirmPopup(INullaryVoidFunction confirmHandler, IDisplayString message) {
 
+		this(confirmHandler, null, message);
+	}
+
+	/**
+	 * Constructs a new {@link DomModalConfirmPopup} that displays the given
+	 * message, and "OK" / "Cancel" buttons.
+	 *
+	 * @param confirmHandler
+	 *            the handler to be processed in case the user clicks "OK"
+	 *            (never <i>null</i>)
+	 * @param cancelHandler
+	 *            the handler to be processed in case the user clicks "Cancel"
+	 *            (may be <i>null</i>)
+	 * @param message
+	 *            the message to display (never <i>null</i>)
+	 */
+	public DomModalConfirmPopup(INullaryVoidFunction confirmHandler, INullaryVoidFunction cancelHandler, IDisplayString message) {
+
 		addCssClass(DomElementsCssClasses.DOM_MODAL_DIALOG_POPUP_WRAPPED);
 
-		Objects.requireNonNull(confirmHandler);
+		this.confirmHandler = Objects.requireNonNull(confirmHandler);
+		this.cancelHandler = cancelHandler;
 		Objects.requireNonNull(message);
 
+		this.confirmed = false;
+		this.configuration.setCallbackBeforeClose(this::executeCancelCallback);
+
 		getContent().appendText(message);
-		appendActionNode(okayButton = new OkayButton(confirmHandler));
+		appendActionNode(okayButton = new OkayButton());
 		appendCancelButton().addMarker(DomModalConfirmMarker.CANCEL_BUTTON);
 	}
 
 	@Override
-	public void show() {
+	public void open() {
 
 		super.open();
 		getDomEngine().focus(okayButton);
 	}
 
+	private void executeCancelCallback() {
+
+		if (!confirmed) {
+			Optional.ofNullable(cancelHandler).ifPresent(INullaryVoidFunction::apply);
+		}
+	}
+
 	private class OkayButton extends DomButton {
 
-		private final INullaryVoidFunction confirmHandler;
-
-		public OkayButton(INullaryVoidFunction confirmHandler) {
-
-			this.confirmHandler = confirmHandler;
+		public OkayButton() {
 
 			setLabel(DomI18n.OK);
 			setIcon(DomElementsImages.DIALOG_OKAY.getResource());
@@ -62,6 +91,7 @@ public class DomModalConfirmPopup extends DomModalDialogPopup {
 
 		private void handleClick() {
 
+			confirmed = true;
 			close();
 			confirmHandler.apply();
 		}

--- a/platform-dom/src/main/java/com/softicar/platform/dom/elements/dialog/DomModalPromptPopup.java
+++ b/platform-dom/src/main/java/com/softicar/platform/dom/elements/dialog/DomModalPromptPopup.java
@@ -49,7 +49,7 @@ public class DomModalPromptPopup extends DomModalDialogPopup {
 	}
 
 	@Override
-	public void show() {
+	public void open() {
 
 		super.open();
 		getDomEngine().focus(inputElement);

--- a/platform-dom/src/main/java/com/softicar/platform/dom/elements/popup/DomPopup.java
+++ b/platform-dom/src/main/java/com/softicar/platform/dom/elements/popup/DomPopup.java
@@ -125,7 +125,7 @@ public class DomPopup extends DomDiv {
 	 * @deprecated use {@link #open()} instead
 	 */
 	@Deprecated
-	public void show() {
+	public final void show() {
 
 		open();
 	}
@@ -142,7 +142,7 @@ public class DomPopup extends DomDiv {
 	 * @deprecated use {@link #close()} instead
 	 */
 	@Deprecated
-	public void hide() {
+	public final void hide() {
 
 		close();
 	}

--- a/platform-dom/src/main/java/com/softicar/platform/dom/elements/popup/compositor/DomModalPopupBackdropStack.java
+++ b/platform-dom/src/main/java/com/softicar/platform/dom/elements/popup/compositor/DomModalPopupBackdropStack.java
@@ -1,0 +1,75 @@
+package com.softicar.platform.dom.elements.popup.compositor;
+
+import com.softicar.platform.dom.DomCssPseudoClasses;
+import com.softicar.platform.dom.elements.popup.modal.DomModalPopupBackdrop;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+/**
+ * Facilitates handling a stack of {@link DomModalPopupBackdrop} nodes.
+ *
+ * @author Alexander Schmidt
+ */
+class DomModalPopupBackdropStack {
+
+	private List<DomModalPopupBackdrop> stack;
+
+	/**
+	 * Constructs a new {@link DomModalPopupBackdropStack}.
+	 */
+	public DomModalPopupBackdropStack() {
+
+		this.stack = new ArrayList<>();
+	}
+
+	/**
+	 * Adds the given {@link DomModalPopupBackdrop} to this
+	 * {@link DomModalPopupBackdropStack}.
+	 *
+	 * @param backdrop
+	 *            the {@link DomModalPopupBackdrop} to add (never <i>null</i>)
+	 */
+	public void add(DomModalPopupBackdrop backdrop) {
+
+		Objects.requireNonNull(backdrop);
+		stack.add(backdrop);
+	}
+
+	/**
+	 * Refreshes the visibility of all {@link DomModalPopupBackdrop} nodes in
+	 * this {@link DomModalPopupBackdropStack}.
+	 * <p>
+	 * Removes non-appended {@link DomModalPopupBackdrop} nodes from the
+	 * internal stack, prior to recalculating visibility.
+	 */
+	public void refreshVisibility() {
+
+		cleanup();
+		var reverseStack = createReverseStack();
+		reverseStack.forEach(it -> it.removeCssClass(DomCssPseudoClasses.VISIBLE));
+		reverseStack//
+			.stream()
+			.filter(DomModalPopupBackdrop::isAppended)
+			.filter(DomModalPopupBackdrop::isVisible)
+			.findFirst()
+			.ifPresent(it -> it.addCssClass(DomCssPseudoClasses.VISIBLE));
+	}
+
+	private void cleanup() {
+
+		this.stack = stack//
+			.stream()
+			.filter(DomModalPopupBackdrop::isAppended)
+			.collect(Collectors.toList());
+	}
+
+	private List<DomModalPopupBackdrop> createReverseStack() {
+
+		var reverseStack = new ArrayList<>(stack);
+		Collections.reverse(reverseStack);
+		return reverseStack;
+	}
+}

--- a/platform-dom/src/main/java/com/softicar/platform/dom/elements/popup/compositor/DomParentNodeFetcher.java
+++ b/platform-dom/src/main/java/com/softicar/platform/dom/elements/popup/compositor/DomParentNodeFetcher.java
@@ -1,0 +1,53 @@
+package com.softicar.platform.dom.elements.popup.compositor;
+
+import com.softicar.platform.dom.node.IDomNode;
+import com.softicar.platform.dom.parent.IDomParentElement;
+import java.util.Objects;
+import java.util.Optional;
+
+/**
+ * Facilitates finding parents of a specific type for a given {@link IDomNode}.
+ *
+ * @author Alexander Schmidt
+ */
+class DomParentNodeFetcher<T extends IDomNode> {
+
+	private final Class<T> parentNodeClass;
+
+	/**
+	 * Constructs a new {@link DomParentNodeFetcher}.
+	 *
+	 * @param parentNodeClass
+	 *            the expected parent {@link IDomNode} class (never <i>null</i>)
+	 */
+	public DomParentNodeFetcher(Class<T> parentNodeClass) {
+
+		this.parentNodeClass = Objects.requireNonNull(parentNodeClass);
+	}
+
+	/**
+	 * Determines the closest transitive parent of the specified class for the
+	 * given {@link IDomNode}.
+	 * <p>
+	 * Returns {@link Optional#empty()} if the given {@link IDomNode} has no
+	 * such transitive parent.
+	 *
+	 * @param node
+	 *            the {@link IDomNode} to search a parent for (never
+	 *            <i>null</i>)
+	 * @return the closest transitive parent of the specified class
+	 */
+	public Optional<T> getClosestParent(IDomNode node) {
+
+		Objects.requireNonNull(node);
+		Objects.requireNonNull(parentNodeClass);
+
+		IDomNode child = node;
+		IDomParentElement parent = null;
+		do {
+			parent = child.getParent();
+			child = parent;
+		} while (parent != null && !parentNodeClass.isInstance(parent));
+		return Optional.ofNullable(parentNodeClass.cast(parent));
+	}
+}

--- a/platform-dom/src/main/java/com/softicar/platform/dom/elements/popup/compositor/DomPopupFrameHighlighting.java
+++ b/platform-dom/src/main/java/com/softicar/platform/dom/elements/popup/compositor/DomPopupFrameHighlighting.java
@@ -1,0 +1,37 @@
+package com.softicar.platform.dom.elements.popup.compositor;
+
+import com.softicar.platform.dom.DomCssPseudoClasses;
+import com.softicar.platform.dom.elements.popup.DomPopup;
+import com.softicar.platform.dom.elements.popup.DomPopupFrame;
+import java.util.List;
+import java.util.Optional;
+
+class DomPopupFrameHighlighting {
+
+	public void add(DomPopup popup, List<DomPopup> morePopups) {
+
+		highlightFrame(popup);
+		morePopups.forEach(this::highlightFrame);
+	}
+
+	public void remove(DomPopup popup, List<DomPopup> morePopups) {
+
+		unhighlightFrame(popup);
+		morePopups.forEach(child -> unhighlightFrame(child));
+	}
+
+	private void highlightFrame(DomPopup popup) {
+
+		getFrame(popup).ifPresent(frame -> frame.addCssClass(DomCssPseudoClasses.HIGHLIGHTED));
+	}
+
+	private void unhighlightFrame(DomPopup popup) {
+
+		getFrame(popup).ifPresent(frame -> frame.removeCssClass(DomCssPseudoClasses.HIGHLIGHTED));
+	}
+
+	private Optional<DomPopupFrame> getFrame(DomPopup popup) {
+
+		return new DomParentNodeFetcher<>(DomPopupFrame.class).getClosestParent(popup);
+	}
+}

--- a/platform-dom/src/main/java/com/softicar/platform/dom/elements/popup/compositor/DomPopupHierarchyGraph.java
+++ b/platform-dom/src/main/java/com/softicar/platform/dom/elements/popup/compositor/DomPopupHierarchyGraph.java
@@ -1,0 +1,85 @@
+package com.softicar.platform.dom.elements.popup.compositor;
+
+import com.softicar.platform.dom.elements.popup.DomPopup;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Objects;
+
+/**
+ * A graph to track parent-child nesting relations between {@link DomPopup}
+ * nodes.
+ *
+ * @author Alexander Schmidt
+ */
+class DomPopupHierarchyGraph {
+
+	private Map<DomPopup, List<DomPopup>> graph;
+
+	/**
+	 * Constructs a new {@link DomPopupHierarchyGraph}.
+	 */
+	public DomPopupHierarchyGraph() {
+
+		this.graph = new HashMap<>();
+	}
+
+	/**
+	 * Adds the given parent-child relation to this graph.
+	 *
+	 * @param parent
+	 *            the parent {@link DomPopup} (never <i>null</i>)
+	 * @param child
+	 *            the child {@link DomPopup} (never <i>null</i>)
+	 */
+	public void add(DomPopup parent, DomPopup child) {
+
+		Objects.requireNonNull(parent);
+		Objects.requireNonNull(child);
+		graph.computeIfAbsent(parent, dummy -> new ArrayList<>()).add(child);
+	}
+
+	/**
+	 * Determines the transitive child {@link DomPopup} nodes of the given
+	 * parent {@link DomPopup}.
+	 * <p>
+	 * The returned {@link List} will be ordered according to descending depth
+	 * in the hierarchy graph. That is, deeply-nested children will occur before
+	 * less deeply-nested children.
+	 *
+	 * @param parent
+	 *            the parent {@link DomPopup} (never <i>null</i>)
+	 * @return all child {@link DomPopup} nodes (never <i>null</i>)
+	 */
+	public List<DomPopup> getAllChildPopups(DomPopup parent) {
+
+		var childPopups = new ArrayList<DomPopup>();
+		List<DomPopup> children = graph.get(parent);
+		if (children != null && !children.isEmpty()) {
+			for (DomPopup child: children) {
+				childPopups.addAll(getAllChildPopups(child));
+			}
+			childPopups.addAll(children);
+		}
+		return childPopups;
+	}
+
+	/**
+	 * Removes all {@link DomPopup} nodes that are not appended from this graph.
+	 */
+	public void cleanup() {
+
+		Map<DomPopup, List<DomPopup>> map = new HashMap<>();
+		for (Entry<DomPopup, List<DomPopup>> entry: graph.entrySet()) {
+			DomPopup parent = entry.getKey();
+			for (DomPopup child: entry.getValue()) {
+				if (parent.isAppended() && child.isAppended()) {
+					map.computeIfAbsent(parent, dummy -> new ArrayList<>()).add(child);
+				}
+			}
+		}
+		this.graph = map;
+	}
+}

--- a/platform-dom/src/main/java/com/softicar/platform/dom/elements/testing/node/tester/AbstractDomNodeTester.java
+++ b/platform-dom/src/main/java/com/softicar/platform/dom/elements/testing/node/tester/AbstractDomNodeTester.java
@@ -249,20 +249,20 @@ public class AbstractDomNodeTester<N extends IDomNode> implements IDomNodeTester
 		return this;
 	}
 
-	public AbstractDomNodeTester<N> assertDoesNotContainText(IDisplayString expectedText) {
+	public AbstractDomNodeTester<N> assertDoesNotContainText(IDisplayString unexpectedText) {
 
-		return assertDoesNotContainText(expectedText.toString());
+		return assertDoesNotContainText(unexpectedText.toString());
 	}
 
-	public AbstractDomNodeTester<N> assertDoesNotContainText(String expectedText) {
+	public AbstractDomNodeTester<N> assertDoesNotContainText(String unexpectedText) {
 
-		if (containsText(expectedText)) {
+		if (containsText(unexpectedText)) {
 			Assert
 				.fail(
 					String
 						.format(//
 							"Unexpectedly found the text '%s' in the following: '%s'",
-							expectedText,
+							unexpectedText,
 							getAllTextInDocument("|")));
 		}
 		return this;

--- a/platform-dom/src/main/java/com/softicar/platform/dom/node/IDomNode.java
+++ b/platform-dom/src/main/java/com/softicar/platform/dom/node/IDomNode.java
@@ -208,8 +208,6 @@ public interface IDomNode {
 
 	// -------------------------------- alert, confirm and prompt -------------------------------- //
 
-	// -------------------------------- modal dialogs -------------------------------- //
-
 	/**
 	 * Displays a custom modal alert dialog, for the given message.
 	 *
@@ -218,7 +216,7 @@ public interface IDomNode {
 	 */
 	default void executeAlert(IDisplayString message) {
 
-		new DomModalAlertPopup(message).show();
+		new DomModalAlertPopup(message).open();
 	}
 
 	/**
@@ -233,7 +231,25 @@ public interface IDomNode {
 	 */
 	default void executeConfirm(INullaryVoidFunction confirmHandler, IDisplayString message) {
 
-		new DomModalConfirmPopup(confirmHandler, message).show();
+		executeConfirm(confirmHandler, null, message);
+	}
+
+	/**
+	 * Displays a custom modal confirm dialog, for the given handlers and
+	 * message.
+	 *
+	 * @param confirmHandler
+	 *            the handler to be processed in case the user clicks "OK"
+	 *            (never <i>null</i>)
+	 * @param cancelHandler
+	 *            the handler to be processed in case the user clicks "Cancel"
+	 *            (may be <i>null</i>)
+	 * @param message
+	 *            the message to display (never <i>null</i>)
+	 */
+	default void executeConfirm(INullaryVoidFunction confirmHandler, INullaryVoidFunction cancelHandler, IDisplayString message) {
+
+		new DomModalConfirmPopup(confirmHandler, cancelHandler, message).open();
 	}
 
 	/**
@@ -249,6 +265,6 @@ public interface IDomNode {
 	 */
 	default void executePrompt(Consumer<String> promptHandler, IDisplayString message, String defaultValue) {
 
-		new DomModalPromptPopup(promptHandler, message, defaultValue).show();
+		new DomModalPromptPopup(promptHandler, message, defaultValue).open();
 	}
 }

--- a/platform-dom/src/main/resources/com/softicar/platform/dom/elements/dom-popup-style.css
+++ b/platform-dom/src/main/resources/com/softicar/platform/dom/elements/dom-popup-style.css
@@ -1,4 +1,8 @@
 
+:root {
+	--DOM_POPUP_FRAME_HIGHLIGHTED_COLOR: #f00;
+}
+
 .DomPopup {
 	border-radius: 0 0 var(--BORDER_RADIUS) var(--BORDER_RADIUS);
 	display: flex;
@@ -23,6 +27,10 @@
 	box-shadow: var(--BOX_SHADOW_OVERLAY);
 	outline-style: none;
 	width: max-content;
+}
+
+.DomPopupFrame.highlighted {
+	border: 1px solid var(--DOM_POPUP_FRAME_HIGHLIGHTED_COLOR);
 }
 
 .DomPopupFrameHeader {

--- a/platform-dom/src/test/java/com/softicar/platform/dom/elements/dialog/DomModalAlertPopupTest.java
+++ b/platform-dom/src/test/java/com/softicar/platform/dom/elements/dialog/DomModalAlertPopupTest.java
@@ -65,7 +65,7 @@ public class DomModalAlertPopupTest extends AbstractDomModalDialogPopupTest {
 
 			appendChild(new DomButton())//
 				.setLabel("spawn alert")
-				.setClickCallback(new DomModalAlertPopup(MESSAGE)::show)
+				.setClickCallback(new DomModalAlertPopup(MESSAGE)::open)
 				.addMarker(SHOW_BUTTON);
 		}
 	}

--- a/platform-dom/src/test/java/com/softicar/platform/dom/elements/dialog/DomModalConfirmPopupTest.java
+++ b/platform-dom/src/test/java/com/softicar/platform/dom/elements/dialog/DomModalConfirmPopupTest.java
@@ -10,6 +10,7 @@ import org.junit.Test;
 
 public class DomModalConfirmPopupTest extends AbstractDomModalDialogPopupTest {
 
+	private static final String CANCEL_TEXT = "cancelled";
 	private static final String CONFIRMATION_TEXT = "confirmed";
 
 	// ---------------- basics ---------------- //
@@ -17,95 +18,183 @@ public class DomModalConfirmPopupTest extends AbstractDomModalDialogPopupTest {
 	@Test
 	public void testShowMessage() {
 
-		var confirm = showConfirm();
+		var confirm = showConfirm(false);
 		confirm.getContent().assertContainsText(MESSAGE);
 	}
 
 	// ---------------- interaction with "okay" button ---------------- //
 
 	@Test
-	public void testClickOnOkayButton() {
+	public void testClickOnOkayButtonWithoutCancelCallback() {
 
-		var confirm = showConfirm();
+		var confirm = showConfirm(false);
 		confirm.getOkayButton().click();
 		assertNoDisplayedModalDialog();
 		assertConfirmed();
+		assertNotCancelled();
 	}
 
 	@Test
-	public void testEnterOnOkayButton() {
+	public void testClickOnOkayButtonWithCancelCallback() {
 
-		var confirm = showConfirm();
+		var confirm = showConfirm(true);
+		confirm.getOkayButton().click();
+		assertNoDisplayedModalDialog();
+		assertConfirmed();
+		assertNotCancelled();
+	}
+
+	@Test
+	public void testEnterOnOkayButtonWithoutCancelCallback() {
+
+		var confirm = showConfirm(false);
 		confirm.getOkayButton().sendEvent(DomEventType.ENTER);
 		assertNoDisplayedModalDialog();
 		assertConfirmed();
+		assertNotCancelled();
 	}
 
 	@Test
-	public void testSpaceOnOkayButton() {
+	public void testEnterOnOkayButtonWithCancelCallback() {
 
-		var confirm = showConfirm();
+		var confirm = showConfirm(true);
+		confirm.getOkayButton().sendEvent(DomEventType.ENTER);
+		assertNoDisplayedModalDialog();
+		assertConfirmed();
+		assertNotCancelled();
+	}
+
+	@Test
+	public void testSpaceOnOkayButtoWithoutCancelCallbackn() {
+
+		var confirm = showConfirm(false);
 		confirm.getOkayButton().sendEvent(DomEventType.SPACE);
 		assertNoDisplayedModalDialog();
 		assertConfirmed();
+		assertNotCancelled();
+	}
+
+	@Test
+	public void testSpaceOnOkayButtoWithCancelCallbackn() {
+
+		var confirm = showConfirm(true);
+		confirm.getOkayButton().sendEvent(DomEventType.SPACE);
+		assertNoDisplayedModalDialog();
+		assertConfirmed();
+		assertNotCancelled();
 	}
 
 	// ---------------- interaction with "cancel" button ---------------- //
 
 	@Test
-	public void testClickOnCancelButton() {
+	public void testClickOnCancelButtonWithoutCancelCallback() {
 
-		var confirm = showConfirm();
+		var confirm = showConfirm(false);
 		confirm.getCancelButton().click();
 		assertNoDisplayedModalDialog();
 		assertNotConfirmed();
+		assertNotCancelled();
 	}
 
 	@Test
-	public void testEnterOnCancelButton() {
+	public void testClickOnCancelButtonWithCancelCallback() {
 
-		var confirm = showConfirm();
+		var confirm = showConfirm(true);
+		confirm.getCancelButton().click();
+		assertNoDisplayedModalDialog();
+		assertNotConfirmed();
+		assertCancelled();
+	}
+
+	@Test
+	public void testEnterOnCancelButtonWithoutCancelCallback() {
+
+		var confirm = showConfirm(false);
 		confirm.getCancelButton().sendEvent(DomEventType.ENTER);
 		assertNoDisplayedModalDialog();
 		assertNotConfirmed();
+		assertNotCancelled();
 	}
 
 	@Test
-	public void testSpaceOnCancelButton() {
+	public void testEnterOnCancelButtonWithCancelCallback() {
 
-		var confirm = showConfirm();
+		var confirm = showConfirm(true);
+		confirm.getCancelButton().sendEvent(DomEventType.ENTER);
+		assertNoDisplayedModalDialog();
+		assertNotConfirmed();
+		assertCancelled();
+	}
+
+	@Test
+	public void testSpaceOnCancelButtonWithoutCancelCallback() {
+
+		var confirm = showConfirm(false);
 		confirm.getCancelButton().sendEvent(DomEventType.SPACE);
 		assertNoDisplayedModalDialog();
 		assertNotConfirmed();
+		assertNotCancelled();
+	}
+
+	@Test
+	public void testSpaceOnCancelButtonWithCancelCallback() {
+
+		var confirm = showConfirm(true);
+		confirm.getCancelButton().sendEvent(DomEventType.SPACE);
+		assertNoDisplayedModalDialog();
+		assertNotConfirmed();
+		assertCancelled();
 	}
 
 	// ---------------- interaction with frame ---------------- //
 
 	@Test
-	public void testEscapeOnFrame() {
+	public void testEscapeOnFrameWithoutCancelCallback() {
 
-		var confirm = showConfirm();
+		var confirm = showConfirm(false);
 		confirm.getFrame().sendEvent(DomEventType.ESCAPE);
 		assertNoDisplayedModalDialog();
 		assertNotConfirmed();
+		assertNotCancelled();
+	}
+
+	@Test
+	public void testEscapeOnFrameWithCancelCallback() {
+
+		var confirm = showConfirm(true);
+		confirm.getFrame().sendEvent(DomEventType.ESCAPE);
+		assertNoDisplayedModalDialog();
+		assertNotConfirmed();
+		assertCancelled();
 	}
 
 	// ---------------- interaction with backdrop ---------------- //
 
 	@Test
-	public void testClickOnBackdrop() {
+	public void testClickOnBackdropWithoutCancelCallback() {
 
-		var confirm = showConfirm();
+		var confirm = showConfirm(false);
 		confirm.getBackdrop().click();
 		assertNoDisplayedModalDialog();
 		assertNotConfirmed();
+		assertNotCancelled();
+	}
+
+	@Test
+	public void testClickOnBackdropWithCancelCallback() {
+
+		var confirm = showConfirm(true);
+		confirm.getBackdrop().click();
+		assertNoDisplayedModalDialog();
+		assertNotConfirmed();
+		assertCancelled();
 	}
 
 	// ---------------- private ---------------- //
 
-	private IDomModalConfirmNodes<DomNodeTester> showConfirm() {
+	private IDomModalConfirmNodes<DomNodeTester> showConfirm(boolean withCancelCallback) {
 
-		setNodeSupplier(TestDiv::new);
+		setNodeSupplier(() -> new TestDiv(withCancelCallback));
 		findButton(SHOW_BUTTON).click();
 		return findDisplayedModalConfirmOrFail();
 	}
@@ -122,21 +211,47 @@ public class DomModalConfirmPopupTest extends AbstractDomModalDialogPopupTest {
 
 	private void assertNotConfirmed() {
 
-		findNode(OUTPUT_ELEMENT).assertContainsNoText();
+		findNode(OUTPUT_ELEMENT).assertDoesNotContainText(CONFIRMATION_TEXT);
+	}
+
+	private void assertCancelled() {
+
+		findNode(OUTPUT_ELEMENT).assertContainsText(CANCEL_TEXT);
+	}
+
+	private void assertNotCancelled() {
+
+		findNode(OUTPUT_ELEMENT).assertDoesNotContainText(CANCEL_TEXT);
 	}
 
 	private static class TestDiv extends DomDiv {
 
-		public TestDiv() {
+		private final DomDiv outputElement;
 
-			var outputElement = appendChild(new DomDiv());
+		public TestDiv(boolean withCancelCallback) {
+
+			outputElement = appendChild(new DomDiv());
 			outputElement.addMarker(OUTPUT_ELEMENT);
 
+			var confirmPopup = new DomModalConfirmPopup(//
+				this::handleConfirm,
+				withCancelCallback? this::handleCancel : null,
+				MESSAGE);
 			appendChild(
 				new DomButton()//
 					.setLabel("spawn confirm")
-					.setClickCallback(new DomModalConfirmPopup(() -> outputElement.appendText(CONFIRMATION_TEXT), MESSAGE)::show)
+					.setClickCallback(confirmPopup::open)
 					.addMarker(SHOW_BUTTON));
+		}
+
+		private void handleConfirm() {
+
+			outputElement.appendText(CONFIRMATION_TEXT);
+		}
+
+		private void handleCancel() {
+
+			outputElement.appendText(CANCEL_TEXT);
 		}
 	}
 }

--- a/platform-dom/src/test/java/com/softicar/platform/dom/elements/dialog/DomModalPromptPopupTest.java
+++ b/platform-dom/src/test/java/com/softicar/platform/dom/elements/dialog/DomModalPromptPopupTest.java
@@ -187,7 +187,7 @@ public class DomModalPromptPopupTest extends AbstractDomModalDialogPopupTest {
 			appendChild(
 				new DomButton()//
 					.setLabel("spawn prompt")
-					.setClickCallback(new DomModalPromptPopup(outputElement::appendText, MESSAGE, promptInputDefaultValue)::show)
+					.setClickCallback(new DomModalPromptPopup(outputElement::appendText, MESSAGE, promptInputDefaultValue)::open)
 					.addMarker(SHOW_BUTTON));
 		}
 	}

--- a/platform-emf/src/main/java/com/softicar/platform/emf/data/table/filter/EmfDataTableFilterButton.java
+++ b/platform-emf/src/main/java/com/softicar/platform/emf/data/table/filter/EmfDataTableFilterButton.java
@@ -16,11 +16,11 @@ public class EmfDataTableFilterButton<R> extends DomButton {
 		setLabel(column.getTitle());
 		setTitle(EmfDataTableI18n.CLICK_TO_FILTER_IN_THIS_COLUMN);
 		addMarker(EmfDataTableDivMarker.FILTER_POPUP_BUTTON);
-		setClickCallback(this::showFilterPopup);
+		setClickCallback(this::openFilterPopup);
 	}
 
-	private void showFilterPopup() {
+	private void openFilterPopup() {
 
-		column.getFilterPopup().show();
+		column.getFilterPopup().open();
 	}
 }

--- a/platform-emf/src/main/java/com/softicar/platform/emf/data/table/filter/EmfDataTableFilterPopup.java
+++ b/platform-emf/src/main/java/com/softicar/platform/emf/data/table/filter/EmfDataTableFilterPopup.java
@@ -80,7 +80,7 @@ public class EmfDataTableFilterPopup<R> extends DomDismissablePopup implements I
 	}
 
 	@Override
-	public void show() {
+	public void open() {
 
 		filter.reset();
 		filterListDiv.updateAndRebuildFilterElements();

--- a/platform-workflow-module/src/main/java/com/softicar/platform/workflow/module/demo/WorkflowDemoObjectStartWorkflowAction.java
+++ b/platform-workflow-module/src/main/java/com/softicar/platform/workflow/module/demo/WorkflowDemoObjectStartWorkflowAction.java
@@ -67,7 +67,7 @@ class WorkflowDemoObjectStartWorkflowAction implements IEmfManagementAction<AGWo
 
 		if (workflow.getCurrentVersion() != null) {
 			workflow.startWorkflow(object);
-			new DomModalAlertPopup(WorkflowI18n.WORKFLOW_STARTED).show();
+			new DomModalAlertPopup(WorkflowI18n.WORKFLOW_STARTED).open();
 		} else {
 			throw new SofticarUserException(WorkflowI18n.NO_ACTIVE_WORKFLOW_VERSION_FOUND);
 		}


### PR DESCRIPTION
- Establish a hierarchy of `DomPopup` nodes, and let `DomDefaultPopupCompositor` handle it gracefully.
  - If a popup was spawned from a node in another popup, a child-to-parent relation exists between those popups.
  - When trying to close a popup that has at least one child popup, the compositor will ask for confirmation, and highlight the affected popups.
  - If the user confirms, the popup and its transitive child popups are closed. If the user cancels, only the highlighting is removed.
  - Due to this mechanism, orphaned popups are no longer a thing.
- `DomModalConfirmPopup` now allows for the specification of a cancel handler.
  - Added new tests in `DomModalConfirmPopupTest`.
- Extracted various helper classes from `DomDefaultPopupCompositor`.
- Fixed PLAT-823 along the way.
- Semi-related change: `DomPopup`: `show()` and `hide()` are now final; replaced all references to those with their non-deprecated successors

Test Plan:
- Start a local test servlet.

- Regression Tests:
  - Invoke all kinds of popups (dialog, draggable, draggable-modal, popover) and ensure that those are generally visualized as expected.
  - Spawn a dialog above a modal popup:
    - Open the filter popup of an ID column, and enter "qwe".
    - Ensure that the backdrop of the dialog does not aggrevate the darkness of the background.
  - Spawn a popover from a modal popup:
    - Open the filter popup of a Day(Time) column. From it, open the day-picker popover.
    - Ensure that the background color (i.e. color of the filter popup backdrop) does change when opening/closing the popover.
  - Spawn an auto-complete dropdown from a modal popup:
    - Open the filter popup of an FK column.
    - Ensure that the background color (i.e. color of the filter popup backdrop) does change when opening/closing the the AC dropdown.

- Add this code to an arbitrary page:
```
appendChild(new Button());

// ...

private class Button extends DomButton {

	public Button() {

		setLabel("spawn popup");
		setClickCallback(() -> new Popup().open());
	}
}

private class Popup extends DomPopup {

	public Popup() {

		setCaption(IDisplayString.create(getNodeIdString()));
		appendActionNode(new Button());
		appendCloseButton();
	}
}
```
- Spawn popups from other popups.
- Close popups at various points in the hierarchy.
- Note that a confirm dialog about closing child popup appears, if and only if a given popup has child popups.
- Note that child popups are highlighted and closed as expected when the user confirms. Note that the highlighting is removed upon canceling.
