### PR TITLE
PLAT-872 DomModalDialogPopup: Remove an unnecessary CSS class

### DIFF
--- a/platform-dom/src/main/java/com/softicar/platform/dom/elements/DomElementsCssClasses.java
+++ b/platform-dom/src/main/java/com/softicar/platform/dom/elements/DomElementsCssClasses.java
@@ -38,7 +38,6 @@ public interface DomElementsCssClasses {
 
 	ICssClass DOM_MODAL_DIALOG_POPUP = new CssClass("DomModalDialogPopup", DomElementsCssFiles.DOM_MODAL_POPUP_STYLE);
 	ICssClass DOM_MODAL_DIALOG_POPUP_CONTENT = new CssClass("DomModalDialogPopupContent", DomElementsCssFiles.DOM_MODAL_POPUP_STYLE);
-	ICssClass DOM_MODAL_DIALOG_POPUP_WRAPPED = new CssClass("DomModalDialogPopupWrapped", DomElementsCssFiles.DOM_MODAL_POPUP_STYLE);
 
 	ICssClass DOM_MODAL_POPUP_BACKDROP = new CssClass("DomModalPopupBackdrop", DomElementsCssFiles.DOM_MODAL_POPUP_STYLE);
 

--- a/platform-dom/src/main/java/com/softicar/platform/dom/elements/dialog/DomModalDialogPopup.java
+++ b/platform-dom/src/main/java/com/softicar/platform/dom/elements/dialog/DomModalDialogPopup.java
@@ -42,8 +42,6 @@ public class DomModalDialogPopup extends DomPopup {
 	public DomModalDialogPopup() {
 
 		addCssClass(DomElementsCssClasses.DOM_MODAL_DIALOG_POPUP);
-		// TODO this should not be a separate class
-		addCssClass(DomElementsCssClasses.DOM_MODAL_DIALOG_POPUP_WRAPPED);
 		addMarker(DomModalDialogMarker.POPUP);
 
 		this.contentContainer = appendChild(new Content());

--- a/platform-dom/src/main/resources/com/softicar/platform/dom/elements/dom-modal-popup-style.css
+++ b/platform-dom/src/main/resources/com/softicar/platform/dom/elements/dom-modal-popup-style.css
@@ -4,9 +4,6 @@
 	gap: var(--COLUMN_GAP);
 	min-width: 256px;
 	max-width: 512px;
-}
-
-.DomModalDialogPopupWrapped {
 	white-space: pre-wrap;
 }
 


### PR DESCRIPTION
`DOM_MODAL_DIALOG_POPUP_WRAPPED` was set exactly if `DOM_MODAL_DIALOG_POPUP` was set. Hence redundant.
