### PR TITLE
PLAT-1200 Retain URL Debugging Parameters

### DIFF
--- a/platform-ajax/src/main/java/com/softicar/platform/ajax/request/AjaxRequest.java
+++ b/platform-ajax/src/main/java/com/softicar/platform/ajax/request/AjaxRequest.java
@@ -19,6 +19,8 @@ import javax.servlet.http.HttpSession;
  */
 public final class AjaxRequest implements IAjaxRequest {
 
+	public static final String DEBUG_PARAMETER = "debug";
+	public static final String VERBOSE_PARAMETER = "verbose";
 	private final AjaxFramework ajaxFramework;
 	private final HttpServletRequest httpRequest;
 	private final HttpServletResponse httpResponse;
@@ -92,13 +94,13 @@ public final class AjaxRequest implements IAjaxRequest {
 	@Override
 	public boolean isVerbose() {
 
-		return httpRequest.getParameter("verbose") != null && isAdministrative();
+		return httpRequest.getParameter(VERBOSE_PARAMETER) != null && isAdministrative();
 	}
 
 	@Override
 	public boolean isDebug() {
 
-		return httpRequest.getParameter("debug") != null && isAdministrative();
+		return httpRequest.getParameter(DEBUG_PARAMETER) != null && isAdministrative();
 	}
 
 	@Override

--- a/platform-ajax/src/main/java/com/softicar/platform/ajax/testing/selenium/AjaxSeleniumTestEnvironment.java
+++ b/platform-ajax/src/main/java/com/softicar/platform/ajax/testing/selenium/AjaxSeleniumTestEnvironment.java
@@ -2,11 +2,14 @@ package com.softicar.platform.ajax.testing.selenium;
 
 import com.softicar.platform.ajax.document.IAjaxDocument;
 import com.softicar.platform.ajax.testing.AjaxTestingServlet;
+import com.softicar.platform.common.network.url.UrlBuilder;
 import com.softicar.platform.common.web.servlet.HttpServletServer;
 import com.softicar.platform.common.web.servlet.HttpServletServerHandle;
 import com.softicar.platform.dom.document.CurrentDomDocument;
 import com.softicar.platform.dom.document.IDomDocument;
 import com.softicar.platform.dom.node.IDomNode;
+import java.util.Map;
+import java.util.TreeMap;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Supplier;
@@ -14,14 +17,21 @@ import java.util.function.Supplier;
 public class AjaxSeleniumTestEnvironment {
 
 	private final Consumer<String> urlConsumer;
+	private final Map<String, String> urlParameters;
 	private final AjaxTestingServlet servlet;
 	private HttpServletServerHandle serverHandle;
 
 	public AjaxSeleniumTestEnvironment(Consumer<String> urlConsumer) {
 
 		this.urlConsumer = urlConsumer;
+		this.urlParameters = new TreeMap<>();
 		this.servlet = new AjaxTestingServlet();
 		this.serverHandle = null;
+	}
+
+	public void setUrlParameter(String name, String value) {
+
+		urlParameters.put(name, value);
 	}
 
 	public <T extends IDomNode> T openTestNode(Supplier<T> factory) {
@@ -54,9 +64,15 @@ public class AjaxSeleniumTestEnvironment {
 		return serverHandle;
 	}
 
-	private static String getPageUrl(int port) {
+	private String getPageUrl(int port) {
 
-		return String.format("http://%s:%s/", AjaxSeleniumTestProperties.SERVER_IP.getValue(), port);
+		return new UrlBuilder()//
+			.setScheme("http")
+			.setDomainName(AjaxSeleniumTestProperties.SERVER_IP.getValue())
+			.setPort("" + port)
+			.addParameters(urlParameters)
+			.build()
+			.toString();
 	}
 
 	private static class BufferedFactory<T extends IDomNode> implements Function<IAjaxDocument, IDomNode> {

--- a/platform-ajax/src/main/java/com/softicar/platform/ajax/testing/selenium/engine/common/AbstractAjaxSeleniumTestEngine.java
+++ b/platform-ajax/src/main/java/com/softicar/platform/ajax/testing/selenium/engine/common/AbstractAjaxSeleniumTestEngine.java
@@ -53,6 +53,11 @@ public abstract class AbstractAjaxSeleniumTestEngine extends TestWatcher impleme
 		AjaxSeleniumGridController.getInstance().registerRuntimeShutdownHook();
 	}
 
+	public void setUrlParameter(String name, String value) {
+
+		testEnvironment.setUrlParameter(name, value);
+	}
+
 	@Override
 	public void waitForServer(Duration timeout) {
 

--- a/platform-ajax/src/main/java/com/softicar/platform/ajax/testing/selenium/engine/level/high/AjaxSeleniumTestExecutionEngine.java
+++ b/platform-ajax/src/main/java/com/softicar/platform/ajax/testing/selenium/engine/level/high/AjaxSeleniumTestExecutionEngine.java
@@ -18,9 +18,9 @@ import org.openqa.selenium.WebElement;
 import org.openqa.selenium.interactions.Actions;
 
 /**
- * An {@link IDomTestExecutionEngine} based upon the Selenium framework. Allows for the
- * definition and execution of high-level UI tests which mimic the interactions
- * and observations of a human user.
+ * An {@link IDomTestExecutionEngine} based upon the Selenium framework. Allows
+ * for the definition and execution of high-level UI tests which mimic the
+ * interactions and observations of a human user.
  * <p>
  * Uses a web server, and remote-controlled web browsers, which are started on
  * the machine that runs the tests. The web server is created on the fly, and
@@ -35,8 +35,9 @@ import org.openqa.selenium.interactions.Actions;
  * The engine extends {@link TestRule}, so that it can be added to a test class
  * as a JUnit4 {@link Rule}.
  * <p>
- * {@link DomDocumentTestExecutionEngine} and {@link AjaxSeleniumTestExecutionEngine} have
- * individual advantages and disadvantages, when compared with one another:
+ * {@link DomDocumentTestExecutionEngine} and
+ * {@link AjaxSeleniumTestExecutionEngine} have individual advantages and
+ * disadvantages, when compared with one another:
  *
  * <pre>
  * +------------------------+-------+-----------+

--- a/platform-common/src/main/java/com/softicar/platform/common/network/url/Url.java
+++ b/platform-common/src/main/java/com/softicar/platform/common/network/url/Url.java
@@ -98,14 +98,21 @@ public class Url {
 
 	private static String convertToQueryString(Entry<String, List<String>> parameter) {
 
-		List<String> values = parameter.getValue();
-		if (values.isEmpty()) {
-			return UrlCoding.encodeUtf8(parameter.getKey());
+		var encodedKey = UrlCoding.encodeUtf8(parameter.getKey());
+		var values = parameter.getValue();
+		if (isEmpty(values)) {
+			return encodedKey;
 		} else {
 			return values//
 				.stream()
-				.map(value -> UrlCoding.encodeUtf8(parameter.getKey()) + "=" + UrlCoding.encodeUtf8(value))
+				.map(UrlCoding::encodeUtf8)
+				.map(encodedValue -> encodedKey + "=" + encodedValue)
 				.collect(Collectors.joining("&"));
 		}
+	}
+
+	private static boolean isEmpty(List<String> values) {
+
+		return values.isEmpty() || values.size() == 1 && values.get(0).isEmpty();
 	}
 }

--- a/platform-core-module/src/main/java/com/softicar/platform/core/module/ajax/page/EmfPageConnectionProfiler.java
+++ b/platform-core-module/src/main/java/com/softicar/platform/core/module/ajax/page/EmfPageConnectionProfiler.java
@@ -16,7 +16,8 @@ import java.util.stream.Collectors;
 
 public class EmfPageConnectionProfiler extends DbConnectionProfiler {
 
-	private static final String PROFILER_PARAMETER = "profiler";
+	public static final String PROFILER_PARAMETER = "profiler";
+	public static final String STACKTRACE_PARAMETER = "stacktrace";
 	private static final int STACK_TRACE_START = 2;
 	private final int statementCount;
 	private final Integer stacktraceLength;
@@ -25,7 +26,7 @@ public class EmfPageConnectionProfiler extends DbConnectionProfiler {
 	public EmfPageConnectionProfiler(IAjaxDocumentParameters parameters) {
 
 		this.statementCount = parameters.getParameterOrNull(PROFILER_PARAMETER, IntegerParser::parse).orElse(20);
-		this.stacktraceLength = parameters.getParameterOrNull("stacktrace", it -> IntegerParser.parse(it).orElse(1000));
+		this.stacktraceLength = parameters.getParameterOrNull(STACKTRACE_PARAMETER, it -> IntegerParser.parse(it).orElse(1000));
 		this.executionCountPerStatementPerStacktrace = new HashMap<>();
 	}
 

--- a/platform-core-module/src/main/java/com/softicar/platform/core/module/page/PageUrlBuilder.java
+++ b/platform-core-module/src/main/java/com/softicar/platform/core/module/page/PageUrlBuilder.java
@@ -1,5 +1,7 @@
 package com.softicar.platform.core.module.page;
 
+import com.softicar.platform.ajax.document.AjaxDocument;
+import com.softicar.platform.ajax.document.IAjaxDocument;
 import com.softicar.platform.common.code.reference.point.SourceCodeReferencePoints;
 import com.softicar.platform.common.network.url.Url;
 import com.softicar.platform.core.module.page.navigation.entry.PageNavigationEntry;
@@ -7,23 +9,29 @@ import com.softicar.platform.core.module.page.service.PageServiceFactory;
 import com.softicar.platform.core.module.web.service.WebServiceUrlBuilder;
 import com.softicar.platform.emf.module.IEmfModuleInstance;
 import com.softicar.platform.emf.page.IEmfPage;
+import java.util.Collections;
+import java.util.Map;
 import java.util.Objects;
+import java.util.TreeMap;
 
 public class PageUrlBuilder<I extends IEmfModuleInstance<I>> {
 
 	private final IEmfPage<?> page;
 	private final I moduleInstance;
+	private final Map<String, String> debuggingParameters;
 
 	public PageUrlBuilder(PageNavigationEntry<I> linkEntry) {
 
 		this.page = Objects.requireNonNull(linkEntry.getPage());
 		this.moduleInstance = Objects.requireNonNull(linkEntry.getModuleInstance());
+		this.debuggingParameters = extractDebuggingParameters();
 	}
 
 	public PageUrlBuilder(Class<? extends IEmfPage<I>> pageClass, I moduleInstance) {
 
 		this.page = SourceCodeReferencePoints.getReferencePoint(pageClass);
 		this.moduleInstance = Objects.requireNonNull(moduleInstance);
+		this.debuggingParameters = Collections.emptyMap();
 	}
 
 	public Url build() {
@@ -31,6 +39,26 @@ public class PageUrlBuilder<I extends IEmfModuleInstance<I>> {
 		return new WebServiceUrlBuilder(PageServiceFactory.class)//
 			.addParameter(PageParameterParser.getPageParameter(), page.getAnnotatedUuid().toString())
 			.addParameter("moduleInstance", moduleInstance.getItemId().toString())
+			.addParameters(debuggingParameters)
 			.build();
+	}
+
+	private Map<String, String> extractDebuggingParameters() {
+
+		var map = new TreeMap<String, String>();
+		copyParameter("debug", map);
+		copyParameter("profiler", map);
+		copyParameter("stacktrace", map);
+		copyParameter("verbose", map);
+		return map;
+	}
+
+	private void copyParameter(String name, Map<String, String> map) {
+
+		AjaxDocument//
+			.getCurrentDocument()
+			.map(IAjaxDocument::getParameters)
+			.map(parameters -> parameters.getParameterOrNull(name))
+			.ifPresent(value -> map.put(name, value));
 	}
 }

--- a/platform-core-module/src/main/java/com/softicar/platform/core/module/page/PageUrlBuilder.java
+++ b/platform-core-module/src/main/java/com/softicar/platform/core/module/page/PageUrlBuilder.java
@@ -2,8 +2,10 @@ package com.softicar.platform.core.module.page;
 
 import com.softicar.platform.ajax.document.AjaxDocument;
 import com.softicar.platform.ajax.document.IAjaxDocument;
+import com.softicar.platform.ajax.request.AjaxRequest;
 import com.softicar.platform.common.code.reference.point.SourceCodeReferencePoints;
 import com.softicar.platform.common.network.url.Url;
+import com.softicar.platform.core.module.ajax.page.EmfPageConnectionProfiler;
 import com.softicar.platform.core.module.page.navigation.entry.PageNavigationEntry;
 import com.softicar.platform.core.module.page.service.PageServiceFactory;
 import com.softicar.platform.core.module.web.service.WebServiceUrlBuilder;
@@ -46,10 +48,10 @@ public class PageUrlBuilder<I extends IEmfModuleInstance<I>> {
 	private Map<String, String> extractDebuggingParameters() {
 
 		var map = new TreeMap<String, String>();
-		copyParameter("debug", map);
-		copyParameter("profiler", map);
-		copyParameter("stacktrace", map);
-		copyParameter("verbose", map);
+		copyParameter(AjaxRequest.DEBUG_PARAMETER, map);
+		copyParameter(AjaxRequest.VERBOSE_PARAMETER, map);
+		copyParameter(EmfPageConnectionProfiler.PROFILER_PARAMETER, map);
+		copyParameter(EmfPageConnectionProfiler.STACKTRACE_PARAMETER, map);
 		return map;
 	}
 

--- a/platform-core-module/src/test/java/com/softicar/platform/core/module/page/PageDivTest.java
+++ b/platform-core-module/src/test/java/com/softicar/platform/core/module/page/PageDivTest.java
@@ -1,11 +1,14 @@
 package com.softicar.platform.core.module.page;
 
+import com.softicar.platform.ajax.document.AjaxDocument;
 import com.softicar.platform.ajax.document.AjaxDocumentParameters;
+import com.softicar.platform.ajax.request.AjaxRequest;
 import com.softicar.platform.ajax.testing.selenium.engine.level.high.AjaxSeleniumTestExecutionEngine;
 import com.softicar.platform.common.code.reference.point.SourceCodeReferencePoints;
 import com.softicar.platform.core.module.AGCoreModuleInstance;
 import com.softicar.platform.core.module.CorePermissions;
 import com.softicar.platform.core.module.CoreTestMarker;
+import com.softicar.platform.core.module.ajax.page.EmfPageConnectionProfiler;
 import com.softicar.platform.core.module.ajax.session.reset.AjaxSessionPage;
 import com.softicar.platform.core.module.page.header.PageHeaderDiv;
 import com.softicar.platform.core.module.page.navigation.IPageNavigationTestMethods;
@@ -19,7 +22,6 @@ import com.softicar.platform.emf.page.IEmfPage;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
-import java.util.TreeMap;
 import java.util.UUID;
 import java.util.stream.Collectors;
 import org.junit.Ignore;
@@ -33,7 +35,7 @@ public class PageDivTest extends AbstractPageDivTest implements IPageNavigationT
 	public PageDivTest() {
 
 		insertPermissionAssignment(testUser, CorePermissions.ADMINISTRATION, AGCoreModuleInstance.getInstance());
-		setNodeSupplier(() -> new PageDiv(new AjaxDocumentParameters(new TreeMap<>())));
+		setNodeSupplier(() -> new PageDiv(AjaxDocument.getCurrentDocument().get().getParameters()));
 	}
 
 	@Override
@@ -80,6 +82,27 @@ public class PageDivTest extends AbstractPageDivTest implements IPageNavigationT
 		clickPageLink("Test Page");
 
 		assertTestPageIsShown();
+	}
+
+	@Test
+	public void testClickOnLinkEntryWithDebuggingParameters() {
+
+		var profiler = "13";
+		var stacktrace = "42";
+		engine.setUrlParameter(AjaxRequest.DEBUG_PARAMETER, "");
+		engine.setUrlParameter(AjaxRequest.VERBOSE_PARAMETER, "");
+		engine.setUrlParameter(EmfPageConnectionProfiler.PROFILER_PARAMETER, profiler);
+		engine.setUrlParameter(EmfPageConnectionProfiler.STACKTRACE_PARAMETER, stacktrace);
+
+		clickFolderLink("[System]");
+		clickFolderLink("Core");
+		clickPageLink("Test Page");
+
+		assertTestPageIsShown();
+		assertContains(AjaxRequest.DEBUG_PARAMETER, engine.getCurrentUrl());
+		assertContains(AjaxRequest.VERBOSE_PARAMETER, engine.getCurrentUrl());
+		assertContains(EmfPageConnectionProfiler.PROFILER_PARAMETER + "=" + profiler, engine.getCurrentUrl());
+		assertContains(EmfPageConnectionProfiler.STACKTRACE_PARAMETER + "=" + stacktrace, engine.getCurrentUrl());
 	}
 
 	@Test


### PR DESCRIPTION
- this is about the parameters `debug`, `profiler`, `stacktrace` and `verbose`
- without this change, only the initial page request will respect the mentioned debugging parameters which makes it impossible to debug/profile clicks on buttons, etc.