### PR TITLE
PLAT-1238-6 Speed up DiacriticNormalizer

### DIFF
--- a/platform-common/src/main/java/com/softicar/platform/common/string/normalizer/DiacriticNormalizer.java
+++ b/platform-common/src/main/java/com/softicar/platform/common/string/normalizer/DiacriticNormalizer.java
@@ -1,43 +1,30 @@
 package com.softicar.platform.common.string.normalizer;
 
 import java.text.Normalizer;
-import java.text.Normalizer.Form;
-import java.util.Map;
-import java.util.TreeMap;
+import java.util.regex.Pattern;
 
+/**
+ * Removes diacritics (aka. diacritical marks) from text.
+ *
+ * @author Alexander Schmidt
+ */
 public class DiacriticNormalizer {
 
+	private static final Pattern ACCENTS_PATTERN = Pattern.compile("\\p{M}");
+
 	/**
-	 * Some characters (e.g. 'đ') possess no unicode decomposition mapping entry
-	 * (e.g. to 'd'). This map therefore provides manual, explicit decomposition
-	 * mappings.
+	 * Removes diacritics from the characters in the given text.
+	 * <p>
+	 * Relies on Unicode decomposition mappings.
+	 *
+	 * @param text
+	 *            the text to strip of diacritical marks (never <i>null</i>)
+	 * @return the given text, stripped of diacritical marks (never <i>null</i>)
 	 */
-	private static final Map<Character, Character> DECOMPOSITION_MAP = new TreeMap<>();
+	public String normalize(String text) {
 
-	static {
-		DECOMPOSITION_MAP.put('đ', 'd');
-		DECOMPOSITION_MAP.put('Đ', 'D');
-		DECOMPOSITION_MAP.put('ƒ', 'f');
-		DECOMPOSITION_MAP.put('Ƒ', 'F');
-	}
-
-	public String normalize(String string) {
-
-		return applyCustomDecomposition(removeDiacritics(string));
-	}
-
-	private String removeDiacritics(String string) {
-
-		return Normalizer.normalize(string, Form.NFD).replaceAll("\\p{InCombiningDiacriticalMarks}+", "");
-	}
-
-	private String applyCustomDecomposition(String string) {
-
-		StringBuilder output = new StringBuilder();
-		for (char character: string.toCharArray()) {
-			Character replacement = DECOMPOSITION_MAP.get(character);
-			output.append(replacement != null? replacement : character);
-		}
-		return output.toString();
+		return ACCENTS_PATTERN//
+			.matcher(Normalizer.normalize(text, Normalizer.Form.NFKD))
+			.replaceAll("");
 	}
 }

--- a/platform-common/src/test/java/com/softicar/platform/common/string/normalizer/DiacriticNormalizerTest.java
+++ b/platform-common/src/test/java/com/softicar/platform/common/string/normalizer/DiacriticNormalizerTest.java
@@ -130,17 +130,6 @@ public class DiacriticNormalizerTest extends AbstractTest {
 	}
 
 	/**
-	 * https://en.wikipedia.org/wiki/Hook_%28diacritic%29
-	 */
-	@Test
-	public void testHookRemoval() {
-
-		String input = "ƒƑ";
-		String output = new DiacriticNormalizer().normalize(input);
-		assertEquals("fF", output);
-	}
-
-	/**
 	 * https://en.wikipedia.org/wiki/Hook_above
 	 */
 	@Test
@@ -237,16 +226,5 @@ public class DiacriticNormalizerTest extends AbstractTest {
 		String input = "ἀὠ";
 		String output = new DiacriticNormalizer().normalize(input);
 		assertEquals("αω", output);
-	}
-
-	/**
-	 * https://en.wikipedia.org/wiki/Bar_%28diacritic%29
-	 */
-	@Test
-	public void testBarRemoval() {
-
-		String input = "đĐ";
-		String output = new DiacriticNormalizer().normalize(input);
-		assertEquals("dD", output);
 	}
 }


### PR DESCRIPTION
In a real-world test case, `DiacriticNormalizer` was used to normalize 1,474,839 strings.
- Before this PR, it took `2656ms`.
- With this PR, it took `920ms` (i.e. cut by `65%`).

The following measures were applied:
- Use a statically-precompiled pattern.
- Use a different conjunction of (1) normalization form and (2) pattern - which is apparently more efficient.
- Remove custom decomposition mappings.
  - Proper handling of esoteric characters which are irrelevant to our current use cases is not worth a hefty performance impact.
  - We solely rely on Unicode decomposition mappings now.
