### PR TITLE
PLAT-1238-8 DomAutoCompleteDisplayStringDeduplicator: No longer order the results

### DIFF
--- a/platform-dom/build.gradle
+++ b/platform-dom/build.gradle
@@ -3,7 +3,6 @@ dependencies {
 	api "junit:junit:$versions.junit"
 	api "com.google.code.gson:gson:$versions.gson"
 	
+	implementation "com.google.guava:guava:$versions.guava"
 	implementation "io.github.classgraph:classgraph:$versions.classgraph"
-	
-	// testImplementation project(':platform-common-testing')
 }

--- a/platform-dom/src/main/java/com/softicar/platform/dom/elements/input/auto/DomAutoCompleteDisplayStringDeduplicator.java
+++ b/platform-dom/src/main/java/com/softicar/platform/dom/elements/input/auto/DomAutoCompleteDisplayStringDeduplicator.java
@@ -1,5 +1,6 @@
 package com.softicar.platform.dom.elements.input.auto;
 
+import com.google.common.collect.Maps;
 import com.softicar.platform.common.core.i18n.IDisplayString;
 import com.softicar.platform.common.string.normalizer.CurrentDiacriticNormalizationCache;
 import java.util.ArrayList;
@@ -48,7 +49,7 @@ class DomAutoCompleteDisplayStringDeduplicator<T> {
 	public Map<String, T> apply(Collection<T> values) {
 
 		this.listMap = new TreeMap<>(keyComparator);
-		this.resultMap = new TreeMap<>(keyComparator);
+		this.resultMap = Maps.newHashMapWithExpectedSize(values.size());
 
 		for (var value: values) {
 			var string = displayFunction.apply(value).toString();

--- a/platform-dom/src/test/java/com/softicar/platform/dom/elements/input/auto/AbstractDomAutoCompleteDefaultInputEngineTest.java
+++ b/platform-dom/src/test/java/com/softicar/platform/dom/elements/input/auto/AbstractDomAutoCompleteDefaultInputEngineTest.java
@@ -4,9 +4,11 @@ import com.softicar.platform.common.core.i18n.IDisplayString;
 import com.softicar.platform.common.core.i18n.IDisplayable;
 import com.softicar.platform.common.testing.AbstractTest;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
-import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 public abstract class AbstractDomAutoCompleteDefaultInputEngineTest extends AbstractTest {
@@ -33,13 +35,15 @@ public abstract class AbstractDomAutoCompleteDefaultInputEngineTest extends Abst
 		values.clear();
 	}
 
-	protected void assertMap(String expected, Map<String, TestValue> map) {
+	protected void assertMapInArbitraryOrder(Map<String, TestValue> map, String...expectedEntries) {
 
-		var exptectedToString = List//
-			.of(expected.split("\n"))
-			.stream()
-			.collect(Collectors.joining(", "));
-		assertEquals("{" + exptectedToString + "}", map.toString());
+		Set<String> actualEntries = map.entrySet().stream().map(Entry::toString).collect(Collectors.toSet());
+		Arrays.asList(expectedEntries).forEach(expectedEntry -> {
+			assertTrue(//
+				"Entry '%s' was not found in: '%s'".formatted(expectedEntry, actualEntries),
+				actualEntries.contains(expectedEntry));
+		});
+		assertEquals(expectedEntries.length, map.size());
 	}
 
 	protected static class TestValue implements IDisplayable, Comparable<TestValue> {

--- a/platform-dom/src/test/java/com/softicar/platform/dom/elements/input/auto/DomAutoCompleteDisplayStringDeduplicatorTest.java
+++ b/platform-dom/src/test/java/com/softicar/platform/dom/elements/input/auto/DomAutoCompleteDisplayStringDeduplicatorTest.java
@@ -15,16 +15,18 @@ public class DomAutoCompleteDisplayStringDeduplicatorTest extends AbstractDomAut
 	@Test
 	public void testWithDistinctDisplayStringsAndDistinctValues() {
 
+		// different strings with different values
 		addTestValue("FOO", 1);
 		addTestValue("baz", 2);
 		addTestValue("Bar", 3);
 
 		Map<String, TestValue> map = deduplicator.apply(values);
 
-		assertMap("""
-				Bar=3
-				baz=2
-				FOO=1""", map);
+		assertMapInArbitraryOrder(//
+			map,
+			"FOO=1",
+			"baz=2",
+			"Bar=3");
 	}
 
 	@Test
@@ -37,22 +39,23 @@ public class DomAutoCompleteDisplayStringDeduplicatorTest extends AbstractDomAut
 
 		Map<String, TestValue> map = deduplicator.apply(values);
 
-		assertMap("""
-				Bar=3
-				baz=3
-				FOO=3""", map);
+		assertMapInArbitraryOrder(//
+			map,
+			"FOO=3",
+			"baz=3",
+			"Bar=3");
 	}
 
 	@Test
 	public void testWithRedundantDisplayStringsAndDistinctValues() {
 
-		// ascending values
+		// some entries
 		addTestValue("FOO", 1);
 		addTestValue("foo", 2);
 		addTestValue("Foo", 3);
 		addTestValue("fóô", 4);
 
-		// descending values
+		// further entries, with redundant strings but different values
 		addTestValue("FOO", 9);
 		addTestValue("foo", 8);
 		addTestValue("Foo", 7);
@@ -60,28 +63,28 @@ public class DomAutoCompleteDisplayStringDeduplicatorTest extends AbstractDomAut
 
 		Map<String, TestValue> map = deduplicator.apply(values);
 
-		// assert ordered by value
-		assertMap("""
-				FOO (1)=1
-				foo (2)=2
-				Foo (3)=3
-				fóô (4)=4
-				fóô (5)=6
-				Foo (6)=7
-				foo (7)=8
-				FOO (8)=9""", map);
+		assertMapInArbitraryOrder(//
+			map,
+			"FOO (1)=1",
+			"foo (2)=2",
+			"Foo (3)=3",
+			"fóô (4)=4",
+			"fóô (5)=6",
+			"Foo (6)=7",
+			"foo (7)=8",
+			"FOO (8)=9");
 	}
 
 	@Test
 	public void testWithRedundantDisplayStringsAndRedundantValues() {
 
-		// initial order of display strings
+		// some entries
 		addTestValue("FOO", 3);
 		addTestValue("foo", 3);
 		addTestValue("Foo", 3);
 		addTestValue("fóô", 3);
 
-		// reverse order of display strings
+		// further entries, with redundant strings and redundant values
 		addTestValue("fóô", 3);
 		addTestValue("Foo", 3);
 		addTestValue("foo", 3);
@@ -89,16 +92,16 @@ public class DomAutoCompleteDisplayStringDeduplicatorTest extends AbstractDomAut
 
 		Map<String, TestValue> map = deduplicator.apply(values);
 
-		// assert insertion order
-		assertMap("""
-				FOO (1)=3
-				foo (2)=3
-				Foo (3)=3
-				fóô (4)=3
-				fóô (5)=3
-				Foo (6)=3
-				foo (7)=3
-				FOO (8)=3""", map);
+		assertMapInArbitraryOrder(//
+			map,
+			"FOO (1)=3",
+			"foo (2)=3",
+			"Foo (3)=3",
+			"fóô (4)=3",
+			"fóô (5)=3",
+			"Foo (6)=3",
+			"foo (7)=3",
+			"FOO (8)=3");
 	}
 
 	@Test
@@ -115,14 +118,15 @@ public class DomAutoCompleteDisplayStringDeduplicatorTest extends AbstractDomAut
 
 		Map<String, TestValue> map = deduplicator.apply(values);
 
-		assertMap("""
-				foo (1) (1)=4
-				Foo (1) (2)=5
-				foo (1) (3)=9
-				Foo (2)=2
-				foo (3)=6
-				foo (4)=3
-				fOO (5)=7
-				foobar=1""", map);
+		assertMapInArbitraryOrder(//
+			map,
+			"foo (1) (1)=4",
+			"Foo (1) (2)=5",
+			"foo (1) (3)=9",
+			"Foo (2)=2",
+			"foo (3)=6",
+			"foo (4)=3",
+			"fOO (5)=7",
+			"foobar=1");
 	}
 }


### PR DESCRIPTION
Ordering the results was pointless because they will be re-ordered anyway, in all use cases of `DomAutoCompleteDisplayStringDeduplicator`. Using a pressimistically pre-sized `HashMap` yielded further performance benefits.

This PR had the following effect in a real-world test case of creating a complex and partially pre-filled input form:
- The total amount of time spent in `DomAutoCompleteDisplayStringDeduplicator.apply` was reduced from `542ms` to `369ms` (i.e. cut by `32%`).
