### PR TITLE
PLAT-857 Correctly Style Footer Rows in DomDataTable

### DIFF
--- a/platform-dom/src/main/resources/com/softicar/platform/dom/elements/dom-data-table-style.css
+++ b/platform-dom/src/main/resources/com/softicar/platform/dom/elements/dom-data-table-style.css
@@ -24,7 +24,8 @@
 	border-right: 1px solid var(--INPUT_BORDER_COLOR);
 }
 
-.DomDataTable tr > td {
+.DomDataTable tr > td,
+.DomDataTable > tfoot > tr > th {
 	padding: 0.5em 1em;
 }
 

--- a/platform-emf/src/main/java/com/softicar/platform/emf/data/table/EmfDataTableDivBuilder.java
+++ b/platform-emf/src/main/java/com/softicar/platform/emf/data/table/EmfDataTableDivBuilder.java
@@ -401,7 +401,7 @@ public class EmfDataTableDivBuilder<R> {
 	public EmfDataTableExtraRowDefinition<R> addSecondaryHeaderRow() {
 
 		IEmfDataTableExtraRowColumnGroupList<R> columnGroupList = config.getSecondaryHeaderRowAccumulator().addNewColumnGroupList();
-		return new EmfDataTableExtraRowDefinition<>(this, columnGroupList).setTextAlign(CssTextAlign.CENTER);
+		return new EmfDataTableExtraRowDefinition<>(this, columnGroupList);
 	}
 
 	/**
@@ -446,7 +446,7 @@ public class EmfDataTableDivBuilder<R> {
 	public EmfDataTableExtraRowDefinition<R> addFooterRow() {
 
 		IEmfDataTableExtraRowColumnGroupList<R> columnGroupList = config.getFooterRowAccumulator().addNewColumnGroupList();
-		return new EmfDataTableExtraRowDefinition<>(this, columnGroupList).setTextAlign(CssTextAlign.RIGHT);
+		return new EmfDataTableExtraRowDefinition<>(this, columnGroupList);
 	}
 
 	/**

--- a/platform-emf/src/main/java/com/softicar/platform/emf/data/table/header/secondary/EmfDataTableExtraRowDefinition.java
+++ b/platform-emf/src/main/java/com/softicar/platform/emf/data/table/header/secondary/EmfDataTableExtraRowDefinition.java
@@ -8,20 +8,16 @@ import com.softicar.platform.emf.data.table.EmfDataTableDivBuilder;
 import com.softicar.platform.emf.data.table.IEmfDataTableRowProvider;
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.Objects;
-import java.util.Optional;
 
 public class EmfDataTableExtraRowDefinition<R> {
 
 	private final EmfDataTableDivBuilder<R> divBuilder;
 	private final IEmfDataTableExtraRowColumnGroupList<R> columnGroupList;
-	private Optional<CssTextAlign> textAlign;
 
 	public EmfDataTableExtraRowDefinition(EmfDataTableDivBuilder<R> divBuilder, IEmfDataTableExtraRowColumnGroupList<R> columnGroupList) {
 
 		this.divBuilder = divBuilder;
 		this.columnGroupList = columnGroupList;
-		this.textAlign = Optional.empty();
 	}
 
 	public ColumnSetter addEmptyCell() {
@@ -34,15 +30,14 @@ public class EmfDataTableExtraRowDefinition<R> {
 		return addCell(new DisplayStringCellBuilder(label));
 	}
 
+	public ColumnSetter addNumericCell(Number number) {
+
+		return addCell(new NumericCellBuilder(number));
+	}
+
 	public ColumnSetter addCell(IEmfDataTableExtraRowCellBuilder<R> cellBuilder) {
 
 		return new ColumnSetter(cellBuilder);
-	}
-
-	public EmfDataTableExtraRowDefinition<R> setTextAlign(CssTextAlign cssTextAlign) {
-
-		this.textAlign = Optional.of(cssTextAlign);
-		return this;
 	}
 
 	public EmfDataTableDivBuilder<R> endRow() {
@@ -56,7 +51,7 @@ public class EmfDataTableExtraRowDefinition<R> {
 
 		private ColumnSetter(IEmfDataTableExtraRowCellBuilder<R> cellBuilder) {
 
-			this.cellBuilder = new StyledCellBuilder(cellBuilder);
+			this.cellBuilder = cellBuilder;
 		}
 
 		public EmfDataTableExtraRowDefinition<R> setColumns(IDataTableColumn<?, ?>...columns) {
@@ -89,20 +84,22 @@ public class EmfDataTableExtraRowDefinition<R> {
 		}
 	}
 
-	private class StyledCellBuilder implements IEmfDataTableExtraRowCellBuilder<R> {
+	private class NumericCellBuilder implements IEmfDataTableExtraRowCellBuilder<R> {
 
-		private final IEmfDataTableExtraRowCellBuilder<R> other;
+		private final Number number;
 
-		public StyledCellBuilder(IEmfDataTableExtraRowCellBuilder<R> other) {
+		public NumericCellBuilder(Number number) {
 
-			this.other = Objects.requireNonNull(other);
+			this.number = number;
 		}
 
 		@Override
 		public void buildCell(IDomParentElement cell, IEmfDataTableRowProvider<R> rowProvider) {
 
-			textAlign.ifPresent(cell::setStyle);
-			other.buildCell(cell, rowProvider);
+			if (number != null) {
+				cell.setStyle(CssTextAlign.RIGHT);
+				cell.appendChild(number);
+			}
 		}
 	}
 }


### PR DESCRIPTION
  - Removed hardstyled text-alignment
  - Alignment is now default, which is center
  - Added convenience method for NumericCells in footer, which has right-alignment
  - Example:  
![image](https://user-images.githubusercontent.com/90852097/168595423-4627ca07-8b6c-45dd-af97-59a05e5f6f46.png)
