### PR TITLE
PLAT-1238-9 Implement table-based deactivation of input-related display string deduplication

### DIFF
--- a/platform-emf/src/main/java/com/softicar/platform/emf/attribute/field/foreign/entity/input/AbstractEmfEntityInputEngine.java
+++ b/platform-emf/src/main/java/com/softicar/platform/emf/attribute/field/foreign/entity/input/AbstractEmfEntityInputEngine.java
@@ -1,9 +1,9 @@
 package com.softicar.platform.emf.attribute.field.foreign.entity.input;
 
 import com.softicar.platform.common.core.utils.DevNull;
-import com.softicar.platform.db.runtime.table.IDbTable;
 import com.softicar.platform.dom.elements.input.auto.DomAutoCompleteDefaultInputEngine;
 import com.softicar.platform.emf.entity.IEmfEntity;
+import com.softicar.platform.emf.table.IEmfTable;
 import java.util.Collection;
 
 /**
@@ -14,7 +14,7 @@ import java.util.Collection;
  */
 public abstract class AbstractEmfEntityInputEngine<E extends IEmfEntity<E, ?>> extends DomAutoCompleteDefaultInputEngine<E> {
 
-	public AbstractEmfEntityInputEngine(IDbTable<E, ?> table) {
+	public AbstractEmfEntityInputEngine(IEmfTable<E, ?, ?> table) {
 
 		setLoader(() -> {
 			var values = loadItems();
@@ -22,6 +22,7 @@ public abstract class AbstractEmfEntityInputEngine<E extends IEmfEntity<E, ?>> e
 			return values;
 		});
 		addDependsOn(table);
+		setDisplayStringDeduplicationEnabled(table.getEmfTableConfiguration().isDisplayStringDeduplicationEnabled());
 	}
 
 	/**

--- a/platform-emf/src/main/java/com/softicar/platform/emf/table/configuration/EmfTableConfiguration.java
+++ b/platform-emf/src/main/java/com/softicar/platform/emf/table/configuration/EmfTableConfiguration.java
@@ -103,6 +103,7 @@ public class EmfTableConfiguration<R extends IEmfTableRow<R, P>, P, S> implement
 	private IEmfDeleteStrategy<R> deleteStrategy;
 	private IEmfTableRowDeactivationStrategy<R> deactivationStrategy;
 	private IDbKey<R> businessKey;
+	private boolean displayStringDeduplicationEnabled;
 
 	public EmfTableConfiguration(IEmfTable<R, P, S> table) {
 
@@ -133,6 +134,7 @@ public class EmfTableConfiguration<R extends IEmfTableRow<R, P>, P, S> implement
 		this.tableRowsFinder = Optional.empty();
 		this.deleteStrategy = new EmfDeleteStrategyBuilder<R>().build();
 		this.deactivationStrategy = new EmfTableRowDeactivationStrategy<>(table);
+		this.displayStringDeduplicationEnabled = true;
 	}
 
 	// ------------------------------ setters ------------------------------ //
@@ -249,6 +251,22 @@ public class EmfTableConfiguration<R extends IEmfTableRow<R, P>, P, S> implement
 		this.deactivationStrategy = deactivationStrategy;
 	}
 
+	/**
+	 * Specifies whether equivalent {@link IEmfTableRow#toDisplay()} values
+	 * shall be avoided in input elements, by appending numerical suffixes.
+	 * <p>
+	 * De-duplication is enabled by default.
+	 * <p>
+	 * De-duplication has a significant performance cost.
+	 *
+	 * @param enabled
+	 *            <i>true</i> to enable de-duplication; <i>false</i> otherwise
+	 */
+	public void setDisplayStringDeduplicationEnabled(boolean enabled) {
+
+		this.displayStringDeduplicationEnabled = enabled;
+	}
+
 	// ------------------------------ display and input ------------------------------ //
 
 	@Override
@@ -279,6 +297,12 @@ public class EmfTableConfiguration<R extends IEmfTableRow<R, P>, P, S> implement
 	public final IEmfFormTabConfiguration<R> getFormTabConfiguration() {
 
 		return tabConfigurationSupplier.get();
+	}
+
+	@Override
+	public boolean isDisplayStringDeduplicationEnabled() {
+
+		return displayStringDeduplicationEnabled;
 	}
 
 	// ------------------------------ attributes ------------------------------ //

--- a/platform-emf/src/main/java/com/softicar/platform/emf/table/configuration/IEmfTableConfiguration.java
+++ b/platform-emf/src/main/java/com/softicar/platform/emf/table/configuration/IEmfTableConfiguration.java
@@ -54,6 +54,8 @@ public interface IEmfTableConfiguration<R extends IEmfTableRow<R, P>, P, S> {
 
 	IEmfFormTabConfiguration<R> getFormTabConfiguration();
 
+	boolean isDisplayStringDeduplicationEnabled();
+
 	// ------------------------------ attributes ------------------------------ //
 
 	List<IEmfAttribute<R, ?>> getAttributes();


### PR DESCRIPTION
This PR had the following effect in a real-world test case of creating a complex and partially pre-filled input form:
- The total amount of time spent to determine the display strings of values was reduced from `281ms` to `87ms` (i.e. cut by `69%`).
