### PR TITLE
PLAT-1136-2 Implement setPreventDefaultOnWheel

### DIFF
--- a/platform-ajax/src/main/java/com/softicar/platform/ajax/engine/AjaxDomEngine.java
+++ b/platform-ajax/src/main/java/com/softicar/platform/ajax/engine/AjaxDomEngine.java
@@ -26,6 +26,7 @@ import com.softicar.platform.dom.engine.IDomEngine;
 import com.softicar.platform.dom.engine.IDomExport;
 import com.softicar.platform.dom.engine.IDomScriptLibrary;
 import com.softicar.platform.dom.event.DomEventType;
+import com.softicar.platform.dom.event.DomModifier;
 import com.softicar.platform.dom.event.IDomAutoEventHandler;
 import com.softicar.platform.dom.event.IDomDropEventHandler;
 import com.softicar.platform.dom.event.IDomEventHandler;
@@ -286,6 +287,12 @@ public class AjaxDomEngine implements IDomEngine {
 	public void setPreventDefaultOnMouseDown(IDomNode node, boolean enabled) {
 
 		JS_call("setPreventDefaultOnMouseDown", node, enabled);
+	}
+
+	@Override
+	public void setPreventDefaultOnWheel(IDomNode node, Set<DomModifier> modifiers, boolean enabled) {
+
+		JS_call("setPreventDefaultOnWheel", node, modifiers, enabled);
 	}
 
 	@Override

--- a/platform-ajax/src/main/typescript/com/softicar/platform/ajax/engine/Constants.ts
+++ b/platform-ajax/src/main/typescript/com/softicar/platform/ajax/engine/Constants.ts
@@ -7,6 +7,11 @@ const AJAX_REQUEST_DOM_EVENT       = 6;
 const AJAX_REQUEST_DRAG_AND_DROP   = 7;
 const AJAX_REQUEST_UPLOAD          = 8;
 
+const DOM_MODIFIER_ALT = 'Alt';
+const DOM_MODIFIER_CONTROL = 'Control';
+const DOM_MODIFIER_META = 'Meta';
+const DOM_MODIFIER_SHIFT = 'Shift';
+
 const DOM_VK_TAB    = 9;
 const DOM_VK_ENTER  = 13;
 const DOM_VK_ESCAPE = 27;

--- a/platform-ajax/src/main/typescript/com/softicar/platform/ajax/engine/event/DomEvent.ts
+++ b/platform-ajax/src/main/typescript/com/softicar/platform/ajax/engine/event/DomEvent.ts
@@ -21,13 +21,17 @@ function listenToDomEvent(nodeId: number, event: string, doListen: boolean) {
 	case 'KEYUP':       KEYBOARD_EVENT_MANAGER.setListenToKeyUp(element, doListen); break;
 	case 'SPACE':       KEYBOARD_EVENT_MANAGER.setListenToKey(element, event, doListen); break;
 	case 'TAB':         KEYBOARD_EVENT_MANAGER.setListenToKey(element, event, doListen); break;
-	case 'WHEEL':       element.onwheel = handler; break;
-	default: alert('Unknown event ' + event + '.');
+	case 'WHEEL':       WHEEL_EVENT_MANAGER.setListenToWheel(element, doListen); break;
+	default: alert('Unknown event: ' + event);
 	}
 }
 
 function setPreventDefaultOnMouseDown(element: HTMLElement, enabled: boolean) {
 	element.onmousedown = enabled? (event) => event.preventDefault() : null;
+}
+
+function setPreventDefaultOnWheel(element: HTMLElement, modifiers: string[], enabled: boolean) {
+	WHEEL_EVENT_MANAGER.setPreventDefaultBehavior(element, new Set(modifiers), enabled);
 }
 
 function setListenToKeys(element: HTMLElement, keys: string[]) {

--- a/platform-ajax/src/main/typescript/com/softicar/platform/ajax/engine/event/DomKeyboardEvents.ts
+++ b/platform-ajax/src/main/typescript/com/softicar/platform/ajax/engine/event/DomKeyboardEvents.ts
@@ -76,7 +76,7 @@ class KeyboardEventHandler {
 			this.node.onkeydown = event => this.handleKeyDown(event);
 			this.node.onkeyup = event => this.handleKeyUp(event);
 		} else {
-			console.log('Warning: Skipped installation of keyboard event listeners.');
+			console.log('Warning: Skipped installation of a keyboard event listener.');
 		}
 		return this;
 	}

--- a/platform-ajax/src/main/typescript/com/softicar/platform/ajax/engine/event/DomWheelEvents.ts
+++ b/platform-ajax/src/main/typescript/com/softicar/platform/ajax/engine/event/DomWheelEvents.ts
@@ -1,0 +1,67 @@
+
+class WheelEventManager {
+	private readonly handlers = new Map<string, WheelEventHandler>();
+
+	public setListenToWheel(node: HTMLElement, enabled: boolean) {
+		this.getHandler(node).setListenToWheel(enabled);
+	}
+
+	public setPreventDefaultBehavior(node: HTMLElement, modifiers: Set<string>, enabled: boolean) {
+		this.getHandler(node).setPreventDefault(modifiers, enabled);
+	}
+
+	private getHandler(node: HTMLElement) {
+		let handler = this.handlers.get(node.id);
+		if(!handler) {
+			handler = new WheelEventHandler(node).install();
+			this.handlers.set(node.id, handler);
+		}
+		return handler;
+	}
+}
+
+const WHEEL_EVENT_MANAGER = new WheelEventManager();
+
+class WheelEventHandler {
+	private readonly node;
+	private readonly preventDefault = new Map<string, boolean>();
+	private listenToWheel = false;
+
+	public constructor(node: HTMLElement) {
+		this.node = node;
+	}
+
+	public install() {
+		if(!this.node.onwheel) {
+			this.node.onwheel = event => this.handleWheel(event);
+		} else {
+			console.log('Warning: Skipped installation of a wheel event listener.');
+		}
+		return this;
+	}
+
+	public setListenToWheel(enabled: boolean) {
+		this.listenToWheel = enabled;
+	}
+
+	public setPreventDefault(modifiers: Set<string>, enabled: boolean) {
+		this.preventDefault.set(JSON.stringify(Array.from(modifiers)), enabled);
+	}
+
+	private handleWheel(event: WheelEvent) {
+		let modifiers = new Set<string>();
+		if(event.altKey) modifiers.add(DOM_MODIFIER_ALT);
+		if(event.ctrlKey) modifiers.add(DOM_MODIFIER_CONTROL);
+		if(event.metaKey) modifiers.add(DOM_MODIFIER_META);
+		if(event.shiftKey) modifiers.add(DOM_MODIFIER_SHIFT);
+
+		if(this.listenToWheel) {
+			handleDomEvent(event);
+		}
+
+		if(this.preventDefault.get(JSON.stringify(Array.from(modifiers)))) {
+			event.stopPropagation();
+			event.preventDefault();
+		}
+	}
+}

--- a/platform-dom/src/main/java/com/softicar/platform/dom/engine/DomNullEngine.java
+++ b/platform-dom/src/main/java/com/softicar/platform/dom/engine/DomNullEngine.java
@@ -10,6 +10,7 @@ import com.softicar.platform.dom.elements.DomForm;
 import com.softicar.platform.dom.elements.DomLink.Relationship;
 import com.softicar.platform.dom.elements.popup.IDomPopupFrame;
 import com.softicar.platform.dom.event.DomEventType;
+import com.softicar.platform.dom.event.DomModifier;
 import com.softicar.platform.dom.event.timeout.IDomTimeoutNode;
 import com.softicar.platform.dom.input.DomOption;
 import com.softicar.platform.dom.input.DomSelect;
@@ -18,6 +19,7 @@ import com.softicar.platform.dom.node.IDomNode;
 import com.softicar.platform.dom.style.ICssClass;
 import java.util.Collection;
 import java.util.Optional;
+import java.util.Set;
 
 /**
  * This is implementation of {@link IDomEngine} simply ignores all requests.
@@ -232,6 +234,12 @@ public class DomNullEngine implements IDomEngine {
 
 	@Override
 	public void setPreventDefaultOnMouseDown(IDomNode node, boolean enabled) {
+
+		// nothing to do
+	}
+
+	@Override
+	public void setPreventDefaultOnWheel(IDomNode node, Set<DomModifier> modifiers, boolean enabled) {
 
 		// nothing to do
 	}

--- a/platform-dom/src/main/java/com/softicar/platform/dom/engine/IDomEngine.java
+++ b/platform-dom/src/main/java/com/softicar/platform/dom/engine/IDomEngine.java
@@ -14,6 +14,7 @@ import com.softicar.platform.dom.elements.popup.DomPopup;
 import com.softicar.platform.dom.elements.popup.IDomPopupFrame;
 import com.softicar.platform.dom.event.DomEventType;
 import com.softicar.platform.dom.event.DomKeys;
+import com.softicar.platform.dom.event.DomModifier;
 import com.softicar.platform.dom.event.timeout.IDomTimeoutNode;
 import com.softicar.platform.dom.input.DomOption;
 import com.softicar.platform.dom.input.DomSelect;
@@ -22,6 +23,7 @@ import com.softicar.platform.dom.node.IDomNode;
 import com.softicar.platform.dom.style.ICssClass;
 import java.util.Collection;
 import java.util.Optional;
+import java.util.Set;
 
 /**
  * This engine maps the manipulation of the {@link IDomDocument} to the actual
@@ -102,9 +104,59 @@ public interface IDomEngine {
 	 */
 	void setFireOnKeyUp(IDomNode node, DomEventType type, boolean enabled);
 
+	/**
+	 * Tells the client browser to not perform the default action if an event of
+	 * the given {@link DomEventType} occurs on the given {@link IDomNode}.
+	 *
+	 * @param node
+	 *            the {@link IDomNode} on which the event might occur (never
+	 *            <i>null</i>)
+	 * @param type
+	 *            the {@link DomEventType} of the event that might occur (never
+	 *            <i>null</i>)
+	 * @param enabled
+	 *            <i>true</i> if the default action shall be omitted;
+	 *            <i>false</i> otherwise
+	 */
 	void setPreventDefaultBehavior(IDomNode node, DomEventType type, boolean enabled);
 
+	/**
+	 * Tells the client browser to not perform the default action if a
+	 * mouse-down event occurs on the given {@link IDomNode}.
+	 *
+	 * @param node
+	 *            the {@link IDomNode} on which the event might occur (never
+	 *            <i>null</i>)
+	 * @param enabled
+	 *            <i>true</i> if the default action shall be omitted;
+	 *            <i>false</i> otherwise
+	 */
 	void setPreventDefaultOnMouseDown(IDomNode node, boolean enabled);
+
+	/**
+	 * Tells the client browser to not perform the default action if a mouse
+	 * wheel event occurs on the given {@link IDomNode} while the given
+	 * modifiers are pressed.
+	 * <p>
+	 * For instance, if this method is called with modifiers
+	 * {@link DomModifier#CONTROL} and {@link DomModifier#ALT}, the default
+	 * action is only omitted for mouse wheel events that occur while that
+	 * specific combination of modifiers is pressed.
+	 * <p>
+	 * If an empty set of modifiers is given, the default action is only omitted
+	 * while <b>no</b> modifiers are pressed.
+	 *
+	 * @param node
+	 *            the {@link IDomNode} on which the event might occur (never
+	 *            <i>null</i>)
+	 * @param modifiers
+	 *            the modifiers that are pressed while the event might occur
+	 *            (never <i>null</i>)
+	 * @param enabled
+	 *            <i>true</i> if the default action shall be omitted;
+	 *            <i>false</i> otherwise
+	 */
+	void setPreventDefaultOnWheel(IDomNode node, Set<DomModifier> modifiers, boolean enabled);
 
 	/**
 	 * Adds an event handler that stops propagation for the given

--- a/platform-dom/src/main/java/com/softicar/platform/dom/engine/IDomEngine.java
+++ b/platform-dom/src/main/java/com/softicar/platform/dom/engine/IDomEngine.java
@@ -107,6 +107,9 @@ public interface IDomEngine {
 	/**
 	 * Tells the client browser to not perform the default action if an event of
 	 * the given {@link DomEventType} occurs on the given {@link IDomNode}.
+	 * <p>
+	 * Only works for {@link DomEventType} instances that represent a key on a
+	 * keyboard, e.g. {@link DomEventType#SPACE}.
 	 *
 	 * @param node
 	 *            the {@link IDomNode} on which the event might occur (never

--- a/platform-dom/src/main/java/com/softicar/platform/dom/event/DomModifier.java
+++ b/platform-dom/src/main/java/com/softicar/platform/dom/event/DomModifier.java
@@ -7,8 +7,21 @@ package com.softicar.platform.dom.event;
  */
 public enum DomModifier {
 
-	ALT,
-	CONTROL,
-	META,
-	SHIFT
+	ALT("Alt"),
+	CONTROL("Control"),
+	META("Meta"),
+	SHIFT("Shift");
+
+	private final String javascriptName;
+
+	private DomModifier(String javascriptName) {
+
+		this.javascriptName = javascriptName;
+	}
+
+	@Override
+	public String toString() {
+
+		return javascriptName;
+	}
 }


### PR DESCRIPTION
We currently cannot write automated tests for this. We could try https://www.selenium.dev/documentation/webdriver/actions_api/wheel/ but that would require a switch to Chrome based Selenium nodes. So, this PR was only tested manually.

![Peek 2022-09-05 14-57](https://user-images.githubusercontent.com/15086658/188455761-c5b8fc37-4860-4e1a-b29e-f07a2f483eb4.gif)

There are 12 events in this GIF:
- 3x `WHEEL_DOWN` (default behavior allowed = scrolling)
- 3x `Shift + WHEEL_DOWN` (default behavior suppressed = NO scrolling)
- 3x `WHEEL_DOWN` (default behavior allowed = scrolling)
- 3x `Shift + WHEEL_DOWN` (default behavior suppressed = NO scrolling)

This is the wheel test element that can be seen in the GIF:
```
private class WheelTestDiv extends DomDiv implements IDomWheelEventHandler {

	public WheelTestDiv() {

		appendText("wheel me");
		setStyle(CssStyle.BACKGROUND_COLOR, "yellow");

		CurrentDomDocument.get().getEngine().setPreventDefaultOnWheel(this, Set.of(DomModifier.CONTROL), true);
	}

	@Override
	public void handleWheel(IDomEvent event) {

		if (event.getDeltaY() > 0) {
			appendChild(new DomDiv()).appendText("down");
			Sleep.sleep(500);
		} else if (event.getDeltaY() < 0) {
			appendChild(new DomDiv()).appendText("up");
			Sleep.sleep(500);
		}
	}
}
```
