### PR TITLE
PLAT-1204 Let CoreModuleTestFixture implement IModuleTestFixture

### DIFF
--- a/platform-core-module/src/main/java/com/softicar/platform/core/module/test/fixture/CoreModuleTestFixture.java
+++ b/platform-core-module/src/main/java/com/softicar/platform/core/module/test/fixture/CoreModuleTestFixture.java
@@ -5,27 +5,42 @@ import com.softicar.platform.core.module.CoreModule;
 import com.softicar.platform.core.module.CorePermissions;
 import com.softicar.platform.core.module.module.instance.IModuleInstance;
 import com.softicar.platform.core.module.standard.configuration.ProgramStandardConfiguration;
+import com.softicar.platform.core.module.test.instance.registry.IModuleTestFixture;
 import com.softicar.platform.core.module.user.AGUser;
 import com.softicar.platform.emf.module.permission.EmfDefaultModulePermissions;
+import com.softicar.platform.emf.table.IEmfTable;
 
 /**
  * Basic test fixture for the {@link CoreModule}.
  *
+ * @author Alexander Schmidt
  * @author Oliver Richers
  */
-public class CoreModuleTestFixture implements CoreModuleTestFixtureMethods {
+public class CoreModuleTestFixture implements IModuleTestFixture<AGCoreModuleInstance>, CoreModuleTestFixtureMethods {
 
-	private final AGUser viewUser;
-	private final AGUser normalUser;
-	private final AGUser adminUser;
+	private AGCoreModuleInstance instance;
+	private AGUser viewUser;
+	private AGUser normalUser;
+	private AGUser adminUser;
 
-	/**
-	 * FIXME This pattern is abysmal - constructors shall never have a side
-	 * effect on the database!
-	 */
 	public CoreModuleTestFixture() {
 
-		AGCoreModuleInstance//
+		this.instance = null;
+		this.viewUser = null;
+		this.normalUser = null;
+		this.adminUser = null;
+	}
+
+	@Override
+	public AGCoreModuleInstance getInstance() {
+
+		return instance;
+	}
+
+	@Override
+	public IModuleTestFixture<AGCoreModuleInstance> apply() {
+
+		this.instance = AGCoreModuleInstance//
 			.getInstance()
 			.setTestSystem(true)
 			.setDefaultLocalization(insertLocalizationPresetGermany())
@@ -54,6 +69,14 @@ public class CoreModuleTestFixture implements CoreModuleTestFixtureMethods {
 		insertPermissionAssignment(adminUser, CorePermissions.ADMINISTRATION, AGCoreModuleInstance.getInstance());
 
 		new ProgramStandardConfiguration().createAndSaveAll();
+
+		return this;
+	}
+
+	@Override
+	public IEmfTable<?, ?, ?> getTable() {
+
+		return AGCoreModuleInstance.TABLE;
 	}
 
 	public AGUser getViewUser() {

--- a/platform-core-module/src/main/java/com/softicar/platform/core/module/test/instance/registry/TestFixtureRegistry.java
+++ b/platform-core-module/src/main/java/com/softicar/platform/core/module/test/instance/registry/TestFixtureRegistry.java
@@ -13,11 +13,11 @@ import java.util.function.Function;
 public class TestFixtureRegistry {
 
 	private final Map<IEmfTable<?, ?, ?>, IModuleTestFixture<?>> testFixtureMap;
-	//FIXME merge this into testFixtureMap once CoreModule is a standard module
 	private final CoreModuleTestFixture coreModuleTestFixture;
 
 	public TestFixtureRegistry(CoreModuleTestFixture coreModuleTestFixture) {
 
+		coreModuleTestFixture.apply();
 		this.coreModuleTestFixture = coreModuleTestFixture;
 		this.testFixtureMap = new HashMap<>();
 	}


### PR DESCRIPTION
- Eliminated constructor-with-side-effect pattern.
- This change is transparent to projects derived from the platform (this was tested manually).
