### PR TITLE
PLAT-989 PDF previews: Enable rendering of jpeg2000-encoded embedded images

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,6 +28,8 @@ project.ext {
 		guava: "31.1-jre",
 		h2: "2.1.214",
 		hikariCp: "5.0.1",
+		// optional dependency of pdfbox; enables rendering of jpeg2000-encoded embedded images
+		jaiImageioJpeg2000: "1.4.0",
 		jakartaActivation: "1.2.2",
 		javaxServletApi: "4.0.1",
 		jcifsNg: "2.1.7",

--- a/platform-common-pdf/build.gradle
+++ b/platform-common-pdf/build.gradle
@@ -1,5 +1,6 @@
 dependencies {
 	api project(':platform-common')
 
+	implementation "com.github.jai-imageio:jai-imageio-jpeg2000:$versions.jaiImageioJpeg2000"
 	implementation "org.apache.pdfbox:pdfbox:$versions.pdfbox"
 }

--- a/platform-core-module/build.gradle
+++ b/platform-core-module/build.gradle
@@ -7,7 +7,8 @@ dependencies {
 	api "com.sun.mail:mailapi:$versions.sunMail"
 	api "com.sun.mail:smtp:$versions.sunMail"
 
-	implementation("eu.agno3.jcifs:jcifs-ng:$versions.jcifsNg")
+	implementation "com.github.jai-imageio:jai-imageio-jpeg2000:$versions.jaiImageioJpeg2000"
+	implementation "eu.agno3.jcifs:jcifs-ng:$versions.jcifsNg"
 	implementation "org.apache.commons:commons-lang3:$versions.commonsLang3"
 	implementation "org.apache.pdfbox:pdfbox:$versions.pdfbox"
 }

--- a/platform-core-module/src/main/java/com/softicar/platform/core/module/component/external/license/rule/ExternalComponentLicensePredefinedRules.java
+++ b/platform-core-module/src/main/java/com/softicar/platform/core/module/component/external/license/rule/ExternalComponentLicensePredefinedRules.java
@@ -40,6 +40,11 @@ public class ExternalComponentLicensePredefinedRules {
 
 		// Artifact does not contain license information.
 		// License defined at:
+		// https://github.com/jai-imageio/jai-imageio-jpeg2000/blob/master/LICENSE-JJ2000.txt
+		addLibrary("jai-imageio-jpeg2000", ".*", License.JJ_2000);
+
+		// Artifact does not contain license information.
+		// License defined at:
 		// https://github.com/AgNO3/jcifs-ng/blob/master/LICENSE
 		addLibrary("jcifs-ng", ".*", License.LGPL_2_1);
 

--- a/platform-core-module/src/main/java/com/softicar/platform/core/module/license/License.java
+++ b/platform-core-module/src/main/java/com/softicar/platform/core/module/license/License.java
@@ -14,6 +14,7 @@ public enum License {
 	CDDL_1_0("CDDL v1.0"),
 	EPL_1_0("EPL v1.0"),
 	EPL_2_0("EPL v2.0"),
+	JJ_2000("JJ2000"),
 	LGPL_2_1("LGPL v2.1"),
 	MIT("MIT"),
 	MIT_0("MIT-0"),


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/15086658/177164344-8f321a5a-38c7-4a08-ad34-763f5338f93c.png)

See:
- https://pdfbox.apache.org/2.0/dependencies.html#optional-components
- https://mvnrepository.com/artifact/org.apache.pdfbox/pdfbox/2.0.26 (optional dependency on `jai-imageio-jpeg2000` is wrongfully displayed as "Test Dependency", most likely due to a defect in the `pom.xml` parser of mavencentral)
- https://github.com/jai-imageio/jai-imageio-jpeg2000