### PR TITLE
PLAT-1185 AjaxWaitingDivTest: Fix non-determinisms

### DIFF
--- a/platform-ajax/src/test/java/com/softicar/platform/ajax/waiting/div/AjaxWaitingDivTest.java
+++ b/platform-ajax/src/test/java/com/softicar/platform/ajax/waiting/div/AjaxWaitingDivTest.java
@@ -39,13 +39,12 @@ public class AjaxWaitingDivTest extends AbstractAjaxSeleniumLowLevelTest {
 		try (Locker locker = new Locker(lock)) {
 			click(button);
 			waitForSignal(eventHandlerStarted);
-			assertTrue(isWorkingIndicatorDisplayed());
+			waitUntil(() -> isWorkingIndicatorDisplayed());
 			waitingDivChecked.signal();
 		}
 
 		// postcondition: working indicator is hidden
-		waitForServer();
-		assertFalse(isWorkingIndicatorDisplayed());
+		waitUntil(() -> !isWorkingIndicatorDisplayed());
 	}
 
 	private boolean waitForSignal(Condition condition) {


### PR DESCRIPTION
- Assert waiting-indicator state with `FluentWait`.
- Do not test the thing with itself (i.e. avoid `waitForServer`).
