### PR TITLE
PLAT-875 Append modal popups and backdrops to the closest maximization context

### DIFF
--- a/platform-dom/src/main/java/com/softicar/platform/dom/elements/popup/compositor/DomDefaultPopupCompositor.java
+++ b/platform-dom/src/main/java/com/softicar/platform/dom/elements/popup/compositor/DomDefaultPopupCompositor.java
@@ -65,18 +65,18 @@ public class DomDefaultPopupCompositor implements IDomPopupCompositor {
 			applyCallbackBeforeOpen(configuration);
 
 			// -------- append backdrop -------- //
-			appendBackdrop(popup);
+			var maximizationContext = getClosestMaximizationContext(spawningNode);
+			appendBackdrop(popup, maximizationContext);
 
 			// -------- create frame -------- //
-			var frameParent = getFrameParent(configuration, spawningNode);
-			var frame = new DomPopupFrame(popup, frameParent);
+			var frame = new DomPopupFrame(popup, maximizationContext);
 			frameMap.put(popup, frame);
 
 			// -------- append frame -------- //
 			if (displayMode.isMaximized()) {
-				maximizationContextStasher.stash(frameParent);
+				maximizationContextStasher.stash(maximizationContext);
 			}
-			frameParent.appendChild(frame);
+			maximizationContext.appendChild(frame);
 			stateTracker.setOpen(popup);
 
 			// -------- set up popup -------- //
@@ -226,15 +226,6 @@ public class DomDefaultPopupCompositor implements IDomPopupCompositor {
 		}
 	}
 
-	private IDomPopupMaximizationContext getFrameParent(IDomPopupConfiguration configuration, IDomNode spawningNode) {
-
-		if (configuration.getDisplayMode().getModalMode().isModal() || backdropTracker.isAnyBackdropPresent()) {
-			return getBody();
-		} else {
-			return getClosestMaximizationContext(spawningNode);
-		}
-	}
-
 	private void applyCallbackBeforeOpen(IDomPopupConfiguration configuration) {
 
 		configuration.getCallbackBeforeOpen().apply();
@@ -250,7 +241,7 @@ public class DomDefaultPopupCompositor implements IDomPopupCompositor {
 		getDomEngine().raise(frame);
 	}
 
-	private void appendBackdrop(DomPopup popup) {
+	private void appendBackdrop(DomPopup popup, IDomPopupMaximizationContext maximizationContext) {
 
 		var modalMode = popup.getConfiguration().getDisplayMode().getModalMode();
 		if (modalMode.isModal()) {
@@ -259,7 +250,7 @@ public class DomDefaultPopupCompositor implements IDomPopupCompositor {
 			backdropTracker.add(popup, backdrop);
 			refreshBackdropVisibility();
 			getDomEngine().raise(backdrop);
-			getBody().appendChild(backdrop);
+			maximizationContext.appendChild(backdrop);
 		}
 	}
 


### PR DESCRIPTION
- Modal backdrops are no longer displayed full-page, by default. Instead, the closest maximization context (if any) is preferred as a parent.
- Popups spawned from modal popups are now also appended to the closest maximization context (instead of being appended to the body).

This has the following effects:
- Modal backdrops spawned from a page are displayed inside the `PageContentDiv`. They are no longer overlays above the entire viewport.
- Navigation and page header can be interacted with, while a modal popup spawned from a page is present.
- If a modal popup is spawned from outside the page (e.g. from the logout button), backdrop and popup will still be appended to the body.
- Fixed: Popups that were spawned from an EMF management table action popover are now in the same z-index sequence as non-modal popups spawned from the page.

![Peek 2022-05-20 17-25](https://user-images.githubusercontent.com/15086658/169562792-6c0d6f2d-fa2f-42d8-acf8-50f71c9bb285.gif)
