### PR TITLE
PLAT-1074 Fix previews for PDFs with certain embedded JPEGs

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,6 +29,7 @@ project.ext {
 		guava: "31.1-jre",
 		h2: "2.1.214",
 		hikariCp: "5.0.1",
+		imageioJpeg: "3.8.2",
 		// optional dependency of pdfbox; enables rendering of jpeg2000-encoded embedded images
 		jaiImageioJpeg2000: "1.4.0",
 		jakartaActivation: "1.2.2",

--- a/platform-core-module/build.gradle
+++ b/platform-core-module/build.gradle
@@ -7,10 +7,13 @@ dependencies {
 	api "com.sun.mail:mailapi:$versions.sunMail"
 	api "com.sun.mail:smtp:$versions.sunMail"
 
-	implementation "com.github.jai-imageio:jai-imageio-jpeg2000:$versions.jaiImageioJpeg2000"
 	implementation "eu.agno3.jcifs:jcifs-ng:$versions.jcifsNg"
 	implementation "org.apache.commons:commons-lang3:$versions.commonsLang3"
 	implementation "org.apache.pdfbox:pdfbox:$versions.pdfbox"
+
+	// Used by pdfbox to render various embedded image formats
+	implementation "com.github.jai-imageio:jai-imageio-jpeg2000:$versions.jaiImageioJpeg2000"
+	implementation "com.twelvemonkeys.imageio:imageio-jpeg:$versions.imageioJpeg"
 }
 
 // configure Eclipse project to export all dependencies

--- a/platform-core-module/src/main/java/com/softicar/platform/core/module/component/external/license/rule/ExternalComponentLicensePredefinedRules.java
+++ b/platform-core-module/src/main/java/com/softicar/platform/core/module/component/external/license/rule/ExternalComponentLicensePredefinedRules.java
@@ -41,7 +41,7 @@ public class ExternalComponentLicensePredefinedRules {
 		// Artifact does not contain license information.
 		// License defined at:
 		// https://github.com/haraldk/TwelveMonkeys/blob/master/imageio/imageio-jpeg/license.txt
-		addLibrary("imageio-jpeg", ".*", License.BSD_3_CLAUSE);
+		addLibrary("imageio-(jpeg|metadata|core)", ".*", License.BSD_3_CLAUSE);
 
 		// Artifact does not contain license information.
 		// License defined at:

--- a/platform-core-module/src/main/java/com/softicar/platform/core/module/component/external/license/rule/ExternalComponentLicensePredefinedRules.java
+++ b/platform-core-module/src/main/java/com/softicar/platform/core/module/component/external/license/rule/ExternalComponentLicensePredefinedRules.java
@@ -40,6 +40,11 @@ public class ExternalComponentLicensePredefinedRules {
 
 		// Artifact does not contain license information.
 		// License defined at:
+		// https://github.com/haraldk/TwelveMonkeys/blob/master/imageio/imageio-jpeg/license.txt
+		addLibrary("imageio-jpeg", ".*", License.BSD_3_CLAUSE);
+
+		// Artifact does not contain license information.
+		// License defined at:
 		// https://github.com/jai-imageio/jai-imageio-jpeg2000/blob/master/LICENSE-JJ2000.txt
 		addLibrary("jai-imageio-jpeg2000", ".*", License.JJ_2000);
 

--- a/platform-core-module/src/main/java/com/softicar/platform/core/module/component/external/license/rule/ExternalComponentLicensePredefinedRules.java
+++ b/platform-core-module/src/main/java/com/softicar/platform/core/module/component/external/license/rule/ExternalComponentLicensePredefinedRules.java
@@ -30,6 +30,11 @@ public class ExternalComponentLicensePredefinedRules {
 
 		// Artifact does not contain license information.
 		// License defined at:
+		// https://github.com/haraldk/TwelveMonkeys/blob/master/LICENSE.txt
+		addLibrary("common-(lang|io|image)", ".*", License.BSD_3_CLAUSE);
+
+		// Artifact does not contain license information.
+		// License defined at:
 		// https://github.com/google/guava/blob/master/COPYING
 		addLibrary("listenablefuture", ".*", License.APACHE_2_0);
 
@@ -40,7 +45,7 @@ public class ExternalComponentLicensePredefinedRules {
 
 		// Artifact does not contain license information.
 		// License defined at:
-		// https://github.com/haraldk/TwelveMonkeys/blob/master/imageio/imageio-jpeg/license.txt
+		// https://github.com/haraldk/TwelveMonkeys/blob/master/LICENSE.txt
 		addLibrary("imageio-(jpeg|metadata|core)", ".*", License.BSD_3_CLAUSE);
 
 		// Artifact does not contain license information.


### PR DESCRIPTION
- Added dependency on `imageio-jpeg`.
- Fixes "Numbers of source Raster bands and source color space components do not match" when trying to render certain JPEGs.
- See https://stackoverflow.com/questions/18351583/illegalargumentexception-numbers-of-source-raster-bands-and-source-color-space/18400559#18400559

![image](https://user-images.githubusercontent.com/15086658/184602272-5cf4ab63-02ab-47b4-970e-ba9437a82ce3.png)
