### PR TITLE
PLAT-1238-4 DomAutoCompleteInput: Reuse the cache for value and state in deduceValue()

### DIFF
--- a/platform-dom/src/main/java/com/softicar/platform/dom/elements/input/auto/DomAutoCompleteInput.java
+++ b/platform-dom/src/main/java/com/softicar/platform/dom/elements/input/auto/DomAutoCompleteInput.java
@@ -92,6 +92,7 @@ public class DomAutoCompleteInput<T> extends AbstractDomValueInputDiv<T> {
 
 		inputEngine.refresh();
 		inputEngine.reloadCache();
+		statefulValueCache.clear();
 		indicator.refresh();
 		filterDisplay.refresh();
 
@@ -325,6 +326,11 @@ public class DomAutoCompleteInput<T> extends AbstractDomValueInputDiv<T> {
 		private String previousValueText;
 
 		public StatefulValueCache() {
+
+			clear();
+		}
+
+		public void clear() {
 
 			this.statefulValue = null;
 			this.previousValueText = null;

--- a/platform-dom/src/main/java/com/softicar/platform/dom/elements/input/auto/DomAutoCompleteInput.java
+++ b/platform-dom/src/main/java/com/softicar/platform/dom/elements/input/auto/DomAutoCompleteInput.java
@@ -302,10 +302,11 @@ public class DomAutoCompleteInput<T> extends AbstractDomValueInputDiv<T> {
 
 	private void deduceValue() {
 
-		var valueAndState = new DomAutoCompleteValueParser<>(this).parse();
-		if (valueAndState.isValid()) {
-			inputField.setValue(inputEngine.getDisplayString(valueAndState.getValue()).toString());
-		}
+		statefulValueCache//
+			.getValueNoThrow()
+			.map(inputEngine::getDisplayString)
+			.map(IDisplayString::toString)
+			.ifPresent(inputField::setValue);
 	}
 
 	private void setFieldValue(T value) {
@@ -337,6 +338,17 @@ public class DomAutoCompleteInput<T> extends AbstractDomValueInputDiv<T> {
 				throw new DomInputException(DomI18n.PLEASE_SELECT_A_VALID_ENTRY);
 			} else {
 				return Optional.ofNullable(statefulValue.getValue());
+			}
+		}
+
+		public Optional<T> getValueNoThrow() {
+
+			updateValueIfNecessary();
+
+			if (statefulValue.isValid()) {
+				return Optional.ofNullable(statefulValue.getValue());
+			} else {
+				return Optional.empty();
 			}
 		}
 


### PR DESCRIPTION
By no longer calling the expensive `DomAutoCompleteValueParser.parse` method but instead reusing the value-and-state cache in `DomAutoCompleteInput.deduceValue`, the following effects were achieved in a real-world test case, while processing a single DOM event:
- The total time consumption across 16 combined calls to `deduceValue()` and `getValue()` could be reduced from `1050ms` to `534ms` (i.e. cut by `49%`).
- Only one of those 16 combined calls resulted in a `DomAutoCompleteValueParser.parse` call.
