### PR TITLE
PLAT-1015 DomPopupManager: Change CTOR to private

### DIFF
--- a/platform-dom/src/main/java/com/softicar/platform/dom/elements/popup/manager/DomPopupManager.java
+++ b/platform-dom/src/main/java/com/softicar/platform/dom/elements/popup/manager/DomPopupManager.java
@@ -19,7 +19,7 @@ public class DomPopupManager {
 
 	private final Map<DomPopupManagerKey, DomPopup> popups;
 
-	public DomPopupManager() {
+	private DomPopupManager() {
 
 		this.popups = new HashMap<>();
 	}


### PR DESCRIPTION
The static getter should be the only way to retrieve an instance.
