### PR TITLE
PLAT-1238-5 DomAutoCompleteInput: Reuse the value-and-state cache for DomAutoCompleteIndicator

### DIFF
--- a/platform-dom/src/main/java/com/softicar/platform/dom/elements/input/auto/DomAutoCompleteIndicator.java
+++ b/platform-dom/src/main/java/com/softicar/platform/dom/elements/input/auto/DomAutoCompleteIndicator.java
@@ -3,15 +3,15 @@ package com.softicar.platform.dom.elements.input.auto;
 import com.softicar.platform.dom.DomCssClasses;
 import com.softicar.platform.dom.elements.DomDiv;
 import com.softicar.platform.dom.elements.DomImage;
+import java.util.function.Supplier;
 
 public class DomAutoCompleteIndicator<T> extends DomDiv {
 
-	private final DomAutoCompleteInput<T> input;
+	private final Supplier<DomAutoCompleteValueAndState<T>> valueAndStateSupplier;
 
-	public DomAutoCompleteIndicator(DomAutoCompleteInput<T> input) {
+	public DomAutoCompleteIndicator(Supplier<DomAutoCompleteValueAndState<T>> valueAndStateSupplier) {
 
-		this.input = input;
-
+		this.valueAndStateSupplier = valueAndStateSupplier;
 		addCssClass(DomCssClasses.DOM_AUTO_COMPLETE_INDICATOR_PARENT);
 	}
 
@@ -23,8 +23,7 @@ public class DomAutoCompleteIndicator<T> extends DomDiv {
 
 	private void appendIndicator() {
 
-		var valueAndState = new DomAutoCompleteValueParser<>(input).parse();
-
+		var valueAndState = valueAndStateSupplier.get();
 		if (valueAndState.isAmbiguous()) {
 			appendChild(new Image(DomAutoCompleteIndicatorType.AMBIGUOUS));
 		} else if (valueAndState.isIllegal()) {

--- a/platform-dom/src/main/java/com/softicar/platform/dom/elements/input/auto/DomAutoCompleteValueAndState.java
+++ b/platform-dom/src/main/java/com/softicar/platform/dom/elements/input/auto/DomAutoCompleteValueAndState.java
@@ -1,11 +1,11 @@
 package com.softicar.platform.dom.elements.input.auto;
 
-class DomAutoCompleteStatefulValue<T> {
+class DomAutoCompleteValueAndState<T> {
 
 	private final T value;
 	private final DomAutoCompleteValueState state;
 
-	public DomAutoCompleteStatefulValue(T value, DomAutoCompleteValueState state) {
+	public DomAutoCompleteValueAndState(T value, DomAutoCompleteValueState state) {
 
 		this.value = value;
 		this.state = state;

--- a/platform-dom/src/main/java/com/softicar/platform/dom/elements/input/auto/DomAutoCompleteValueAndStateCache.java
+++ b/platform-dom/src/main/java/com/softicar/platform/dom/elements/input/auto/DomAutoCompleteValueAndStateCache.java
@@ -1,0 +1,33 @@
+package com.softicar.platform.dom.elements.input.auto;
+
+import java.util.Objects;
+
+class DomAutoCompleteValueAndStateCache<T> {
+
+	private final DomAutoCompleteInput<T> input;
+	private DomAutoCompleteValueAndState<T> valueAndState;
+	private String previousValueText;
+
+	public DomAutoCompleteValueAndStateCache(DomAutoCompleteInput<T> input) {
+
+		this.input = Objects.requireNonNull(input);
+		clear();
+	}
+
+	public void clear() {
+
+		this.valueAndState = null;
+		this.previousValueText = null;
+	}
+
+	public DomAutoCompleteValueAndState<T> getValueAndState() {
+
+		String currentValueText = input.getValueText();
+		if (!currentValueText.equals(previousValueText)) {
+			this.valueAndState = new DomAutoCompleteValueParser<>(input).parse();
+			this.previousValueText = currentValueText;
+		}
+
+		return Objects.requireNonNull(valueAndState);
+	}
+}

--- a/platform-dom/src/main/java/com/softicar/platform/dom/elements/input/auto/DomAutoCompleteValueParser.java
+++ b/platform-dom/src/main/java/com/softicar/platform/dom/elements/input/auto/DomAutoCompleteValueParser.java
@@ -11,36 +11,36 @@ class DomAutoCompleteValueParser<T> {
 		this.input = input;
 	}
 
-	public DomAutoCompleteStatefulValue<T> parse() {
+	public DomAutoCompleteValueAndState<T> parse() {
 
 		if (input.isBlank()) {
-			return createStatefulValue(DomAutoCompleteValueState.NONE);
+			return createResult(DomAutoCompleteValueState.NONE);
 		} else if (input.getValidationMode().isPermissive()) {
 			// TODO PLAT-753 This cast should not be necessary. Permissive mode should not even be handled in the same auto-complete input implementation.
-			return createStatefulValue(CastUtils.<T> cast(input.getValueText()));
+			return createResult(CastUtils.<T> cast(input.getValueText()));
 		} else {
 			var matches = input.getInputEngine().findMatches(input.getPattern(), 2);
 			if (matches.isEmpty()) {
-				return createStatefulValue(DomAutoCompleteValueState.ILLEGAL);
+				return createResult(DomAutoCompleteValueState.ILLEGAL);
 			} else {
 				if (matches.size() == 1) {
-					return createStatefulValue(matches.getAll().iterator().next().getValue());
+					return createResult(matches.getAll().iterator().next().getValue());
 				} else if (matches.getPerfectMatchValue().isPresent()) {
-					return createStatefulValue(matches.getPerfectMatchValue().get());
+					return createResult(matches.getPerfectMatchValue().get());
 				} else {
-					return createStatefulValue(DomAutoCompleteValueState.AMBIGUOUS);
+					return createResult(DomAutoCompleteValueState.AMBIGUOUS);
 				}
 			}
 		}
 	}
 
-	private DomAutoCompleteStatefulValue<T> createStatefulValue(DomAutoCompleteValueState state) {
+	private DomAutoCompleteValueAndState<T> createResult(DomAutoCompleteValueState state) {
 
-		return new DomAutoCompleteStatefulValue<>(null, state);
+		return new DomAutoCompleteValueAndState<>(null, state);
 	}
 
-	private DomAutoCompleteStatefulValue<T> createStatefulValue(T value) {
+	private DomAutoCompleteValueAndState<T> createResult(T value) {
 
-		return new DomAutoCompleteStatefulValue<>(value, DomAutoCompleteValueState.VALID);
+		return new DomAutoCompleteValueAndState<>(value, DomAutoCompleteValueState.VALID);
 	}
 }


### PR DESCRIPTION
By reusing the value-and-state cache in `DomAutoCompleteIndicator`, the following effects were achieved in a real-world test case, while processing the creation of a complex input form, and a sequence of DOM event therein:
- The total time spent in `DomAutoCompleteValueParser.parse` could be reduced from `2700ms` to `677ms` (i.e. cut by `76%`).
- The total time spent to handle all DOM events was reduced from `8823ms` to `6677ms` (i.e. cut by `24%`).

Further notes:
- The value-and-state cache was extracted as top-level class `DomAutoCompleteValueAndStateCache`.
  - The recent renaming was de-facto reverted, for now.
  - Moved result handling to calling code. Particularly, the cache no longer throws.
- As of this PR, `DomAutoCompleteValueParser.parse` is exclusively called from within `DomAutoCompleteValueAndStateCache`.
  - As a result, all parser invications are now cached.
