### PR TITLE
PLAT 1060 to v20

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,6 +27,8 @@ project.ext {
 		guava: "31.0.1-jre",
 		h2: "2.1.210",
 		hikariCp: "5.0.1",
+		// optional dependency of pdfbox; enables rendering of jpeg2000-encoded embedded images
+		jaiImageioJpeg2000: "1.4.0",
 		jakartaActivation: "1.2.2",
 		javaxServletApi: "4.0.1",
 		jcifsNg: "2.1.7",

--- a/platform-ajax/src/main/resources/com/softicar/platform/ajax/ajax-style.css
+++ b/platform-ajax/src/main/resources/com/softicar/platform/ajax/ajax-style.css
@@ -9,6 +9,7 @@
 	border-radius: var(--BORDER_RADIUS);
 	box-shadow: var(--BOX_SHADOW_OVERLAY);
 
+	color: var(--FONT_COLOR);
 	background-color: var(--INPUT_BACKGROUND_COLOR); 
 	overflow:hidden;
 	gap: 0;

--- a/platform-common-pdf/build.gradle
+++ b/platform-common-pdf/build.gradle
@@ -1,5 +1,6 @@
 dependencies {
 	api project(':platform-common')
 
+	implementation "com.github.jai-imageio:jai-imageio-jpeg2000:$versions.jaiImageioJpeg2000"
 	implementation "org.apache.pdfbox:pdfbox:$versions.pdfbox"
 }

--- a/platform-core-module/build.gradle
+++ b/platform-core-module/build.gradle
@@ -7,7 +7,8 @@ dependencies {
 	api "com.sun.mail:mailapi:$versions.sunMail"
 	api "com.sun.mail:smtp:$versions.sunMail"
 
-	implementation("eu.agno3.jcifs:jcifs-ng:$versions.jcifsNg")
+	implementation "com.github.jai-imageio:jai-imageio-jpeg2000:$versions.jaiImageioJpeg2000"
+	implementation "eu.agno3.jcifs:jcifs-ng:$versions.jcifsNg"
 	implementation "org.apache.commons:commons-lang3:$versions.commonsLang3"
 	implementation "org.apache.pdfbox:pdfbox:$versions.pdfbox"
 }

--- a/platform-core-module/src/main/java/com/softicar/platform/core/module/CoreI18n.java
+++ b/platform-core-module/src/main/java/com/softicar/platform/core/module/CoreI18n.java
@@ -545,6 +545,8 @@ public interface CoreI18n extends EmfI18n {
 		.de("Ausgabe");
 	I18n0 PAGE_DEFINITIONS = new I18n0("Page Definitions")//
 		.de("Seiten-Definitionen");
+	I18n0 PAGE_NOT_ACCESSIBLE = new I18n0("Page not accessible.")//
+		.de("Seite nicht zugreifbar.");
 	I18n0 PAGE_OVERVIEW = new I18n0("Page Overview")//
 		.de("Seiten-Übersicht");
 	I18n0 PANIC_RECEIVERS = new I18n0("Panic Receivers")//
@@ -688,6 +690,8 @@ public interface CoreI18n extends EmfI18n {
 		.de("Passwort zurücksetzen");
 	I18n1 RETURN_TO_USER_ARG1 = new I18n1("Return to user: %s")//
 		.de("Zurückkehren zu Benuter: %s");
+	I18n0 RETURNING_TO_START_PAGE = new I18n0("Returning to start page.")//
+		.de("Kehre zur Start-Seite zurück.");
 	I18n0 REVISION = new I18n0("Revision")//
 		.de("Revision");
 	I18n0 ROLE = new I18n0("Role")//

--- a/platform-core-module/src/main/java/com/softicar/platform/core/module/component/external/license/rule/ExternalComponentLicensePredefinedRules.java
+++ b/platform-core-module/src/main/java/com/softicar/platform/core/module/component/external/license/rule/ExternalComponentLicensePredefinedRules.java
@@ -40,6 +40,11 @@ public class ExternalComponentLicensePredefinedRules {
 
 		// Artifact does not contain license information.
 		// License defined at:
+		// https://github.com/jai-imageio/jai-imageio-jpeg2000/blob/master/LICENSE-JJ2000.txt
+		addLibrary("jai-imageio-jpeg2000", ".*", License.JJ_2000);
+
+		// Artifact does not contain license information.
+		// License defined at:
 		// https://github.com/AgNO3/jcifs-ng/blob/master/LICENSE
 		addLibrary("jcifs-ng", ".*", License.LGPL_2_1);
 

--- a/platform-core-module/src/main/java/com/softicar/platform/core/module/license/License.java
+++ b/platform-core-module/src/main/java/com/softicar/platform/core/module/license/License.java
@@ -14,6 +14,7 @@ public enum License {
 	CDDL_1_0("CDDL v1.0"),
 	EPL_1_0("EPL v1.0"),
 	EPL_2_0("EPL v2.0"),
+	JJ_2000("JJ2000"),
 	LGPL_2_1("LGPL v2.1"),
 	MIT("MIT"),
 	MIT_0("MIT-0"),

--- a/platform-core-module/src/main/java/com/softicar/platform/core/module/module/instance/actions/ModuleInstanceInitializationAction.java
+++ b/platform-core-module/src/main/java/com/softicar/platform/core/module/module/instance/actions/ModuleInstanceInitializationAction.java
@@ -9,6 +9,7 @@ import com.softicar.platform.core.module.module.IModule;
 import com.softicar.platform.core.module.module.instance.AGModuleInstance;
 import com.softicar.platform.core.module.module.instance.IModuleInstance;
 import com.softicar.platform.core.module.module.instance.ModuleInstancePredicates;
+import com.softicar.platform.dom.elements.popup.manager.DomPopupManager;
 import com.softicar.platform.emf.action.AbstractEmfButtonAction;
 import com.softicar.platform.emf.action.IEmfManagementAction;
 import com.softicar.platform.emf.form.IEmfFormBody;
@@ -61,7 +62,15 @@ public class ModuleInstanceInitializationAction extends AbstractEmfButtonAction<
 
 	private <I extends IModuleInstance<I>> void createInstanceAndShowPopup(IModule<I> standadModule, AGModuleInstance moduleInstance) {
 
+		DomPopupManager//
+			.getInstance()
+			.getPopup(moduleInstance, EmfFormPopup.class, dummy -> createPopup(standadModule, moduleInstance))
+			.open();
+	}
+
+	private <I extends IModuleInstance<I>> EmfFormPopup<I> createPopup(IModule<I> standadModule, AGModuleInstance moduleInstance) {
+
 		I newModuleInstance = standadModule.getModuleInstanceTable().createObject(moduleInstance);
-		new EmfFormPopup<>(newModuleInstance).open();
+		return new EmfFormPopup<>(newModuleInstance);
 	}
 }

--- a/platform-core-module/src/main/java/com/softicar/platform/core/module/module/instance/actions/ModuleInstanceInitializationAction.java
+++ b/platform-core-module/src/main/java/com/softicar/platform/core/module/module/instance/actions/ModuleInstanceInitializationAction.java
@@ -9,7 +9,6 @@ import com.softicar.platform.core.module.module.IModule;
 import com.softicar.platform.core.module.module.instance.AGModuleInstance;
 import com.softicar.platform.core.module.module.instance.IModuleInstance;
 import com.softicar.platform.core.module.module.instance.ModuleInstancePredicates;
-import com.softicar.platform.dom.elements.popup.manager.DomPopupManager;
 import com.softicar.platform.emf.action.AbstractEmfButtonAction;
 import com.softicar.platform.emf.action.IEmfManagementAction;
 import com.softicar.platform.emf.form.IEmfFormBody;
@@ -60,17 +59,9 @@ public class ModuleInstanceInitializationAction extends AbstractEmfButtonAction<
 		createInstanceAndShowPopup(moduleInstance.getModuleOrThrow(), moduleInstance);
 	}
 
-	private <I extends IModuleInstance<I>> void createInstanceAndShowPopup(IModule<I> standadModule, AGModuleInstance moduleInstance) {
+	private <I extends IModuleInstance<I>> void createInstanceAndShowPopup(IModule<I> module, AGModuleInstance moduleInstance) {
 
-		DomPopupManager//
-			.getInstance()
-			.getPopup(moduleInstance, EmfFormPopup.class, dummy -> createPopup(standadModule, moduleInstance))
-			.open();
-	}
-
-	private <I extends IModuleInstance<I>> EmfFormPopup<I> createPopup(IModule<I> standadModule, AGModuleInstance moduleInstance) {
-
-		I newModuleInstance = standadModule.getModuleInstanceTable().createObject(moduleInstance);
-		return new EmfFormPopup<>(newModuleInstance);
+		I newModuleInstance = module.getModuleInstanceTable().createObject(moduleInstance);
+		new EmfFormPopup<>(newModuleInstance).open();
 	}
 }

--- a/platform-core-module/src/main/java/com/softicar/platform/core/module/page/navigation/PageNavigationPageController.java
+++ b/platform-core-module/src/main/java/com/softicar/platform/core/module/page/navigation/PageNavigationPageController.java
@@ -1,12 +1,17 @@
 package com.softicar.platform.core.module.page.navigation;
 
+import com.softicar.platform.core.module.AGCoreModuleInstance;
+import com.softicar.platform.core.module.CoreI18n;
 import com.softicar.platform.core.module.page.PageHeaderAndContentDiv;
 import com.softicar.platform.core.module.page.navigation.link.PageNavigationLink;
 import com.softicar.platform.core.module.page.navigation.link.display.PageNavigationFolderDiv;
 import com.softicar.platform.core.module.page.navigation.link.display.PageNavigationPageLinkDiv;
 import com.softicar.platform.core.module.page.navigation.link.display.PageNavigationPageLinkDivMap;
+import com.softicar.platform.core.module.start.page.StartPage;
 import com.softicar.platform.dom.DomCssPseudoClasses;
+import com.softicar.platform.dom.elements.dialog.DomModalAlertDialog;
 import com.softicar.platform.emf.page.IEmfPage;
+import com.softicar.platform.emf.source.code.reference.point.EmfSourceCodeReferencePoints;
 import java.util.Optional;
 
 public class PageNavigationPageController {
@@ -33,7 +38,15 @@ public class PageNavigationPageController {
 
 	public void showPage(IEmfPage<?> page, Integer moduleInstanceId) {
 
-		pageLinkDivMap.getLinkDiv(page, moduleInstanceId).ifPresent(this::showPage);
+		pageLinkDivMap//
+			.getLinkDiv(page, moduleInstanceId)
+			.ifPresentOrElse(this::showPage, this::showStartPage);
+	}
+
+	private void showStartPage() {
+
+		showPage(EmfSourceCodeReferencePoints.getReferencePoint(StartPage.class), AGCoreModuleInstance.getInstance().getId());
+		new DomModalAlertDialog(CoreI18n.PAGE_NOT_ACCESSIBLE.concatSentence(CoreI18n.RETURNING_TO_START_PAGE)).open();
 	}
 
 	public void showPage(PageNavigationPageLinkDiv pageLinkDiv) {

--- a/platform-core-module/src/main/java/com/softicar/platform/core/module/program/execution/ProgramExecutionRunnable.java
+++ b/platform-core-module/src/main/java/com/softicar/platform/core/module/program/execution/ProgramExecutionRunnable.java
@@ -38,7 +38,7 @@ public class ProgramExecutionRunnable implements Runnable {
 			} finally {
 				updateOutputAndTerminatedAt();
 				if (failed) {
-					new SystemEventBuilder(AGSystemEventSeverityEnum.WARNING, CoreI18n.PROGRAM_EXECUTION_FAILED.toString())//
+					new SystemEventBuilder(AGSystemEventSeverityEnum.ERROR, CoreI18n.PROGRAM_EXECUTION_FAILED.toString())//
 						.addProperty("program", Programs.getProgramName(getProgramUuid()).toString())
 						.save();
 				}

--- a/platform-dom/src/main/java/com/softicar/platform/dom/elements/button/popup/DomPopupButton.java
+++ b/platform-dom/src/main/java/com/softicar/platform/dom/elements/button/popup/DomPopupButton.java
@@ -14,8 +14,9 @@ import java.util.function.Supplier;
 public class DomPopupButton extends DomButton {
 
 	private DomPopup popup;
-	private INullaryVoidFunction callbackBeforeOpen = INullaryVoidFunction.NO_OPERATION;
-	private INullaryVoidFunction callbackAfterOpen = INullaryVoidFunction.NO_OPERATION;
+	private boolean retainOpen;
+	private INullaryVoidFunction callbackBeforeOpen;
+	private INullaryVoidFunction callbackAfterOpen;
 
 	/**
 	 * Constructs a new {@link DomPopupButton}.
@@ -26,6 +27,9 @@ public class DomPopupButton extends DomButton {
 	public DomPopupButton() {
 
 		this.popup = null;
+		this.retainOpen = true;
+		this.callbackBeforeOpen = INullaryVoidFunction.NO_OPERATION;
+		this.callbackAfterOpen = INullaryVoidFunction.NO_OPERATION;
 	}
 
 	/**
@@ -71,15 +75,30 @@ public class DomPopupButton extends DomButton {
 		return this;
 	}
 
+	/**
+	 * Specifies whether an already-open {@link DomPopup} shall be retained if
+	 * this {@link DomPopupButton} is clicked again.
+	 *
+	 * @param retainOpen
+	 *            <i>true</i> if the {@link DomPopup} shall be retained on
+	 *            click; <i>false</i> if an additional {@link DomPopup} shall be
+	 *            opened on click
+	 * @return this {@link DomPopupButton}
+	 */
+	public DomPopupButton setRetainOpen(boolean retainOpen) {
+
+		this.retainOpen = retainOpen;
+		return this;
+	}
+
 	private void openPopup(Supplier<DomPopup> popupFactory) {
 
-		boolean alreadyOpen = isOpen();
-		if (!alreadyOpen) {
+		if (isOpen() && retainOpen) {
+			popup.open();
+		} else {
 			popup = popupFactory.get();
 			callbackBeforeOpen.apply();
-		}
-		popup.open();
-		if (!alreadyOpen) {
+			popup.open();
 			callbackAfterOpen.apply();
 		}
 	}

--- a/platform-dom/src/main/java/com/softicar/platform/dom/elements/input/auto/entity/DomAutoCompleteEntityInMemoryInputEngine.java
+++ b/platform-dom/src/main/java/com/softicar/platform/dom/elements/input/auto/entity/DomAutoCompleteEntityInMemoryInputEngine.java
@@ -48,6 +48,12 @@ public class DomAutoCompleteEntityInMemoryInputEngine<T extends IEntity> extends
 		cache.invalidate();
 	}
 
+	public void refreshCache() {
+
+		cache.invalidate();
+		cache.get();
+	}
+
 	@Override
 	public T getById(Integer id) {
 

--- a/platform-dom/src/test/java/com/softicar/platform/dom/elements/button/popup/DomPopupButtonTest.java
+++ b/platform-dom/src/test/java/com/softicar/platform/dom/elements/button/popup/DomPopupButtonTest.java
@@ -14,6 +14,7 @@ import com.softicar.platform.dom.elements.testing.engine.document.DomDocumentTes
 import com.softicar.platform.dom.elements.testing.node.tester.DomNodeTester;
 import com.softicar.platform.dom.input.DomTextInput;
 import com.softicar.platform.dom.node.IDomNode;
+import java.util.List;
 import org.junit.Rule;
 import org.junit.Test;
 import org.mockito.Mockito;
@@ -93,6 +94,27 @@ public class DomPopupButtonTest extends AbstractTest implements IDomTestExecutio
 		assertEquals("foo", findTextInput().getInputValue());
 		callbackBeforeOpen.assertCalled(1);
 		callbackAfterOpen.assertCalled(1);
+	}
+
+	@Test
+	public void testOpenAndOpenWithRetainOpenFalse() {
+
+		button.setPopupFactory(TestPopup::new);
+		button.setCallbackBeforeOpen(callbackBeforeOpen);
+		button.setCallbackAfterOpen(callbackAfterOpen);
+		button.setRetainOpen(false);
+		openPopup();
+		findTextInput().setInputValue("foo");
+
+		openPopup();
+
+		List<DomNodeTester> popups = assertPopupsPresent(2);
+
+		// Ensure that the input value was retained.
+		assertEquals("foo", popups.get(0).findInput(TEXT_INPUT).getInputValue());
+		assertEquals("", popups.get(1).findInput(TEXT_INPUT).getInputValue());
+		callbackBeforeOpen.assertCalled(2);
+		callbackAfterOpen.assertCalled(2);
 	}
 
 	@Test
@@ -184,6 +206,11 @@ public class DomPopupButtonTest extends AbstractTest implements IDomTestExecutio
 	private DomNodeTester assertPopupPresent() {
 
 		return findNodes(POPUP).assertOne();
+	}
+
+	private List<DomNodeTester> assertPopupsPresent(int size) {
+
+		return findNodes(POPUP).assertSize(size);
 	}
 
 	private DomNodeTester assertOtherPopupPresent() {

--- a/platform-emf/src/main/java/com/softicar/platform/emf/attribute/field/foreign/entity/input/engine/AbstractEmfDependentAutoCompleteInputEngine.java
+++ b/platform-emf/src/main/java/com/softicar/platform/emf/attribute/field/foreign/entity/input/engine/AbstractEmfDependentAutoCompleteInputEngine.java
@@ -65,7 +65,7 @@ public abstract class AbstractEmfDependentAutoCompleteInputEngine<I extends IEnt
 	public void refresh() {
 
 		filters.forEach(IDomAutoCompleteInputFilter::refresh);
-		invalidateCache();
+		refreshCache();
 	}
 
 	@Override

--- a/platform-emf/src/main/java/com/softicar/platform/emf/attribute/transients/EmfTransientAttributeDisplay.java
+++ b/platform-emf/src/main/java/com/softicar/platform/emf/attribute/transients/EmfTransientAttributeDisplay.java
@@ -1,5 +1,6 @@
 package com.softicar.platform.emf.attribute.transients;
 
+import com.softicar.platform.common.core.i18n.IDisplayable;
 import com.softicar.platform.common.core.number.formatter.BigDecimalFormatter;
 import com.softicar.platform.dom.elements.DomDiv;
 import java.math.BigDecimal;
@@ -15,6 +16,8 @@ public class EmfTransientAttributeDisplay<V> extends DomDiv {
 				appendText(new BigDecimalFormatter().format((Double) value));
 			} else if (value instanceof Float) {
 				appendText(new BigDecimalFormatter().format((Float) value));
+			} else if (value instanceof IDisplayable) {
+				appendText(((IDisplayable) value).toDisplay());
 			} else {
 				appendText(value.toString());
 			}

--- a/platform-emf/src/main/java/com/softicar/platform/emf/management/EmfManagementDiv.java
+++ b/platform-emf/src/main/java/com/softicar/platform/emf/management/EmfManagementDiv.java
@@ -184,6 +184,7 @@ public class EmfManagementDiv<R extends IEmfTableRow<R, P>, P, S> extends DomDiv
 			appendChild(
 				new DomPopupButton()//
 					.setPopupFactory(() -> createNewEntityPopup())
+					.setRetainOpen(false)
 					.setIcon(EmfImages.ENTITY_CREATE.getResource())
 					.setLabel(EmfI18n.CREATE)
 					.addMarker(EmfManagementMarker.CREATE_BUTTON)

--- a/platform-emf/src/test/java/com/softicar/platform/emf/attribute/transients/EmfTransientAttributeDisplayTest.java
+++ b/platform-emf/src/test/java/com/softicar/platform/emf/attribute/transients/EmfTransientAttributeDisplayTest.java
@@ -1,0 +1,73 @@
+package com.softicar.platform.emf.attribute.transients;
+
+import com.softicar.platform.common.core.locale.CurrentLocale;
+import com.softicar.platform.common.core.locale.Locale;
+import com.softicar.platform.common.date.Day;
+import com.softicar.platform.common.date.DayTime;
+import com.softicar.platform.dom.elements.DomDiv;
+import com.softicar.platform.emf.AbstractEmfTest;
+import java.math.BigDecimal;
+import org.junit.Test;
+
+public class EmfTransientAttributeDisplayTest extends AbstractEmfTest {
+
+	private final DomDiv testDiv;
+
+	public EmfTransientAttributeDisplayTest() {
+
+		this.testDiv = new DomDiv();
+
+		setNode(testDiv);
+
+		var locale = new Locale()//
+			.setDecimalSeparator(",")
+			.setDigitGroupSeparator("'")
+			.setDateFormat("dd.MM.yyyy");
+		CurrentLocale.set(locale);
+	}
+
+	@Test
+	public void testWithBigDecimal() {
+
+		testDiv.appendChild(new EmfTransientAttributeDisplay<>(new BigDecimal("12345.678")));
+
+		assertText("12'345,678");
+	}
+
+	@Test
+	public void testWithDouble() {
+
+		testDiv.appendChild(new EmfTransientAttributeDisplay<>(12345.125));
+
+		assertText("12'345,125");
+	}
+
+	@Test
+	public void testWithFloat() {
+
+		testDiv.appendChild(new EmfTransientAttributeDisplay<>(12345.25f));
+
+		assertText("12'345,25");
+	}
+
+	@Test
+	public void testWithDay() {
+
+		testDiv.appendChild(new EmfTransientAttributeDisplay<>(Day.fromYMD(2022, 8, 1)));
+
+		assertText("01.08.2022");
+	}
+
+	@Test
+	public void testWithDayTime() {
+
+		testDiv.appendChild(new EmfTransientAttributeDisplay<>(DayTime.fromYMD_HMS(2022, 8, 1, 11, 2, 5)));
+
+		assertText("01.08.2022 11:02:05");
+	}
+
+	private void assertText(String expectedText) {
+
+		assertEquals(expectedText, findBody().getAllTextInDocument("|"));
+	}
+}


### PR DESCRIPTION
- PLAT-998 EmfManagementDiv: Always spawn a new popup when 'create' is clicked (#348) (#354)
- PLAT-1003 Failing Program Executions Are Now Errors Not Warnings (#340) (#356)
- PLAT-999 Fix Handling of not-accessible Page-Parameters (#344) (#357)
- PLAT-1000 Fix duplicatable popups in Module Instances page (#346) (#358)
- PLAT-1001 Eagerly refresh the cache when refreshing an input engine (#350) (#359)
- PLAT-1007 Fix font color in auto-complete popover if input is in error state (#352) (#360)
- PLAT-1021 Ensure that 'initialize module instance' popup remains accessible (#361) (#362)
- PLAT-989 PDF previews: Enable rendering of jpeg2000-encoded embedded images (#368) (#370)
- PLAT-1060 EmfTransientAttributeDisplay Now Respects Date Format (#410)
