### PR TITLE
PLAT-1212 Use combined jakarta.mail artifact to avoid spam in catalina.out

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,6 +31,7 @@ project.ext {
 		// optional dependency of pdfbox; enables rendering of jpeg2000-encoded embedded images
 		jaiImageioJpeg2000: "1.4.0",
 		jakartaActivation: "1.2.2",
+		jakartaMail: "1.6.7",
 		javaxServletApi: "4.0.1",
 		jcifsNg: "2.1.7",
 		jetty: "9.4.48.v20220622",
@@ -45,7 +46,6 @@ project.ext {
 		poi: "5.2.2",
 		selenium: "4.2.2",
 		slf4j: "1.7.33",
-		sunMail: "1.6.7",
 		tesseractPlatform: "4.1.1-1.5.4",
 	]
 }

--- a/platform-core-module/build.gradle
+++ b/platform-core-module/build.gradle
@@ -4,9 +4,7 @@ dependencies {
 	api project(':platform-db-sqml-builtin')
 	api project(':platform-emf')
 
-	api "com.sun.mail:imap:$versions.sunMail"
-	api "com.sun.mail:mailapi:$versions.sunMail"
-	api "com.sun.mail:smtp:$versions.sunMail"
+	api "com.sun.mail:jakarta.mail:$versions.jakartaMail"
 
 	implementation "eu.agno3.jcifs:jcifs-ng:$versions.jcifsNg"
 	implementation "org.apache.commons:commons-lang3:$versions.commonsLang3"


### PR DESCRIPTION
- Use `com.sun.mail:jakarta.mail`
- ...instead of three single artifacts, `com.sun.mail:[mailapi|imap|smtp]`
- ...none of which provides `/META-INF/javamail.default.address.map`.
![image](https://user-images.githubusercontent.com/15086658/199822204-7732e298-4894-4a38-a71b-9e14d05906f1.png)
