### PR TITLE
PLAT-937 Generalized applyFixture() Method from SofticarTestDatabase to IDbDatabase

### DIFF
--- a/platform-core-module/src/main/java/com/softicar/platform/core/module/test/SofticarTestDatabase.java
+++ b/platform-core-module/src/main/java/com/softicar/platform/core/module/test/SofticarTestDatabase.java
@@ -1,8 +1,5 @@
 package com.softicar.platform.core.module.test;
 
-import com.softicar.platform.core.module.test.fixture.IDatabaseTestFixtureApplier;
-import com.softicar.platform.db.core.connection.DbConnectionOverrideScope;
-import com.softicar.platform.db.core.database.DbDatabaseScope;
 import com.softicar.platform.db.core.test.DbTestDatabase;
 import com.softicar.platform.db.runtime.table.creator.DbAutomaticTableCreator;
 
@@ -18,22 +15,5 @@ public class SofticarTestDatabase extends DbTestDatabase {
 	public SofticarTestDatabase() {
 
 		addListener(new DbAutomaticTableCreator(() -> 1));
-	}
-
-	/**
-	 * Executes the given {@link IDatabaseTestFixtureApplier} to the internal
-	 * {@link DbTestDatabase}.
-	 *
-	 * @param fixtureApplier
-	 *            a {@link IDatabaseTestFixtureApplier} (never null)
-	 * @return the applied test fixture
-	 */
-	public <T> T applyFixture(IDatabaseTestFixtureApplier<T> fixtureApplier) {
-
-		try (DbDatabaseScope databaseScope = new DbDatabaseScope(this)) {
-			try (DbConnectionOverrideScope connectionScope = new DbConnectionOverrideScope(this)) {
-				return fixtureApplier.apply();
-			}
-		}
 	}
 }

--- a/platform-core-module/src/main/java/com/softicar/platform/core/module/test/SofticarTestDatabase.java
+++ b/platform-core-module/src/main/java/com/softicar/platform/core/module/test/SofticarTestDatabase.java
@@ -1,7 +1,9 @@
 package com.softicar.platform.core.module.test;
 
+import com.softicar.platform.db.core.database.IDbDatabase;
 import com.softicar.platform.db.core.test.DbTestDatabase;
 import com.softicar.platform.db.runtime.table.creator.DbAutomaticTableCreator;
+import java.util.function.Supplier;
 
 /**
  * Extension of the {@link DbTestDatabase}.
@@ -15,5 +17,14 @@ public class SofticarTestDatabase extends DbTestDatabase {
 	public SofticarTestDatabase() {
 
 		addListener(new DbAutomaticTableCreator(() -> 1));
+	}
+
+	/**
+	 * @deprecated use {@link IDbDatabase#apply}
+	 */
+	@Deprecated
+	public <T> T applyFixture(Supplier<T> supplier) {
+
+		return super.apply(supplier);
 	}
 }

--- a/platform-core-module/src/main/java/com/softicar/platform/core/module/web/service/test/WebServiceTestServer.java
+++ b/platform-core-module/src/main/java/com/softicar/platform/core/module/web/service/test/WebServiceTestServer.java
@@ -2,7 +2,7 @@ package com.softicar.platform.core.module.web.service.test;
 
 import com.softicar.platform.common.web.service.WebServiceServer;
 import com.softicar.platform.core.module.AGCoreModuleInstance;
-import com.softicar.platform.core.module.test.SofticarTestDatabase;
+import com.softicar.platform.db.core.database.IDbDatabase;
 
 /**
  * A {@link WebServiceServer} for {@link WebServiceTestService}.
@@ -17,7 +17,7 @@ import com.softicar.platform.core.module.test.SofticarTestDatabase;
  *
  *         SofticarTestDatabase database = new SofticarTestDatabase();
  *
- *         database.applyFixture(() -> {...});
+ *         database.apply(() -> {...});
  *
  *         new WebServiceTestServer(database)//
  *             .setRequestString(...)
@@ -31,7 +31,7 @@ import com.softicar.platform.core.module.test.SofticarTestDatabase;
  */
 public class WebServiceTestServer extends WebServiceServer {
 
-	public WebServiceTestServer(SofticarTestDatabase database) {
+	public WebServiceTestServer(IDbDatabase database) {
 
 		super(new WebServiceTestService(database));
 

--- a/platform-core-module/src/main/java/com/softicar/platform/core/module/web/service/test/WebServiceTestService.java
+++ b/platform-core-module/src/main/java/com/softicar/platform/core/module/web/service/test/WebServiceTestService.java
@@ -3,19 +3,20 @@ package com.softicar.platform.core.module.web.service.test;
 import com.softicar.platform.core.module.test.SofticarTestDatabase;
 import com.softicar.platform.core.module.web.service.WebServiceBrokerService;
 import com.softicar.platform.db.core.database.DbDatabaseScope;
+import com.softicar.platform.db.core.database.IDbDatabase;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
 public class WebServiceTestService extends WebServiceBrokerService {
 
-	protected final SofticarTestDatabase database;
+	protected final IDbDatabase database;
 
 	public WebServiceTestService() {
 
 		this(new SofticarTestDatabase());
 	}
 
-	public WebServiceTestService(SofticarTestDatabase database) {
+	public WebServiceTestService(IDbDatabase database) {
 
 		this.database = database;
 	}

--- a/platform-db-core/src/main/java/com/softicar/platform/db/core/database/IDbDatabase.java
+++ b/platform-db-core/src/main/java/com/softicar/platform/db/core/database/IDbDatabase.java
@@ -1,8 +1,11 @@
 package com.softicar.platform.db.core.database;
 
+import com.softicar.platform.common.core.interfaces.INullaryVoidFunction;
+import com.softicar.platform.db.core.connection.DbConnectionOverrideScope;
 import com.softicar.platform.db.core.connection.IDbConnectionProperties;
 import com.softicar.platform.db.core.connection.IDbServerType;
 import com.softicar.platform.db.core.statement.IDbStatementExecutionListener;
+import java.util.function.Supplier;
 
 /**
  * Defines the database server and the name of the database.
@@ -39,4 +42,38 @@ public interface IDbDatabase extends IDbStatementExecutionListener {
 	 * @return the connection properties (never null)
 	 */
 	IDbConnectionProperties getConnectionProperties();
+
+	/**
+	 * Executes the given {@link INullaryVoidFunction} in the
+	 * {@link DbDatabaseScope} of this {@link IDbDatabase}.
+	 *
+	 * @param function
+	 *            the {@link INullaryVoidFunction} to execute (never
+	 *            <i>null</i>)
+	 */
+	default void apply(INullaryVoidFunction function) {
+
+		try (var databaseScope = new DbDatabaseScope(this)) {
+			try (var connectionScope = new DbConnectionOverrideScope(this)) {
+				function.apply();
+			}
+		}
+	}
+
+	/**
+	 * Executes the given {@link Supplier} in the {@link DbDatabaseScope} of
+	 * this {@link IDbDatabase}.
+	 *
+	 * @param supplier
+	 *            the {@link Supplier} to execute (never <i>null</i>)
+	 * @return the return value of the {@link Supplier}
+	 */
+	default <T> T apply(Supplier<T> supplier) {
+
+		try (var databaseScope = new DbDatabaseScope(this)) {
+			try (var connectionScope = new DbConnectionOverrideScope(this)) {
+				return supplier.get();
+			}
+		}
+	}
 }


### PR DESCRIPTION
- As requested, `WebServiceTestServer` now takes `IDbDatabase` instead of `SofticarTestDatabase`
- For this to work, the method `SofticarTestDatabase.applyFixture()` was generalized into `IDbDatabase.apply()`
  - retained deprecated method `SofticarTestDatabase.applyFixture()` delegating to `IDbDatabase.apply()`
- Existing code is easy to adapt, just call `apply` instead of `applyFixture`:

![image](https://user-images.githubusercontent.com/83839745/174625887-9e010d7a-e327-43d6-a082-c97cf4d202c6.png)
