### PR TITLE
PLAT-1048 Implement DomDeferredInitializationController

### DIFF
--- a/platform-ajax/src/main/java/com/softicar/platform/ajax/document/AjaxDomDeferredInitializationControllerTest.java
+++ b/platform-ajax/src/main/java/com/softicar/platform/ajax/document/AjaxDomDeferredInitializationControllerTest.java
@@ -1,0 +1,48 @@
+package com.softicar.platform.ajax.document;
+
+import com.softicar.platform.ajax.testing.selenium.engine.level.low.AjaxSeleniumLowLevelTestEngine;
+import com.softicar.platform.ajax.testing.selenium.engine.level.low.interfaces.IAjaxSeleniumLowLevelTestEngine;
+import com.softicar.platform.ajax.testing.selenium.engine.level.low.interfaces.IAjaxSeleniumLowLevelTestEngineMethods;
+import com.softicar.platform.dom.node.initialization.AbstractDomDeferredInitializationControllerTest;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class AjaxDomDeferredInitializationControllerTest extends AbstractDomDeferredInitializationControllerTest
+		implements IAjaxSeleniumLowLevelTestEngineMethods {
+
+	@Rule public final IAjaxSeleniumLowLevelTestEngine engine = new AjaxSeleniumLowLevelTestEngine();
+
+	private final TestDiv testDiv;
+
+	public AjaxDomDeferredInitializationControllerTest() {
+
+		testDiv = openTestNode(() -> new TestDiv(this::addInitializedNode));
+	}
+
+	@Override
+	public IAjaxSeleniumLowLevelTestEngine getTestEngine() {
+
+		return engine;
+	}
+
+	@Test
+	public void test() {
+
+		// assert initial state
+		assertTrue(initializedNodes.isEmpty());
+
+		// connect upper node
+		click(TestDiv.CONNECT_UPPER_NODE_BUTTON);
+		waitForServer();
+		assertEquals(1, initializedNodes.size());
+		assertSame(testDiv.upperNode, initializedNodes.get(0));
+
+		// connect lower and middle ndoes
+		click(TestDiv.CONNECT_MIDDLE_AND_LOWER_NODES_BUTTON);
+		waitForServer();
+		assertEquals(3, initializedNodes.size());
+		assertSame(testDiv.upperNode, initializedNodes.get(0));
+		assertSame(testDiv.lowerNode, initializedNodes.get(1));
+		assertSame(testDiv.middleNode, initializedNodes.get(2));
+	}
+}

--- a/platform-ajax/src/main/java/com/softicar/platform/ajax/engine/AjaxDomEngine.java
+++ b/platform-ajax/src/main/java/com/softicar/platform/ajax/engine/AjaxDomEngine.java
@@ -163,6 +163,7 @@ public class AjaxDomEngine implements IDomEngine {
 		} else {
 			JS_call("a", parent.getNodeId(), child.getNodeId());
 		}
+		document.getDeferredInitializationController().queueAppended(child);
 
 		lastCreationNodeID = -1;
 	}
@@ -171,6 +172,7 @@ public class AjaxDomEngine implements IDomEngine {
 	public void insertBefore(IDomNode parent, IDomNode child, IDomNode otherChild) {
 
 		JS_call("i", parent.getNodeId(), child.getNodeId(), otherChild.getNodeId());
+		document.getDeferredInitializationController().queueAppended(child);
 		lastCreationNodeID = -1;
 	}
 

--- a/platform-common/src/main/java/com/softicar/platform/common/testing/Asserts.java
+++ b/platform-common/src/main/java/com/softicar/platform/common/testing/Asserts.java
@@ -68,7 +68,7 @@ public class Asserts extends Assert {
 		Throwable thrown = null;
 		try {
 			thrower.apply();
-		} catch (Exception throwable) {
+		} catch (Throwable throwable) {
 			thrown = throwable;
 		}
 		assertNotNull(String.format("Expected a Throwable of class %s but none was thrown.", expectedThrowableClass.getCanonicalName()), thrown);
@@ -82,7 +82,7 @@ public class Asserts extends Assert {
 					StackTraceFormatting.getStackTraceAsString(thrown)),
 			expectedThrowableClass.isAssignableFrom(thrownClass));
 		if (expectedMessage != null) {
-			assertEquals("Unexpected exception message.", expectedMessage, thrown.getMessage());
+			assertEquals("Unexpected message.", expectedMessage, thrown.getMessage());
 		}
 	}
 
@@ -91,8 +91,8 @@ public class Asserts extends Assert {
 		try {
 			thrower.apply();
 			fail("An expected exception failed to occur.");
-		} catch (Exception exception) {
-			assertEquals(expectedMessage.toString(), getNonNullMessageOrFail(exception));
+		} catch (Throwable throwable) {
+			assertEquals(expectedMessage.toString(), getNonNullMessageOrFail(throwable));
 		}
 	}
 
@@ -101,11 +101,11 @@ public class Asserts extends Assert {
 		try {
 			thrower.apply();
 			fail("An expected exception failed to occur.");
-		} catch (Exception exception) {
-			String message = getNonNullMessageOrFail(exception);
+		} catch (Throwable throwable) {
+			String message = getNonNullMessageOrFail(throwable);
 			assertTrue(//
 				"The expected text\n\"%s\"\n is not contained in the encountered exception message:\n\"%s\"".formatted(expectedMessage.toString(), message),
-				exception.getMessage().contains(expectedMessage.toString()));
+				throwable.getMessage().contains(expectedMessage.toString()));
 		}
 	}
 
@@ -214,13 +214,13 @@ public class Asserts extends Assert {
 			.collect(Collectors.toList());
 	}
 
-	private static String getNonNullMessageOrFail(Exception exception) {
+	private static String getNonNullMessageOrFail(Throwable throwable) {
 
-		String message = exception.getMessage();
+		String message = throwable.getMessage();
 		if (message != null) {
 			return message;
 		} else {
-			throw new AssertionError("The encountered %s does not have a message.".formatted(exception.getClass().getSimpleName()));
+			throw new AssertionError("The encountered %s does not have a message.".formatted(throwable.getClass().getSimpleName()));
 		}
 	}
 }

--- a/platform-core-module/src/main/java/com/softicar/platform/core/module/page/PageHeaderAndContentDiv.java
+++ b/platform-core-module/src/main/java/com/softicar/platform/core/module/page/PageHeaderAndContentDiv.java
@@ -29,12 +29,16 @@ public class PageHeaderAndContentDiv extends DomDiv {
 		removeChildren();
 		CurrentDomPopupCompositor.get().closeAll();
 
+		CurrentDomDocument.get().getDeferredInitializationController().clear();
+
 		DbTableRowCaches.invalidateAll();
 		CurrentLocale.set(CurrentUser.get().getLocale());
 
 		changeBrowserUrl(link);
 		appendChild(new PageHeaderDiv<>(link, navigationToggleFunction));
 		appendChild(new PageContentDiv(link));
+
+		CurrentDomDocument.get().getDeferredInitializationController().handleAllAppended();
 	}
 
 	private void changeBrowserUrl(PageNavigationLink<?> link) {

--- a/platform-dom/src/main/java/com/softicar/platform/dom/document/AbstractDomDocument.java
+++ b/platform-dom/src/main/java/com/softicar/platform/dom/document/AbstractDomDocument.java
@@ -12,6 +12,8 @@ import com.softicar.platform.dom.document.marker.DomDocumentMarkerHolder;
 import com.softicar.platform.dom.document.marker.IDomDocumentMarkerHolder;
 import com.softicar.platform.dom.event.IDomEvent;
 import com.softicar.platform.dom.node.IDomNode;
+import com.softicar.platform.dom.node.initialization.DomDeferredInitializationController;
+import com.softicar.platform.dom.node.initialization.IDomDeferredInitializationController;
 import com.softicar.platform.dom.refresh.bus.DomRefreshBus;
 import com.softicar.platform.dom.refresh.bus.IDomRefreshBus;
 import com.softicar.platform.dom.refresh.bus.IDomRefreshBusListener;
@@ -30,6 +32,7 @@ public abstract class AbstractDomDocument implements IDomDocument {
 	private final IDomRefreshBus refreshBus;
 	private final ClassInstanceMap<Object> dataMap;
 	private final IDomDocumentMarkerHolder markerHolder;
+	private final IDomDeferredInitializationController deferredInitializationController;
 	private final DomHead head;
 	private final DomBody body;
 	private int maximumExistingNodeCount;
@@ -43,6 +46,7 @@ public abstract class AbstractDomDocument implements IDomDocument {
 		this.refreshBus = new DomRefreshBus();
 		this.dataMap = new ClassInstanceMap<>();
 		this.markerHolder = new DomDocumentMarkerHolder(this);
+		this.deferredInitializationController = new DomDeferredInitializationController(this);
 		this.head = new DomHead(this);
 		this.body = new DomBody(this);
 		this.maximumExistingNodeCount = 0;
@@ -109,6 +113,12 @@ public abstract class AbstractDomDocument implements IDomDocument {
 	public final void removeCollectedNodes() {
 
 		activeNodes.collect();
+	}
+
+	@Override
+	public IDomDeferredInitializationController getDeferredInitializationController() {
+
+		return deferredInitializationController;
 	}
 
 	// -------------------------------- event -------------------------------- //

--- a/platform-dom/src/main/java/com/softicar/platform/dom/document/IDomDocument.java
+++ b/platform-dom/src/main/java/com/softicar/platform/dom/document/IDomDocument.java
@@ -7,6 +7,7 @@ import com.softicar.platform.dom.engine.IDomEngine;
 import com.softicar.platform.dom.event.IDomEvent;
 import com.softicar.platform.dom.node.AbstractDomNode;
 import com.softicar.platform.dom.node.IDomNode;
+import com.softicar.platform.dom.node.initialization.IDomDeferredInitializationController;
 import com.softicar.platform.dom.refresh.bus.IDomRefreshBus;
 import java.lang.ref.WeakReference;
 
@@ -77,6 +78,14 @@ public interface IDomDocument extends IDomDocumentMarkerHolder {
 	 * this method removes the respective reference from the internal registry.
 	 */
 	void removeCollectedNodes();
+
+	/**
+	 * Returns the controller for deferred node initialization.
+	 *
+	 * @return the {@link IDomDeferredInitializationController} (never
+	 *         <i>null</i>)
+	 */
+	IDomDeferredInitializationController getDeferredInitializationController();
 
 	// -------------------------------- event -------------------------------- //
 

--- a/platform-dom/src/main/java/com/softicar/platform/dom/elements/popup/compositor/DomParentNodeFinder.java
+++ b/platform-dom/src/main/java/com/softicar/platform/dom/elements/popup/compositor/DomParentNodeFinder.java
@@ -61,4 +61,32 @@ public class DomParentNodeFinder<T extends IDomNode> {
 		}
 		return Optional.empty();
 	}
+
+	/**
+	 * For the given child {@link IDomNode}, finds the most distant transitive
+	 * parent of the type given to {@link #DomParentNodeFinder(Class)}.
+	 * <p>
+	 * Returns {@link Optional#empty()} if the given {@link IDomNode} has no
+	 * such transitive parent, or no parent at all.
+	 *
+	 * @param child
+	 *            the {@link IDomNode} to search a parent for (never
+	 *            <i>null</i>)
+	 * @return the most distant transitive parent {@link IDomNode} that matches
+	 *         the specified class
+	 */
+	public Optional<T> findMostDistantParent(IDomNode child) {
+
+		Objects.requireNonNull(child);
+		IDomNode parent = null;
+		T typedParent = null;
+		do {
+			parent = child.getParent();
+			if (parentClass.isInstance(parent)) {
+				typedParent = parentClass.cast(parent);
+			}
+			child = parent;
+		} while (parent != null);
+		return Optional.ofNullable(typedParent);
+	}
 }

--- a/platform-dom/src/main/java/com/softicar/platform/dom/elements/testing/engine/AbstractDomTestExecutionEngineLazySetup.java
+++ b/platform-dom/src/main/java/com/softicar/platform/dom/elements/testing/engine/AbstractDomTestExecutionEngineLazySetup.java
@@ -66,6 +66,8 @@ public abstract class AbstractDomTestExecutionEngineLazySetup implements IDomTes
 		if (node == null) {
 			flushRefreshBus();
 			this.node = createNode();
+			// Explicitly perform deferred initialization for appended nodes, because we have no DOM event that would have triggered this automatically.
+			CurrentDomDocument.get().getDeferredInitializationController().handleAllAppended();
 		}
 	}
 

--- a/platform-dom/src/main/java/com/softicar/platform/dom/engine/DomTestEngine.java
+++ b/platform-dom/src/main/java/com/softicar/platform/dom/engine/DomTestEngine.java
@@ -44,4 +44,18 @@ public class DomTestEngine extends DomNullEngine {
 
 		setNodeStyle(node, "zIndex", "" + maxZIndex++);
 	}
+
+	@Override
+	public void appendChild(IDomNode parent, IDomNode child) {
+
+		var document = child.getDomDocument();
+		document.getDeferredInitializationController().queueAppended(child);
+	}
+
+	@Override
+	public void insertBefore(IDomNode parent, IDomNode child, IDomNode otherChild) {
+
+		var document = child.getDomDocument();
+		document.getDeferredInitializationController().queueAppended(child);
+	}
 }

--- a/platform-dom/src/main/java/com/softicar/platform/dom/event/DomEventHandlerNodeCaller.java
+++ b/platform-dom/src/main/java/com/softicar/platform/dom/event/DomEventHandlerNodeCaller.java
@@ -26,6 +26,7 @@ public class DomEventHandlerNodeCaller {
 			} else {
 				event.getType().handleEvent(eventNode, event);
 			}
+			document.getDeferredInitializationController().handleAllAppended();
 		} catch (Exception exception) {
 			IDomExceptionDisplayElement displayElement = findExceptionDisplayElement(eventNode, exception);
 			if (displayElement != null) {

--- a/platform-dom/src/main/java/com/softicar/platform/dom/node/IDomNode.java
+++ b/platform-dom/src/main/java/com/softicar/platform/dom/node/IDomNode.java
@@ -217,6 +217,25 @@ public interface IDomNode {
 		return getDomDocument().hasMarker(this, markers);
 	}
 
+	// -------------------------------- initializer -------------------------------- //
+
+	/**
+	 * Adds the given deferred initializer (i.e. an initialization callback) for
+	 * this {@link IDomNode}.
+	 * <p>
+	 * The initializer is executed when the {@link IDomNode} obtains a
+	 * transitive parent connection to the {@link DomBody}.
+	 *
+	 * @param initializer
+	 *            the initialization callback to execute as soon as this
+	 *            {@link IDomNode} is transitively appended to the
+	 *            {@link DomBody} (never <i>null</i>)
+	 */
+	default void addDeferredInitializer(INullaryVoidFunction initializer) {
+
+		getDomDocument().getDeferredInitializationController().addDeferredInitializer(this, initializer);
+	}
+
 	// -------------------------------- alert, confirm and prompt -------------------------------- //
 
 	/**

--- a/platform-dom/src/main/java/com/softicar/platform/dom/node/initialization/AbstractDomDeferredInitializationControllerTest.java
+++ b/platform-dom/src/main/java/com/softicar/platform/dom/node/initialization/AbstractDomDeferredInitializationControllerTest.java
@@ -1,0 +1,59 @@
+package com.softicar.platform.dom.node.initialization;
+
+import com.softicar.platform.common.core.interfaces.IStaticObject;
+import com.softicar.platform.common.testing.AbstractTest;
+import com.softicar.platform.dom.elements.DomDiv;
+import com.softicar.platform.dom.elements.button.DomButton;
+import com.softicar.platform.dom.node.IDomNode;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Consumer;
+import org.mockito.Mockito;
+
+public abstract class AbstractDomDeferredInitializationControllerTest extends AbstractTest {
+
+	protected final List<IDomNode> initializedNodes;
+
+	protected AbstractDomDeferredInitializationControllerTest() {
+
+		initializedNodes = new ArrayList<>();
+	}
+
+	protected void addInitializedNode(IDomNode node) {
+
+		this.initializedNodes.add(node);
+	}
+
+	protected static class TestDiv extends DomDiv {
+
+		public static final IStaticObject CONNECT_UPPER_NODE_BUTTON = Mockito.mock(IStaticObject.class);
+		public static final IStaticObject CONNECT_MIDDLE_AND_LOWER_NODES_BUTTON = Mockito.mock(IStaticObject.class);
+		public DomDiv upperNode;
+		public DomDiv middleNode;
+		public DomDiv lowerNode;
+
+		public TestDiv(Consumer<IDomNode> nodeInitializationHandler) {
+
+			upperNode = new DomDiv();
+			upperNode.addDeferredInitializer(() -> nodeInitializationHandler.accept(upperNode));
+
+			middleNode = new DomDiv();
+			middleNode.addDeferredInitializer(() -> nodeInitializationHandler.accept(middleNode));
+
+			lowerNode = new DomDiv();
+			lowerNode.addDeferredInitializer(() -> nodeInitializationHandler.accept(lowerNode));
+
+			appendChild(//
+				new DomButton().addMarker(CONNECT_UPPER_NODE_BUTTON).setLabel("connect upper node").setClickCallback(() -> {
+					// append only the upper node
+					appendChild(upperNode);
+				}));
+			appendChild(//
+				new DomButton().addMarker(CONNECT_MIDDLE_AND_LOWER_NODES_BUTTON).setLabel("connect lower and middle nodes").setClickCallback(() -> {
+					// append the lower node first; then, append the middle node
+					middleNode.appendChild(lowerNode);
+					upperNode.appendChild(middleNode);
+				}));
+		}
+	}
+}

--- a/platform-dom/src/main/java/com/softicar/platform/dom/node/initialization/DomDeferredInitializationController.java
+++ b/platform-dom/src/main/java/com/softicar/platform/dom/node/initialization/DomDeferredInitializationController.java
@@ -1,0 +1,83 @@
+package com.softicar.platform.dom.node.initialization;
+
+import com.softicar.platform.common.core.interfaces.INullaryVoidFunction;
+import com.softicar.platform.dom.document.IDomDocument;
+import com.softicar.platform.dom.elements.popup.compositor.DomParentNodeFinder;
+import com.softicar.platform.dom.node.IDomNode;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.WeakHashMap;
+
+/**
+ * The default implementation of an
+ * {@link IDomDeferredInitializationController}.
+ *
+ * @author Alexander Schmidt
+ */
+public class DomDeferredInitializationController implements IDomDeferredInitializationController {
+
+	private final IDomDocument document;
+	private final List<IDomNode> appendedNodes;
+	private final Map<IDomNode, List<INullaryVoidFunction>> initializers;
+
+	/**
+	 * Constructs a new {@link DomDeferredInitializationController}.
+	 *
+	 * @param document
+	 *            the {@link IDomDocument} to which the appended nodes and the
+	 *            initializers refer (never <i>null</i>)
+	 */
+	public DomDeferredInitializationController(IDomDocument document) {
+
+		this.document = Objects.requireNonNull(document);
+		this.appendedNodes = new ArrayList<>();
+		this.initializers = new WeakHashMap<>();
+	}
+
+	@Override
+	public void addDeferredInitializer(IDomNode node, INullaryVoidFunction initializer) {
+
+		Objects.requireNonNull(node);
+		Objects.requireNonNull(initializer);
+		initializers.computeIfAbsent(node, dummy -> new ArrayList<>()).add(initializer);
+	}
+
+	@Override
+	public void queueAppended(IDomNode node) {
+
+		Objects.requireNonNull(node);
+		this.appendedNodes.add(node);
+	}
+
+	@Override
+	public void handleAllAppended() {
+
+		var finder = new DomParentNodeFinder<>(IDomNode.class);
+
+		for (var appendedNode: appendedNodes) {
+			finder.findMostDistantParent(appendedNode).ifPresent(distantParent -> {
+				Optional.ofNullable(initializers.remove(appendedNode)).ifPresent(initializerList -> {
+					initializers.computeIfAbsent(distantParent, dummy -> new ArrayList<>()).addAll(initializerList);
+				});
+			});
+		}
+
+		Optional//
+			.ofNullable(initializers.remove(document.getBody()))
+			.orElse(Collections.emptyList())
+			.forEach(INullaryVoidFunction::apply);
+
+		appendedNodes.clear();
+	}
+
+	@Override
+	public void clear() {
+
+		appendedNodes.clear();
+		initializers.clear();
+	}
+}

--- a/platform-dom/src/main/java/com/softicar/platform/dom/node/initialization/IDomDeferredInitializationController.java
+++ b/platform-dom/src/main/java/com/softicar/platform/dom/node/initialization/IDomDeferredInitializationController.java
@@ -1,0 +1,58 @@
+package com.softicar.platform.dom.node.initialization;
+
+import com.softicar.platform.common.core.interfaces.INullaryVoidFunction;
+import com.softicar.platform.dom.document.DomBody;
+import com.softicar.platform.dom.document.IDomDocument;
+import com.softicar.platform.dom.node.IDomNode;
+
+/**
+ * Provides the "deferred node initialization" feature to {@link IDomDocument}.
+ *
+ * @author Alexander Schmidt
+ */
+public interface IDomDeferredInitializationController {
+
+	/**
+	 * Adds the given deferred initializer (i.e. an initialization callback) for
+	 * the given {@link IDomNode}.
+	 * <p>
+	 * The initializer is executed when the {@link IDomNode} obtains a
+	 * transitive parent connection to the {@link DomBody}.
+	 *
+	 * @param node
+	 *            the {@link IDomNode} that must be transitively appended to the
+	 *            {@link DomBody}, for the initializer to be executed (never
+	 *            <i>null</i>)
+	 * @param initializer
+	 *            the initialization callback to execute as soon as the
+	 *            {@link IDomNode} is transitively appended to the
+	 *            {@link DomBody} (never <i>null</i>)
+	 */
+	void addDeferredInitializer(IDomNode node, INullaryVoidFunction initializer);
+
+	/**
+	 * Adds the given {@link IDomNode} to the queue of recently appended nodes.
+	 *
+	 * @param node
+	 *            the appended {@link IDomNode} (never <i>null</i>)
+	 */
+	void queueAppended(IDomNode node);
+
+	/**
+	 * Processes the queue of recently appended nodes, and execute initializers
+	 * if appropriate.
+	 * <p>
+	 * Initializers are executed in the order in which the corresponding nodes
+	 * were appended to any parent. This order might differ from the order in
+	 * which the respective nodes obtained a transitive parent connection to the
+	 * {@link DomBody}.
+	 * <p>
+	 * Clears the queue afterwards.
+	 */
+	void handleAllAppended();
+
+	/**
+	 * Resets all internal states.
+	 */
+	void clear();
+}

--- a/platform-dom/src/test/java/com/softicar/platform/dom/elements/popup/compositor/DomParentNodeFinderTest.java
+++ b/platform-dom/src/test/java/com/softicar/platform/dom/elements/popup/compositor/DomParentNodeFinderTest.java
@@ -86,6 +86,53 @@ public class DomParentNodeFinderTest extends AbstractTest {
 		createFetcher(IDomNode.class).findClosestParent(null);
 	}
 
+	@Test
+	public void testFindMostDistantParent() {
+
+		DomDiv top = appendChild(new DomDiv());
+		DomDiv upper = top.appendChild(new TestParent());
+		DomDiv middle = upper.appendChild(new DomDiv());
+		DomDiv lower = middle.appendChild(new TestParent());
+		DomDiv bottom = lower.appendChild(new DomDiv());
+
+		Optional<TestParent> parent = createFetcher(TestParent.class).findMostDistantParent(bottom);
+
+		assertTrue(parent.isPresent());
+		assertSame(upper, parent.get());
+	}
+
+	@Test
+	public void testFindMostDistantParentOfAnyType() {
+
+		DomDiv top = appendChild(new DomDiv());
+		DomDiv middle = top.appendChild(new TestParent());
+		DomDiv lower = middle.appendChild(new DomDiv());
+
+		Optional<IDomNode> parent = createFetcher(IDomNode.class).findMostDistantParent(lower);
+
+		assertTrue(parent.isPresent());
+		assertSame(document.getBody(), parent.get());
+	}
+
+	@Test
+	public void testFindMostDistantParentWithoutParent() {
+
+		Optional<TestParent> parent = createFetcher(TestParent.class).findMostDistantParent(new DomDiv());
+
+		assertFalse(parent.isPresent());
+	}
+
+	@Test
+	public void testFindMostDistantParentWithoutMatchingParent() {
+
+		DomDiv upper = appendChild(new DomDiv());
+		DomDiv lower = upper.appendChild(new DomDiv());
+
+		Optional<TestParent> parent = createFetcher(TestParent.class).findMostDistantParent(lower);
+
+		assertFalse(parent.isPresent());
+	}
+
 	private <T extends IDomNode> T appendChild(T node) {
 
 		return document.getBody().appendChild(node);

--- a/platform-dom/src/test/java/com/softicar/platform/dom/node/initialization/DomDeferredInitializationControllerTest.java
+++ b/platform-dom/src/test/java/com/softicar/platform/dom/node/initialization/DomDeferredInitializationControllerTest.java
@@ -1,0 +1,45 @@
+package com.softicar.platform.dom.node.initialization;
+
+import com.softicar.platform.dom.elements.testing.engine.IDomTestExecutionEngine;
+import com.softicar.platform.dom.elements.testing.engine.IDomTestExecutionEngineMethods;
+import com.softicar.platform.dom.elements.testing.engine.document.DomDocumentTestExecutionEngine;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class DomDeferredInitializationControllerTest extends AbstractDomDeferredInitializationControllerTest implements IDomTestExecutionEngineMethods {
+
+	@Rule public final IDomTestExecutionEngine engine = new DomDocumentTestExecutionEngine();
+
+	private final TestDiv testDiv;
+
+	public DomDeferredInitializationControllerTest() {
+
+		testDiv = new TestDiv(this::addInitializedNode);
+		setNodeSupplier(() -> testDiv);
+	}
+
+	@Override
+	public IDomTestExecutionEngine getEngine() {
+
+		return engine;
+	}
+
+	@Test
+	public void test() {
+
+		// assert initial state
+		assertTrue(initializedNodes.isEmpty());
+
+		// connect upper node
+		findButton(TestDiv.CONNECT_UPPER_NODE_BUTTON).click();
+		assertEquals(1, initializedNodes.size());
+		assertSame(testDiv.upperNode, initializedNodes.get(0));
+
+		// connect lower and middle ndoes
+		findButton(TestDiv.CONNECT_MIDDLE_AND_LOWER_NODES_BUTTON).click();
+		assertEquals(3, initializedNodes.size());
+		assertSame(testDiv.upperNode, initializedNodes.get(0));
+		assertSame(testDiv.lowerNode, initializedNodes.get(1));
+		assertSame(testDiv.middleNode, initializedNodes.get(2));
+	}
+}


### PR DESCRIPTION
Allows for execution of an initialization callback as soon as a node obtains a transitive parent connection to the `DomBody`.
