### PR TITLE
PLAT-1007 Fix font color in auto-complete popover if input is in error state

### DIFF
--- a/platform-ajax/src/main/resources/com/softicar/platform/ajax/ajax-style.css
+++ b/platform-ajax/src/main/resources/com/softicar/platform/ajax/ajax-style.css
@@ -9,6 +9,7 @@
 	border-radius: var(--BORDER_RADIUS);
 	box-shadow: var(--BOX_SHADOW_OVERLAY);
 
+	color: var(--FONT_COLOR);
 	background-color: var(--INPUT_BACKGROUND_COLOR); 
 	overflow:hidden;
 	gap: 0;


### PR DESCRIPTION
We recently changed the parent element of the auto-complete popover to fix positioning when the page is scrolled. That change caused the regression fixed in this PR.

![image](https://user-images.githubusercontent.com/15086658/176946254-227c03df-75e3-45aa-ac7c-794a28406b5b.png)
