### PR TITLE
PLAT-961 Allow subsampling to boost PDF preview rendering

### DIFF
--- a/platform-core-module/src/main/java/com/softicar/platform/core/module/file/stored/preview/pdf/StoredFilePdfToZoomableImagesConverter.java
+++ b/platform-core-module/src/main/java/com/softicar/platform/core/module/file/stored/preview/pdf/StoredFilePdfToZoomableImagesConverter.java
@@ -47,7 +47,9 @@ public class StoredFilePdfToZoomableImagesConverter {
 		try (InputStream stream = file.getFileContentInputStream()) {
 			try (PDDocument pdDocument = PDDocument.load(stream)) {
 				for (int index = 0; index < pdDocument.getNumberOfPages(); index++) {
-					BufferedImage image = new PDFRenderer(pdDocument).renderImageWithDPI(index, PREVIEW_DPI);
+					var renderer = new PDFRenderer(pdDocument);
+					renderer.setSubsamplingAllowed(true);
+					BufferedImage image = renderer.renderImageWithDPI(index, PREVIEW_DPI);
 					ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
 					ImageIO.write(image, THUMBNAIL_IMAGE_TYPE, outputStream);
 					String fileName = file//


### PR DESCRIPTION
For a well-known test PDF, this change reduces the rendering time per page from ~1500 ms to ~320 ms, at the cost of an apparently marginal loss in quality.
