### PR TITLE
PLAT-1196-2 Discard premature refresh bus events

### DIFF
--- a/platform-demo/src/test/java/com/softicar/platform/demo/invoice/module/invoice/stale/StaleDemoInvoiceRefreshTest.java
+++ b/platform-demo/src/test/java/com/softicar/platform/demo/invoice/module/invoice/stale/StaleDemoInvoiceRefreshTest.java
@@ -7,7 +7,6 @@ import com.softicar.platform.core.module.user.CurrentUser;
 import com.softicar.platform.demo.invoice.module.AbstractDemoInvoiceModuleTest;
 import com.softicar.platform.demo.invoice.module.invoice.AGDemoInvoice;
 import com.softicar.platform.demo.invoice.module.type.AGDemoInvoiceTypeEnum;
-import com.softicar.platform.dom.document.CurrentDomDocument;
 import com.softicar.platform.dom.elements.testing.node.tester.DomNodeTester;
 import com.softicar.platform.emf.EmfTestMarker;
 import com.softicar.platform.emf.management.EmfManagementDivBuilder;
@@ -32,8 +31,6 @@ public class StaleDemoInvoiceRefreshTest extends AbstractDemoInvoiceModuleTest {
 	@Test
 	public void testViewActionFromManagementDivWithStaleInvoice() {
 
-		CurrentDomDocument.get().getRefreshBus().discardEvent();
-
 		ensurePageIsShown();
 		modifyInvoiceConcurrently();
 
@@ -45,8 +42,6 @@ public class StaleDemoInvoiceRefreshTest extends AbstractDemoInvoiceModuleTest {
 
 	@Test
 	public void testEditActionFromManagementDivWithStaleInvoice() {
-
-		CurrentDomDocument.get().getRefreshBus().discardEvent();
 
 		ensurePageIsShown();
 		modifyInvoiceConcurrently();

--- a/platform-dom/src/main/java/com/softicar/platform/dom/elements/testing/engine/AbstractDomTestExecutionEngineLazySetup.java
+++ b/platform-dom/src/main/java/com/softicar/platform/dom/elements/testing/engine/AbstractDomTestExecutionEngineLazySetup.java
@@ -64,10 +64,20 @@ public abstract class AbstractDomTestExecutionEngineLazySetup implements IDomTes
 	private void initializeNode() {
 
 		if (node == null) {
+			// Discard all refresh bus events that predate the creation of the node-under-test.
+			flushRefreshBus();
+
+			// Create the node-under-test.
 			this.node = createNode();
+
 			// Explicitly perform deferred initialization for appended nodes, because we have no DOM event that would have triggered this automatically.
 			CurrentDomDocument.get().getDeferredInitializationController().handleAllAppended();
 		}
+	}
+
+	private void flushRefreshBus() {
+
+		CurrentDomDocument.get().getRefreshBus().discardEvent();
 	}
 
 	private IDomNode createNode() {


### PR DESCRIPTION
Once again discard refresh bus events that predate the creation of the node-under-test.
