### PR TITLE
PLAT-1238-3 DomAutoCompleteInput: Implement a stateful value cache

### DIFF
--- a/platform-dom/src/main/java/com/softicar/platform/dom/elements/input/auto/DomAutoCompleteStatefulValue.java
+++ b/platform-dom/src/main/java/com/softicar/platform/dom/elements/input/auto/DomAutoCompleteStatefulValue.java
@@ -1,11 +1,11 @@
 package com.softicar.platform.dom.elements.input.auto;
 
-class DomAutoCompleteValueAndState<T> {
+class DomAutoCompleteStatefulValue<T> {
 
 	private final T value;
 	private final DomAutoCompleteValueState state;
 
-	public DomAutoCompleteValueAndState(T value, DomAutoCompleteValueState state) {
+	public DomAutoCompleteStatefulValue(T value, DomAutoCompleteValueState state) {
 
 		this.value = value;
 		this.state = state;

--- a/platform-dom/src/main/java/com/softicar/platform/dom/elements/input/auto/DomAutoCompleteValueParser.java
+++ b/platform-dom/src/main/java/com/softicar/platform/dom/elements/input/auto/DomAutoCompleteValueParser.java
@@ -11,36 +11,36 @@ class DomAutoCompleteValueParser<T> {
 		this.input = input;
 	}
 
-	public DomAutoCompleteValueAndState<T> parse() {
+	public DomAutoCompleteStatefulValue<T> parse() {
 
 		if (input.isBlank()) {
-			return createResult(DomAutoCompleteValueState.NONE);
+			return createStatefulValue(DomAutoCompleteValueState.NONE);
 		} else if (input.getValidationMode().isPermissive()) {
 			// TODO PLAT-753 This cast should not be necessary. Permissive mode should not even be handled in the same auto-complete input implementation.
-			return createResult(CastUtils.<T> cast(input.getValueText()));
+			return createStatefulValue(CastUtils.<T> cast(input.getValueText()));
 		} else {
 			var matches = input.getInputEngine().findMatches(input.getPattern(), 2);
 			if (matches.isEmpty()) {
-				return createResult(DomAutoCompleteValueState.ILLEGAL);
+				return createStatefulValue(DomAutoCompleteValueState.ILLEGAL);
 			} else {
 				if (matches.size() == 1) {
-					return createResult(matches.getAll().iterator().next().getValue());
+					return createStatefulValue(matches.getAll().iterator().next().getValue());
 				} else if (matches.getPerfectMatchValue().isPresent()) {
-					return createResult(matches.getPerfectMatchValue().get());
+					return createStatefulValue(matches.getPerfectMatchValue().get());
 				} else {
-					return createResult(DomAutoCompleteValueState.AMBIGUOUS);
+					return createStatefulValue(DomAutoCompleteValueState.AMBIGUOUS);
 				}
 			}
 		}
 	}
 
-	private DomAutoCompleteValueAndState<T> createResult(DomAutoCompleteValueState state) {
+	private DomAutoCompleteStatefulValue<T> createStatefulValue(DomAutoCompleteValueState state) {
 
-		return new DomAutoCompleteValueAndState<>(null, state);
+		return new DomAutoCompleteStatefulValue<>(null, state);
 	}
 
-	private DomAutoCompleteValueAndState<T> createResult(T value) {
+	private DomAutoCompleteStatefulValue<T> createStatefulValue(T value) {
 
-		return new DomAutoCompleteValueAndState<>(value, DomAutoCompleteValueState.VALID);
+		return new DomAutoCompleteStatefulValue<>(value, DomAutoCompleteValueState.VALID);
 	}
 }


### PR DESCRIPTION
Adding a stateful value cache to `DomAutoCompleteInput` had the following effects in a real-world test case, while processing a single DOM event:
- The total time spent in `DomAutoCompleteValueParser.parse` could be reduced from `1436ms` to `531ms` (i.e. cut by `63%`).
- The number of invocations of the expensive `DomAutoCompleteValueParser.parse` was halved.
