### PR TITLE
PLAT-1191 ProgramPage now requires CorePermissions.OPERATION

### DIFF
--- a/platform-core-module/src/main/java/com/softicar/platform/core/module/program/ProgramPage.java
+++ b/platform-core-module/src/main/java/com/softicar/platform/core/module/program/ProgramPage.java
@@ -30,7 +30,7 @@ public class ProgramPage extends AbstractEmfManagementPage<AGCoreModuleInstance>
 	@Override
 	public IEmfModulePermission<AGCoreModuleInstance> getRequiredPermission() {
 
-		return CorePermissions.ADMINISTRATION;
+		return CorePermissions.OPERATION;
 	}
 
 	@Override


### PR DESCRIPTION
Previously, `CorePermissions.ADMINISTRATION` was erroneously required.

A user which only has `CorePermissions.OPERATION` can now enqueue programs:
![image](https://user-images.githubusercontent.com/15086658/197158255-5134ad16-2ad5-4e7a-bdc9-0f3bd16e6a6a.png)
