### PR TITLE
PLAT-991-1 Fix context and coordinates of popups that are spawned from drag-and-drop file uploads

### DIFF
--- a/platform-ajax/src/main/java/com/softicar/platform/ajax/upload/AjaxUploadService.java
+++ b/platform-ajax/src/main/java/com/softicar/platform/ajax/upload/AjaxUploadService.java
@@ -2,7 +2,9 @@ package com.softicar.platform.ajax.upload;
 
 import com.softicar.platform.ajax.document.IAjaxDocument;
 import com.softicar.platform.ajax.document.service.AbstractAjaxDocumentActionService;
+import com.softicar.platform.ajax.event.AjaxDomEvent;
 import com.softicar.platform.ajax.request.IAjaxRequest;
+import com.softicar.platform.dom.document.DomDocumentEventScope;
 import com.softicar.platform.dom.event.upload.IDomFileUploadHandler;
 import com.softicar.platform.dom.node.IDomNode;
 
@@ -23,7 +25,10 @@ public class AjaxUploadService extends AbstractAjaxDocumentActionService {
 
 		setHiddenFrame(true);
 
-		executePayloadCodeOnNode(IDomFileUploadHandler.class, this::handleFileUploads);
+		var event = new AjaxDomEvent(document, message);
+		try (var scope = new DomDocumentEventScope(document, event)) {
+			executePayloadCodeOnNode(IDomFileUploadHandler.class, this::handleFileUploads);
+		}
 	}
 
 	private void handleFileUploads(IDomFileUploadHandler handler) {

--- a/platform-ajax/src/main/resources/com/softicar/platform/ajax/engine/TypeScriptGenerated.js
+++ b/platform-ajax/src/main/resources/com/softicar/platform/ajax/engine/TypeScriptGenerated.js
@@ -445,9 +445,13 @@ function handleTimeout(timeoutNode) {
     AJAX_REQUEST_QUEUE.submit(message);
 }
 function sendUploadRequestThroughForm(form) {
+    let formRect = form.getBoundingClientRect();
     let message = new AjaxRequestMessage()
         .setActionType(AJAX_REQUEST_UPLOAD)
-        .setNode(form);
+        .setNode(form)
+        .setMousePosition(new Vector2d(formRect.x, formRect.y))
+        .setWindowPageOffset(new Vector2d(window.pageXOffset, window.pageYOffset))
+        .setWindowInnerSize(new Vector2d(window.innerWidth, window.innerHeight));
     AJAX_REQUEST_QUEUE.submit(message, form);
 }
 class ValueNodeMap {

--- a/platform-ajax/src/main/typescript/com/softicar/platform/ajax/engine/Upload.ts
+++ b/platform-ajax/src/main/typescript/com/softicar/platform/ajax/engine/Upload.ts
@@ -2,8 +2,12 @@
  * Sends an AJAX upload request through the given form element.
  */
 function sendUploadRequestThroughForm(form: HTMLFormElement) {
+	let formRect = form.getBoundingClientRect();
 	let message = new AjaxRequestMessage()
 		.setActionType(AJAX_REQUEST_UPLOAD)
-		.setNode(form);
+		.setNode(form)
+		.setMousePosition(new Vector2d(formRect.x, formRect.y))
+		.setWindowPageOffset(new Vector2d(window.pageXOffset, window.pageYOffset))
+		.setWindowInnerSize(new Vector2d(window.innerWidth, window.innerHeight));
 	AJAX_REQUEST_QUEUE.submit(message, form);
 }

--- a/platform-core-module/src/main/java/com/softicar/platform/core/module/CoreCssClasses.java
+++ b/platform-core-module/src/main/java/com/softicar/platform/core/module/CoreCssClasses.java
@@ -5,6 +5,10 @@ import com.softicar.platform.dom.style.ICssClass;
 
 public interface CoreCssClasses {
 
+	ICssClass FILE_DROP_AREA_DIV = new CssClass("FileDropAreaDiv", CoreCssFiles.FILE_DROP_AREA_STYLE);
+	ICssClass FILE_DROP_AREA_DIV_HIDDEN = new CssClass("FileDropAreaDivHidden", CoreCssFiles.FILE_DROP_AREA_STYLE);
+	ICssClass FILE_DROP_AREA_DIV_CLOSE_BUTTON = new CssClass("FileDropAreaDivCloseButton", CoreCssFiles.FILE_DROP_AREA_STYLE);
+
 	ICssClass MAINTENANCE_WINDOWS_INFO_ELEMENT = new CssClass("MaintenanceWindowsInfoElement", CoreCssFiles.MAINTENANCE_WINDOW_STYLE);
 
 	ICssClass PAGE_CONTENT_DIV = new CssClass("PageContentDiv", CoreCssFiles.PAGE_STYLE);

--- a/platform-core-module/src/main/java/com/softicar/platform/core/module/CoreCssFiles.java
+++ b/platform-core-module/src/main/java/com/softicar/platform/core/module/CoreCssFiles.java
@@ -11,6 +11,7 @@ public interface CoreCssFiles {
 
 	IResourceSupplierFactory FACTORY = new DomResourceSupplierProxyFactory(CoreCssFiles.class, Charsets.UTF8);
 
+	IResourceSupplier FILE_DROP_AREA_STYLE = FACTORY.create("file-drop-area-style.css");
 	IResourceSupplier MAINTENANCE_WINDOW_STYLE = FACTORY.create("maintenance-window-style.css");
 	IResourceSupplier PAGE_NAVIGATION_STYLE = FACTORY.create("page-navigation-style.css");
 	IResourceSupplier PAGE_STYLE = FACTORY.create("page-style.css");

--- a/platform-core-module/src/main/java/com/softicar/platform/core/module/CoreI18n.java
+++ b/platform-core-module/src/main/java/com/softicar/platform/core/module/CoreI18n.java
@@ -142,6 +142,10 @@ public interface CoreI18n extends EmfI18n {
 		.de("Klassenname");
 	I18n0 CLEANS_FILE_SERVERS_FROM_TEMPORARY_FILES = new I18n0("Cleans file servers from temporary files")//
 		.de("Bereinigt Dateiserver von temporären Dateien");
+	I18n0 CLICK_OR_DROP_FILE_HERE = new I18n0("Click or drop file here")//
+		.de("Hier klicken oder Datei ablegen");
+	I18n0 CLICK_OR_DROP_FILES_HERE = new I18n0("Click or drop files here")//
+		.de("Hier klicken oder Dateien ablegen");
 	I18n0 CLICK_TO_DELETE_THIS_PROCESS = new I18n0("Click to delete this process.")//
 		.de("Klicken, um diesen Prozess zu löschen.");
 	I18n1 CLICK_TO_DOWNLOAD_THE_FILE_ARG1 = new I18n1("Click to download the file: %s")//

--- a/platform-core-module/src/main/java/com/softicar/platform/core/module/file/upload/FileDropArea.java
+++ b/platform-core-module/src/main/java/com/softicar/platform/core/module/file/upload/FileDropArea.java
@@ -1,0 +1,141 @@
+package com.softicar.platform.core.module.file.upload;
+
+import com.softicar.platform.common.core.exceptions.SofticarUserException;
+import com.softicar.platform.common.core.i18n.IDisplayString;
+import com.softicar.platform.common.core.interfaces.Consumers;
+import com.softicar.platform.common.date.DayTime;
+import com.softicar.platform.common.io.mime.CustomMimeType;
+import com.softicar.platform.core.module.CoreCssClasses;
+import com.softicar.platform.core.module.CoreI18n;
+import com.softicar.platform.core.module.file.stored.AGStoredFile;
+import com.softicar.platform.core.module.file.stored.StoredFileBuilder;
+import com.softicar.platform.core.module.user.CurrentUser;
+import com.softicar.platform.db.core.transaction.DbTransaction;
+import com.softicar.platform.dom.DomImages;
+import com.softicar.platform.dom.elements.DomDiv;
+import com.softicar.platform.dom.elements.DomFileInput;
+import com.softicar.platform.dom.elements.DomForm;
+import com.softicar.platform.dom.elements.button.DomButton;
+import com.softicar.platform.dom.event.upload.IDomFileUpload;
+import com.softicar.platform.dom.event.upload.IDomFileUploadHandler;
+import com.softicar.platform.emf.EmfI18n;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Optional;
+import java.util.function.Consumer;
+
+public class FileDropArea extends DomForm implements IDomFileUploadHandler {
+
+	private final boolean multipleFiles;
+	private final boolean alwaysOpen;
+	private final DomDiv dropAreaDiv;
+	private final FileInput fileInput;
+	private Consumer<Collection<AGStoredFile>> callback;
+
+	public FileDropArea(IDisplayString label, boolean multipleFiles, boolean closable) {
+
+		this(label, multipleFiles, closable, false);
+	}
+
+	public FileDropArea(IDisplayString label, boolean multipleFiles, boolean closable, boolean alwaysOpen) {
+
+		super(true);
+
+		this.multipleFiles = multipleFiles;
+		this.alwaysOpen = alwaysOpen;
+		this.callback = Consumers.noOperation();
+
+		this.dropAreaDiv = appendChild(new DomDiv());
+		getDropAreaDiv().addCssClass(CoreCssClasses.FILE_DROP_AREA_DIV);
+		if (!alwaysOpen) {
+			getDropAreaDiv().addCssClass(CoreCssClasses.FILE_DROP_AREA_DIV_HIDDEN);
+			// TODO: do this properly
+			getDropAreaDiv()
+				.setAttribute(
+					"ondragenter",
+					"if(event.dataTransfer.types.indexOf('Files') != -1 || event.dataTransfer.types.contains('Files')) this.classList.remove('"
+							+ CoreCssClasses.FILE_DROP_AREA_DIV_HIDDEN.getName() + "')");
+		}
+		getDropAreaDiv()
+			.appendChild(
+				Optional
+					.ofNullable(label)
+					.orElse(
+						multipleFiles//
+								? CoreI18n.CLICK_OR_DROP_FILES_HERE
+								: CoreI18n.CLICK_OR_DROP_FILE_HERE));
+		this.fileInput = getDropAreaDiv().appendChild(new FileInput());
+		if (closable) {
+			getDropAreaDiv()
+				.appendChild(new DomButton())
+				.setIcon(DomImages.DIALOG_CLOSE.getResource())
+				.setClickCallback(() -> getDropAreaDiv().addCssClass(CoreCssClasses.FILE_DROP_AREA_DIV_HIDDEN))
+				.addCssClass(CoreCssClasses.FILE_DROP_AREA_DIV_CLOSE_BUTTON);
+		}
+	}
+
+	public FileDropArea setAfterDropCallback(Consumer<Collection<AGStoredFile>> callback) {
+
+		this.callback = callback;
+		return this;
+	}
+
+	@Override
+	public void handleFileUploads(Iterable<IDomFileUpload> fileUploads) {
+
+		if (!alwaysOpen) {
+			getDropAreaDiv().addCssClass(CoreCssClasses.FILE_DROP_AREA_DIV_HIDDEN);
+		}
+		if (fileUploads.iterator().hasNext()) {
+			Collection<AGStoredFile> files = saveFiles(fileUploads);
+			if (!multipleFiles && files.size() > 1) {
+				throw new SofticarUserException(EmfI18n.ONLY_ONE_SINGLE_FILE_MAY_BE_ATTACHED);
+			}
+			fileInput.setAttribute("value", ""); // FIXME: replace with proper method, once available
+			callback.accept(files);
+		}
+	}
+
+	private Collection<AGStoredFile> saveFiles(Iterable<IDomFileUpload> fileUploads) {
+
+		Collection<AGStoredFile> files = new ArrayList<>();
+		try (DbTransaction transaction = new DbTransaction()) {
+			for (IDomFileUpload upload: fileUploads) {
+				AGStoredFile file = new StoredFileBuilder()
+					.setContentType(new CustomMimeType(upload.getContentType()))
+					.setCreatedBy(CurrentUser.get())
+					.setFilename(upload.getFilename())
+					.setRemoveAt(DayTime.now().plusDays(1))
+					.build();
+
+				try (InputStream inputStream = upload.getStream()) {
+					file.uploadFileContent(inputStream);
+				} catch (IOException exception) {
+					throw new RuntimeException(exception);
+				}
+
+				files.add(file);
+			}
+			transaction.commit();
+		}
+		return files;
+	}
+
+	public DomDiv getDropAreaDiv() {
+
+		return dropAreaDiv;
+	}
+
+	private class FileInput extends DomFileInput {
+
+		public FileInput() {
+
+			addCssClass(CoreCssClasses.STORED_FILE_UPLOAD_INPUT);
+			setTabIndex(-1);
+			setMultiple(true);
+			setOnChangeHandler(() -> uploadFiles());
+		}
+	}
+}

--- a/platform-core-module/src/main/resources/com/softicar/platform/core/module/file-drop-area-style.css
+++ b/platform-core-module/src/main/resources/com/softicar/platform/core/module/file-drop-area-style.css
@@ -1,0 +1,36 @@
+.FileDropAreaDiv {
+	display: inline-grid;
+	position: absolute;
+	top: 20px;
+	left: 20px;
+	right: 20px;
+    padding: 4px;
+    min-height: 80px;
+	border: 4px dashed var(--INFO_BORDER_COLOR);
+    border-radius: var(--BORDER_RADIUS);
+    font-weight: var(--LABEL_FONT_WEIGHT);
+    color: var(--INFO_FONT_COLOR);
+    background-color: var(--INFO_BACKGROUND_COLOR);
+    justify-content: center;
+    align-content: center;
+    transition-duration: 0.2s;
+	opacity: 0.95;
+	z-index: 10;
+}
+
+.FileDropAreaDivHidden {
+	position: absolute;
+	opacity: 0;
+	z-index: 0;
+}
+
+.FileDropAreaDivHidden * {
+	display: none;
+}
+
+.FileDropAreaDivCloseButton {
+	z-index: 11;
+	position: absolute;
+	top: 4px;
+	right: 4px;
+}

--- a/platform-dom/src/main/java/com/softicar/platform/dom/document/AbstractDomDocument.java
+++ b/platform-dom/src/main/java/com/softicar/platform/dom/document/AbstractDomDocument.java
@@ -130,12 +130,6 @@ public abstract class AbstractDomDocument implements IDomDocument {
 	}
 
 	@Override
-	public void unsetCurrentEvent() {
-
-		this.currentEvent = null;
-	}
-
-	@Override
 	public IDomEvent getCurrentEvent() {
 
 		return currentEvent;

--- a/platform-dom/src/main/java/com/softicar/platform/dom/document/DomDocumentEventScope.java
+++ b/platform-dom/src/main/java/com/softicar/platform/dom/document/DomDocumentEventScope.java
@@ -1,0 +1,26 @@
+package com.softicar.platform.dom.document;
+
+import com.softicar.platform.dom.event.IDomEvent;
+import java.util.Objects;
+
+public class DomDocumentEventScope implements AutoCloseable {
+
+	private final IDomDocument document;
+	private final IDomEvent previousEvent;
+
+	public DomDocumentEventScope(IDomDocument document, IDomEvent event) {
+
+		Objects.requireNonNull(document);
+		Objects.requireNonNull(event);
+
+		this.document = document;
+		this.previousEvent = document.getCurrentEvent();
+		document.setCurrentEvent(event);
+	}
+
+	@Override
+	public void close() {
+
+		document.setCurrentEvent(previousEvent);
+	}
+}

--- a/platform-dom/src/main/java/com/softicar/platform/dom/document/IDomDocument.java
+++ b/platform-dom/src/main/java/com/softicar/platform/dom/document/IDomDocument.java
@@ -101,11 +101,6 @@ public interface IDomDocument extends IDomDocumentMarkerHolder {
 	void setCurrentEvent(IDomEvent event);
 
 	/**
-	 * Sets the current event to be undefined.
-	 */
-	void unsetCurrentEvent();
-
-	/**
 	 * Returns the current event.
 	 *
 	 * @return the current event object or <i>null</i>

--- a/platform-dom/src/main/java/com/softicar/platform/dom/event/DomEventHandlerNodeCaller.java
+++ b/platform-dom/src/main/java/com/softicar/platform/dom/event/DomEventHandlerNodeCaller.java
@@ -1,5 +1,6 @@
 package com.softicar.platform.dom.event;
 
+import com.softicar.platform.dom.document.DomDocumentEventScope;
 import com.softicar.platform.dom.node.IDomNode;
 import com.softicar.platform.dom.utils.DomPayloadCodeExecutor;
 import java.util.Objects;
@@ -20,9 +21,8 @@ public class DomEventHandlerNodeCaller {
 	public void call() {
 
 		var document = eventNode.getDomDocument();
-		document.setCurrentEvent(event);
 
-		try {
+		try (var scope = new DomDocumentEventScope(document, event)) {
 			executor.execute(() -> {
 				if (eventNode instanceof IDomEventHandler) {
 					((IDomEventHandler) eventNode).handleDOMEvent(event);
@@ -31,8 +31,6 @@ public class DomEventHandlerNodeCaller {
 				}
 				document.getDeferredInitializationController().handleAllAppended();
 			});
-		} finally {
-			document.unsetCurrentEvent();
 		}
 	}
 }


### PR DESCRIPTION
- Add `FileDropArea` from a payload project (blunt extraction; no refactoring).
- Create `DomDocumentEventScope`, and use it in `AjaxUploadService`.
- Set window geometry and fake event coordinates in `Upload.ts`.
  - Assumed that the top-left corner of the form is sensible (as in: better than nothing) as event coordinates.

![Peek 2022-09-29 15-28](https://user-images.githubusercontent.com/15086658/193046490-6646ca93-a1c1-49d4-ab63-fdc81abf58a1.gif)

