### PR TITLE
PLAT-1238-1 DomAutoCompleteMatchEntryComparator: Cache normalization results

### DIFF
--- a/platform-dom/src/main/java/com/softicar/platform/dom/elements/input/auto/matching/DomAutoCompleteMatchEntryComparator.java
+++ b/platform-dom/src/main/java/com/softicar/platform/dom/elements/input/auto/matching/DomAutoCompleteMatchEntryComparator.java
@@ -2,7 +2,9 @@ package com.softicar.platform.dom.elements.input.auto.matching;
 
 import com.softicar.platform.common.string.normalizer.DiacriticNormalizer;
 import java.util.Comparator;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Map.Entry;
 
 class DomAutoCompleteMatchEntryComparator<E extends Entry<String, DomAutoCompleteWordMatches>> implements Comparator<E> {
@@ -10,12 +12,14 @@ class DomAutoCompleteMatchEntryComparator<E extends Entry<String, DomAutoComplet
 	private final boolean ignoreDiacritics;
 	private final String perfectMatchIdentifier;
 	private final DiacriticNormalizer normalizer;
+	private final Map<String, String> normalizedTextCache;
 
 	public DomAutoCompleteMatchEntryComparator(boolean ignoreDiacritics, String perfectMatchIdentifier) {
 
 		this.ignoreDiacritics = ignoreDiacritics;
 		this.perfectMatchIdentifier = perfectMatchIdentifier;
 		this.normalizer = new DiacriticNormalizer();
+		this.normalizedTextCache = new HashMap<>();
 	}
 
 	@Override
@@ -90,6 +94,10 @@ class DomAutoCompleteMatchEntryComparator<E extends Entry<String, DomAutoComplet
 
 	private String normalize(String text) {
 
-		return ignoreDiacritics? normalizer.normalize(text) : text;
+		if (ignoreDiacritics) {
+			return normalizedTextCache.computeIfAbsent(text, normalizer::normalize);
+		} else {
+			return text;
+		}
 	}
 }

--- a/platform-dom/src/main/java/com/softicar/platform/dom/elements/input/auto/matching/DomAutoCompleteMatchesBuilder.java
+++ b/platform-dom/src/main/java/com/softicar/platform/dom/elements/input/auto/matching/DomAutoCompleteMatchesBuilder.java
@@ -48,8 +48,8 @@ class DomAutoCompleteMatchesBuilder<V> {
 			.entrySet()
 			.stream()
 			.sorted(comparator)
-			.map(this::createMatch)
 			.limit(limit)
+			.map(this::createMatch)
 			.forEach(matches::add);
 		Optional//
 			.ofNullable(perfectMatchIdentifier)

--- a/platform-dom/src/main/java/com/softicar/platform/dom/elements/input/auto/matching/DomAutoCompleteMatchesBuilder.java
+++ b/platform-dom/src/main/java/com/softicar/platform/dom/elements/input/auto/matching/DomAutoCompleteMatchesBuilder.java
@@ -43,7 +43,6 @@ class DomAutoCompleteMatchesBuilder<V> {
 	public DomAutoCompleteMatches<V> build(int limit) {
 
 		var matches = new DomAutoCompleteMatches<V>();
-		// TODO try to pull the comparator out even further, to reuse the cache as much as possible
 		var comparator = new DomAutoCompleteMatchEntryComparator<>(ignoreDiacritics, perfectMatchIdentifier);
 		identifierToWordMatches//
 			.entrySet()

--- a/platform-dom/src/main/java/com/softicar/platform/dom/elements/input/auto/matching/DomAutoCompleteMatchesBuilder.java
+++ b/platform-dom/src/main/java/com/softicar/platform/dom/elements/input/auto/matching/DomAutoCompleteMatchesBuilder.java
@@ -43,10 +43,12 @@ class DomAutoCompleteMatchesBuilder<V> {
 	public DomAutoCompleteMatches<V> build(int limit) {
 
 		var matches = new DomAutoCompleteMatches<V>();
+		// TODO try to pull the comparator out even further, to reuse the cache as much as possible
+		var comparator = new DomAutoCompleteMatchEntryComparator<>(ignoreDiacritics, perfectMatchIdentifier);
 		identifierToWordMatches//
 			.entrySet()
 			.stream()
-			.sorted(new DomAutoCompleteMatchEntryComparator<>(ignoreDiacritics, perfectMatchIdentifier))
+			.sorted(comparator)
 			.map(this::createMatch)
 			.limit(limit)
 			.forEach(matches::add);


### PR DESCRIPTION
Added an internal cache to be used when normalization is enabled.

In a real-world test case, this led to a ~10x performance boost wrt. time spent in the `Comparator` code.
- Before this PR, sorting a `Stream` of `8520` items with this `Comparator` took `1455 ms`.
- As of this PR, sorting the same `Stream` took merely `150 ms`.

As a result, in the auto-complete input element of the aforementioned real-world test case, the overall time to find matches could by cut short by ~65%.