### PR TITLE
PLAT-1222 DomImage: Ensure that alternate resources are not garbage-collected

### DIFF
--- a/platform-dom/src/main/java/com/softicar/platform/dom/elements/DomImage.java
+++ b/platform-dom/src/main/java/com/softicar/platform/dom/elements/DomImage.java
@@ -14,6 +14,10 @@ public class DomImage extends DomElement {
 
 	private IResource resource;
 
+	// Keep a strong reference to the alternate resource, to avoid that it gets garbage-collected.
+	// TODO Find a better solution.
+	@SuppressWarnings("unused") private IResource alternateResource;
+
 	/**
 	 * Constructs an image showing the specified resource.
 	 * <p>
@@ -56,6 +60,8 @@ public class DomImage extends DomElement {
 	}
 
 	public DomImage setAlternateResourceOnError(IResource resource) {
+
+		this.alternateResource = resource;
 
 		getDomEngine().setAlternateResourceOnError(this, resource);
 		return this;


### PR DESCRIPTION
Test Plan:
- Before applying this PR, change `AjaxDomEngineTest.testSetAlternateResourceOnErrorWithTiff` so that `System.gc()` gets called directly after `openTestNode`.
- Watch the test fail consistently.
- Apply this PR.
- Watch the test pass consistently.