### PR TITLE
PLAT-1201 Explicit GC on Page Change

### DIFF
--- a/platform-core-module/src/main/java/com/softicar/platform/core/module/page/PageHeaderAndContentDiv.java
+++ b/platform-core-module/src/main/java/com/softicar/platform/core/module/page/PageHeaderAndContentDiv.java
@@ -32,10 +32,10 @@ public class PageHeaderAndContentDiv extends DomDiv {
 
 		removeChildren();
 		CurrentDomPopupCompositor.get().closeAll();
-
 		CurrentDomDocument.get().getDeferredInitializationController().clear();
-
 		DbTableRowCaches.invalidateAll();
+		System.gc();
+
 		CurrentLocale.set(CurrentUser.get().getLocale());
 
 		changeBrowserUrl(linkEntry);


### PR DESCRIPTION
- this is a quick fix to prevent dangling refresh bus listeners to pile up, degrading performance
- we can consider to remove this quick fix later