### PR TITLE
PLAT-1030 Adapted height of inputs

### DIFF
--- a/platform-dom/src/main/resources/com/softicar/platform/dom/dom-style.css
+++ b/platform-dom/src/main/resources/com/softicar/platform/dom/dom-style.css
@@ -120,6 +120,7 @@ textarea {
 input[type=text],
 input[type=password],
 textarea {
+	height: 14px;
 	border: 1px solid var(--INPUT_BORDER_COLOR);
 	border-radius: var(--BORDER_RADIUS);
 	outline: none;


### PR DESCRIPTION
Contrary to PLAT-1030s description, checkbox height in my tests were 26px while other rows were 27px high.
Since scaling up the checkbox looks absurd, I reduced the height of inputs to 14px instead of 15px so that all input rows are now 26px high

Chrome: 
![image](https://user-images.githubusercontent.com/90852097/178247616-e38fee69-45a8-4aee-a191-e5df39541ec4.png)

Firefox:
![image](https://user-images.githubusercontent.com/90852097/178247730-a456461c-836c-44d7-af53-ec8c02bb6e52.png)
