### PR TITLE
PLAT-1238-7 Create a singleton cache for diacritic normalization

### DIFF
--- a/platform-common/src/main/java/com/softicar/platform/common/string/normalizer/CurrentDiacriticNormalizationCache.java
+++ b/platform-common/src/main/java/com/softicar/platform/common/string/normalizer/CurrentDiacriticNormalizationCache.java
@@ -1,0 +1,25 @@
+package com.softicar.platform.common.string.normalizer;
+
+import com.softicar.platform.common.core.singleton.Singleton;
+
+/**
+ * A {@link Singleton} that holds the currently-used
+ * {@link DiacriticNormalizationCache}.
+ *
+ * @author Alexander Schmidt
+ */
+public class CurrentDiacriticNormalizationCache {
+
+	private static final Singleton<DiacriticNormalizationCache> INSTANCE = new Singleton<>(DiacriticNormalizationCache::new);
+
+	/**
+	 * Returns the currently-used {@link DiacriticNormalizationCache}.
+	 *
+	 * @return the current {@link DiacriticNormalizationCache} (never
+	 *         <i>null</i>)
+	 */
+	public static DiacriticNormalizationCache get() {
+
+		return INSTANCE.get();
+	}
+}

--- a/platform-common/src/main/java/com/softicar/platform/common/string/normalizer/DiacriticNormalizationCache.java
+++ b/platform-common/src/main/java/com/softicar/platform/common/string/normalizer/DiacriticNormalizationCache.java
@@ -1,0 +1,48 @@
+package com.softicar.platform.common.string.normalizer;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * A cache for {@link DiacriticNormalizer}.
+ *
+ * @author Alexander Schmidt
+ */
+public class DiacriticNormalizationCache {
+
+	private final DiacriticNormalizer normalizer;
+	private final Map<String, String> normalizedTextMap;
+
+	/**
+	 * Constructs a new {@link DiacriticNormalizationCache}.
+	 */
+	public DiacriticNormalizationCache() {
+
+		this.normalizer = new DiacriticNormalizer();
+		this.normalizedTextMap = new HashMap<>();
+	}
+
+	/**
+	 * Uses {@link DiacriticNormalizer#normalize(String)} to remove diacritics
+	 * from the characters in the given text.
+	 * <p>
+	 * The result is cached, so that {@link DiacriticNormalizer} will not be
+	 * invoked again for the same text.
+	 *
+	 * @param text
+	 *            the text to strip of diacritical marks (never <i>null</i>)
+	 * @return the given text, stripped of diacritical marks (never <i>null</i>)
+	 */
+	public String normalize(String text) {
+
+		return normalizedTextMap.computeIfAbsent(text, normalizer::normalize);
+	}
+
+	/**
+	 * Clears all previously cached normalized texts.
+	 */
+	public void clear() {
+
+		normalizedTextMap.clear();
+	}
+}

--- a/platform-core-module/src/main/java/com/softicar/platform/core/module/page/PageHeaderAndContentDiv.java
+++ b/platform-core-module/src/main/java/com/softicar/platform/core/module/page/PageHeaderAndContentDiv.java
@@ -2,6 +2,7 @@ package com.softicar.platform.core.module.page;
 
 import com.softicar.platform.common.core.interfaces.INullaryVoidFunction;
 import com.softicar.platform.common.core.locale.CurrentLocale;
+import com.softicar.platform.common.string.normalizer.CurrentDiacriticNormalizationCache;
 import com.softicar.platform.core.module.page.header.PageHeaderDiv;
 import com.softicar.platform.core.module.page.navigation.PageNavigationController;
 import com.softicar.platform.core.module.page.navigation.entry.PageNavigationEntry;
@@ -37,6 +38,7 @@ public class PageHeaderAndContentDiv extends DomDiv {
 		CurrentDomDocument.get().getRefreshBus().discardEvent();
 		CurrentLocale.set(CurrentUser.get().getLocale());
 		DbTableRowCaches.invalidateAll();
+		CurrentDiacriticNormalizationCache.get().clear();
 		System.gc();
 
 		changeBrowserUrl(linkEntry);

--- a/platform-dom/src/main/java/com/softicar/platform/dom/elements/input/auto/DomAutoCompleteDisplayStringDeduplicator.java
+++ b/platform-dom/src/main/java/com/softicar/platform/dom/elements/input/auto/DomAutoCompleteDisplayStringDeduplicator.java
@@ -1,7 +1,7 @@
 package com.softicar.platform.dom.elements.input.auto;
 
 import com.softicar.platform.common.core.i18n.IDisplayString;
-import com.softicar.platform.common.string.normalizer.DiacriticNormalizer;
+import com.softicar.platform.common.string.normalizer.CurrentDiacriticNormalizationCache;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -42,8 +42,7 @@ class DomAutoCompleteDisplayStringDeduplicator<T> {
 
 		this.displayFunction = displayFunction;
 		this.valueComparator = valueComparator;
-		var normalizer = new DiacriticNormalizer();
-		this.keyComparator = Comparator.comparing(string -> normalizer.normalize(string).toLowerCase());
+		this.keyComparator = Comparator.comparing(string -> CurrentDiacriticNormalizationCache.get().normalize(string).toLowerCase());
 	}
 
 	public Map<String, T> apply(Collection<T> values) {

--- a/platform-dom/src/main/java/com/softicar/platform/dom/elements/input/auto/matching/DomAutoCompleteMatchEntryComparator.java
+++ b/platform-dom/src/main/java/com/softicar/platform/dom/elements/input/auto/matching/DomAutoCompleteMatchEntryComparator.java
@@ -1,25 +1,19 @@
 package com.softicar.platform.dom.elements.input.auto.matching;
 
-import com.softicar.platform.common.string.normalizer.DiacriticNormalizer;
+import com.softicar.platform.common.string.normalizer.CurrentDiacriticNormalizationCache;
 import java.util.Comparator;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.Map.Entry;
 
 class DomAutoCompleteMatchEntryComparator<E extends Entry<String, DomAutoCompleteWordMatches>> implements Comparator<E> {
 
 	private final boolean ignoreDiacritics;
 	private final String perfectMatchIdentifier;
-	private final DiacriticNormalizer normalizer;
-	private final Map<String, String> normalizedTextCache;
 
 	public DomAutoCompleteMatchEntryComparator(boolean ignoreDiacritics, String perfectMatchIdentifier) {
 
 		this.ignoreDiacritics = ignoreDiacritics;
 		this.perfectMatchIdentifier = perfectMatchIdentifier;
-		this.normalizer = new DiacriticNormalizer();
-		this.normalizedTextCache = new HashMap<>();
 	}
 
 	@Override
@@ -95,9 +89,8 @@ class DomAutoCompleteMatchEntryComparator<E extends Entry<String, DomAutoComplet
 	private String normalize(String text) {
 
 		if (ignoreDiacritics) {
-			return normalizedTextCache.computeIfAbsent(text, normalizer::normalize);
-		} else {
-			return text;
+			text = CurrentDiacriticNormalizationCache.get().normalize(text);
 		}
+		return text;
 	}
 }

--- a/platform-dom/src/main/java/com/softicar/platform/dom/elements/input/auto/matching/DomAutoCompleteMatcher.java
+++ b/platform-dom/src/main/java/com/softicar/platform/dom/elements/input/auto/matching/DomAutoCompleteMatcher.java
@@ -1,6 +1,6 @@
 package com.softicar.platform.dom.elements.input.auto.matching;
 
-import com.softicar.platform.common.string.normalizer.DiacriticNormalizer;
+import com.softicar.platform.common.string.normalizer.CurrentDiacriticNormalizationCache;
 import com.softicar.platform.dom.elements.input.auto.DomAutoCompleteInput;
 import java.util.ArrayList;
 import java.util.List;
@@ -22,7 +22,6 @@ public class DomAutoCompleteMatcher<V> {
 
 	private static final Pattern WHITESPACES = Pattern.compile("\\s+");
 	private final Map<String, V> identifierToValueMap;
-	private final DiacriticNormalizer normalizer;
 	private boolean ignoreDiacritics;
 
 	/**
@@ -35,7 +34,6 @@ public class DomAutoCompleteMatcher<V> {
 	public DomAutoCompleteMatcher(Map<String, V> identifierToValueMap) {
 
 		this.identifierToValueMap = Objects.requireNonNull(identifierToValueMap);
-		this.normalizer = new DiacriticNormalizer();
 		this.ignoreDiacritics = false;
 	}
 
@@ -172,6 +170,6 @@ public class DomAutoCompleteMatcher<V> {
 
 	private String normalize(String text) {
 
-		return ignoreDiacritics? normalizer.normalize(text) : text;
+		return ignoreDiacritics? CurrentDiacriticNormalizationCache.get().normalize(text) : text;
 	}
 }

--- a/platform-emf/src/main/java/com/softicar/platform/emf/attribute/EmfAttributeByTitleComparator.java
+++ b/platform-emf/src/main/java/com/softicar/platform/emf/attribute/EmfAttributeByTitleComparator.java
@@ -1,17 +1,10 @@
 package com.softicar.platform.emf.attribute;
 
-import com.softicar.platform.common.string.normalizer.DiacriticNormalizer;
+import com.softicar.platform.common.string.normalizer.CurrentDiacriticNormalizationCache;
 import com.softicar.platform.emf.table.row.IEmfTableRow;
 import java.util.Comparator;
 
 public class EmfAttributeByTitleComparator<R extends IEmfTableRow<R, ?>> implements Comparator<IEmfAttribute<R, ?>> {
-
-	private final DiacriticNormalizer normalizer;
-
-	public EmfAttributeByTitleComparator() {
-
-		this.normalizer = new DiacriticNormalizer();
-	}
 
 	@Override
 	public int compare(IEmfAttribute<R, ?> first, IEmfAttribute<R, ?> second) {
@@ -23,6 +16,6 @@ public class EmfAttributeByTitleComparator<R extends IEmfTableRow<R, ?>> impleme
 
 	private String getNormalizedTitle(IEmfAttribute<R, ?> attribute) {
 
-		return normalizer.normalize(attribute.getTitle().toString());
+		return CurrentDiacriticNormalizationCache.get().normalize(attribute.getTitle().toString());
 	}
 }


### PR DESCRIPTION
This PR had the following effect in a real-world test case of creating a complex and partially pre-filled input form:
- The total amount of time spent in `DomAutoCompleteDisplayStringDeduplicator.apply` was reduced from `1213ms` to `615ms` (i.e. cut by `49%`).
- The total amount of time to display said input form was equally reduced.
