### PR TITLE
PLAT-1209 ImapMessage: Fix getSubject to never return null

### DIFF
--- a/platform-core-module/src/main/java/com/softicar/platform/core/module/email/mailbox/imap/ImapMessage.java
+++ b/platform-core-module/src/main/java/com/softicar/platform/core/module/email/mailbox/imap/ImapMessage.java
@@ -5,6 +5,7 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import javax.mail.Address;
@@ -27,7 +28,7 @@ class ImapMessage implements IMailboxMessage {
 	public String getSubject() {
 
 		try {
-			return message.getSubject();
+			return Optional.ofNullable(message.getSubject()).orElse("");
 		} catch (MessagingException exception) {
 			throw new RuntimeException(exception);
 		}


### PR DESCRIPTION
Calling code in a payload project revealed that the implementation before this PR could indeed return _null_.