### PR TITLE
EXP-2296 Table export: Fix misalignment of header and body columns

### DIFF
--- a/platform-dom/src/main/java/com/softicar/platform/dom/elements/AbstractDomCell.java
+++ b/platform-dom/src/main/java/com/softicar/platform/dom/elements/AbstractDomCell.java
@@ -7,7 +7,7 @@ import com.softicar.platform.dom.parent.DomParentElement;
  *
  * @author Oliver Richers
  */
-public abstract class AbstractDomCell extends DomParentElement {
+public abstract class AbstractDomCell extends DomParentElement implements IDomCell {
 
 	public AbstractDomCell setColSpan(int colSpan) {
 

--- a/platform-dom/src/main/java/com/softicar/platform/dom/elements/DomChildElementFinder.java
+++ b/platform-dom/src/main/java/com/softicar/platform/dom/elements/DomChildElementFinder.java
@@ -1,6 +1,5 @@
 package com.softicar.platform.dom.elements;
 
-import com.softicar.platform.common.core.exceptions.SofticarDeveloperException;
 import com.softicar.platform.dom.node.IDomNode;
 import com.softicar.platform.dom.parent.DomParentElement;
 import com.softicar.platform.dom.parent.IDomParentElement;
@@ -8,47 +7,39 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
+import java.util.Objects;
 
 public class DomChildElementFinder {
 
-	public static List<AbstractDomCell> getCells(DomRow row) {
+	public static <T extends IDomNode> List<T> getChildrenWithClass(IDomParentElement parent, Class<T> childClass) {
 
-		return DomChildElementFinder.getChildrenByClass(row, AbstractDomCell.class, null, null);
+		return getChildrenWithClass(parent, childClass, null, null);
 	}
 
-	public static <T extends IDomNode> List<T> getChildrenByClass(IDomParentElement parent, Class<T> childClass, Collection<Integer> skipChildIndexes,
+	public static <T extends IDomNode> List<T> getChildrenWithClass(IDomParentElement parent, Class<T> childClass, Collection<Integer> skipChildIndexes,
 			List<Class<? extends T>> ignoreChildSubClasses) {
 
-		if (childClass != null) {
-			if (parent != null) {
-				List<T> filteredChildren = new ArrayList<>();
-				List<IDomNode> children = parent.getChildren();
+		Objects.requireNonNull(parent);
+		Objects.requireNonNull(childClass);
 
-				if (ignoreChildSubClasses == null) {
-					ignoreChildSubClasses = new ArrayList<>();
+		List<T> filteredChildren = new ArrayList<>();
+		List<IDomNode> children = parent.getChildren();
+
+		if (ignoreChildSubClasses == null) {
+			ignoreChildSubClasses = new ArrayList<>();
+		}
+
+		for (int i = 0; i < children.size(); i++) {
+			IDomNode child = children.get(i);
+
+			if (child != null && childClass.isInstance(child) && !isIndexSkipped(skipChildIndexes, i)) {
+				if (!ignoreChildSubClasses.contains(child.getClass())) {
+					filteredChildren.add(childClass.cast(child));
 				}
-
-				for (int i = 0; i < children.size(); i++) {
-					IDomNode child = children.get(i);
-
-					if (child != null && childClass.isInstance(child) && !isIndexSkipped(skipChildIndexes, i)) {
-						if (!ignoreChildSubClasses.contains(child.getClass())) {
-							filteredChildren.add(childClass.cast(child));
-						}
-					}
-				}
-
-				return filteredChildren;
-			}
-
-			else {
-				throw new SofticarDeveloperException("The given parent element must not be null.");
 			}
 		}
 
-		else {
-			throw new SofticarDeveloperException("The given child class must not be null.");
-		}
+		return filteredChildren;
 	}
 
 	public static List<IDomNode> fetchChildrenAtIndexPath(IDomNode parent, Integer...indexPath) {

--- a/platform-dom/src/main/java/com/softicar/platform/dom/elements/IDomCell.java
+++ b/platform-dom/src/main/java/com/softicar/platform/dom/elements/IDomCell.java
@@ -1,0 +1,8 @@
+package com.softicar.platform.dom.elements;
+
+import com.softicar.platform.dom.parent.IDomParentElement;
+
+public interface IDomCell extends IDomParentElement {
+
+	// nothing
+}

--- a/platform-emf/src/main/java/com/softicar/platform/emf/data/table/IEmfDataTableActionCell.java
+++ b/platform-emf/src/main/java/com/softicar/platform/emf/data/table/IEmfDataTableActionCell.java
@@ -1,13 +1,13 @@
 package com.softicar.platform.emf.data.table;
 
-import com.softicar.platform.dom.parent.IDomParentElement;
+import com.softicar.platform.dom.elements.IDomCell;
 
 /**
  * Represents an action cell of a result row of an {@link IEmfDataTable}.
  *
  * @author Oliver Richers
  */
-public interface IEmfDataTableActionCell<R> extends IDomParentElement {
+public interface IEmfDataTableActionCell<R> extends IDomCell {
 
 	/**
 	 * Returns the table row that this cell is a child of.

--- a/platform-emf/src/main/java/com/softicar/platform/emf/data/table/export/element/TableExportChildElementFetcher.java
+++ b/platform-emf/src/main/java/com/softicar/platform/emf/data/table/export/element/TableExportChildElementFetcher.java
@@ -6,6 +6,7 @@ import com.softicar.platform.dom.elements.DomRow;
 import com.softicar.platform.dom.elements.DomTBody;
 import com.softicar.platform.dom.elements.DomTHead;
 import com.softicar.platform.dom.elements.DomTable;
+import com.softicar.platform.dom.elements.IDomCell;
 import com.softicar.platform.dom.elements.tables.DomDataTable;
 import com.softicar.platform.dom.elements.tables.pageable.DomPageableTable;
 import com.softicar.platform.emf.data.table.export.util.TableExportLib;
@@ -33,7 +34,7 @@ public class TableExportChildElementFetcher {
 
 		DomTHead tHead = getTableHeadOrNull(table);
 		if (tHead != null) {
-			return DomChildElementFinder.getChildrenByClass(tHead, DomRow.class, createHeaderRowSkipIndexs(table), null);
+			return DomChildElementFinder.getChildrenWithClass(tHead, DomRow.class, createHeaderRowSkipIndexs(table), null);
 		} else {
 			return new ArrayList<>();
 		}
@@ -46,10 +47,15 @@ public class TableExportChildElementFetcher {
 			tBody = ((DomDataTable) table).getBody();
 		}
 		if (tBody != null) {
-			return DomChildElementFinder.getChildrenByClass(tBody, DomRow.class, null, null);
+			return DomChildElementFinder.getChildrenWithClass(tBody, DomRow.class);
 		} else {
 			return new ArrayList<>();
 		}
+	}
+
+	public static List<IDomCell> getCells(DomRow row) {
+
+		return DomChildElementFinder.getChildrenWithClass(row, IDomCell.class);
 	}
 
 	// TODO: this is really nasty

--- a/platform-emf/src/main/java/com/softicar/platform/emf/data/table/export/element/TableExportNamedDomCell.java
+++ b/platform-emf/src/main/java/com/softicar/platform/emf/data/table/export/element/TableExportNamedDomCell.java
@@ -3,15 +3,15 @@ package com.softicar.platform.emf.data.table.export.element;
 import com.softicar.platform.common.container.matrix.IMatrixTraits;
 import com.softicar.platform.common.core.exceptions.SofticarNotImplementedYetException;
 import com.softicar.platform.common.string.unicode.UnicodeEnum;
-import com.softicar.platform.dom.elements.AbstractDomCell;
+import com.softicar.platform.dom.elements.IDomCell;
 import java.io.Serializable;
 
 public class TableExportNamedDomCell {
 
 	private final String name;
-	private final AbstractDomCell cell;
+	private final IDomCell cell;
 
-	public TableExportNamedDomCell(String name, AbstractDomCell cell) {
+	public TableExportNamedDomCell(String name, IDomCell cell) {
 
 		this.name = name;
 		this.cell = cell;
@@ -22,7 +22,7 @@ public class TableExportNamedDomCell {
 		return name;
 	}
 
-	public AbstractDomCell getCell() {
+	public IDomCell getCell() {
 
 		return cell;
 	}

--- a/platform-emf/src/main/java/com/softicar/platform/emf/data/table/export/engine/AbstractTableExportColumnFilteringEngine.java
+++ b/platform-emf/src/main/java/com/softicar/platform/emf/data/table/export/engine/AbstractTableExportColumnFilteringEngine.java
@@ -2,10 +2,9 @@ package com.softicar.platform.emf.data.table.export.engine;
 
 import com.softicar.platform.common.container.pair.Pair;
 import com.softicar.platform.dom.document.DomDocument;
-import com.softicar.platform.dom.elements.AbstractDomCell;
-import com.softicar.platform.dom.elements.DomChildElementFinder;
 import com.softicar.platform.dom.elements.DomRow;
 import com.softicar.platform.dom.elements.DomTable;
+import com.softicar.platform.dom.elements.IDomCell;
 import com.softicar.platform.dom.elements.tables.pageable.DomPageableTable;
 import com.softicar.platform.dom.node.IDomNode;
 import com.softicar.platform.emf.data.table.export.chunking.TableExportChunkBoundaryCalculator;
@@ -192,7 +191,8 @@ public abstract class AbstractTableExportColumnFilteringEngine<CT, ROW, CELL> ex
 
 				TableExportLib.Timing.begin("332 cell fetching");
 				TableExportSpanningElementList<TableExportSpanningCell> cells = new TableExportSpanningElementList<>();
-				for (AbstractDomCell cell: DomChildElementFinder.getCells(row)) {
+				List<IDomCell> cellsFromRow = TableExportChildElementFetcher.getCells(row);
+				for (IDomCell cell: cellsFromRow) {
 					int colspan = TableExportSpanFetcher.getColspanFromCell(cell);
 					int rowspan = TableExportSpanFetcher.getRowspanFromCell(cell);
 

--- a/platform-emf/src/main/java/com/softicar/platform/emf/data/table/export/engine/AbstractTableExportColumnFilteringEngine.java
+++ b/platform-emf/src/main/java/com/softicar/platform/emf/data/table/export/engine/AbstractTableExportColumnFilteringEngine.java
@@ -191,8 +191,7 @@ public abstract class AbstractTableExportColumnFilteringEngine<CT, ROW, CELL> ex
 
 				TableExportLib.Timing.begin("332 cell fetching");
 				TableExportSpanningElementList<TableExportSpanningCell> cells = new TableExportSpanningElementList<>();
-				List<IDomCell> cellsFromRow = TableExportChildElementFetcher.getCells(row);
-				for (IDomCell cell: cellsFromRow) {
+				for (IDomCell cell: TableExportChildElementFetcher.getCells(row)) {
 					int colspan = TableExportSpanFetcher.getColspanFromCell(cell);
 					int rowspan = TableExportSpanFetcher.getRowspanFromCell(cell);
 

--- a/platform-emf/src/main/java/com/softicar/platform/emf/data/table/export/model/TableExportColumnModelFetcher.java
+++ b/platform-emf/src/main/java/com/softicar/platform/emf/data/table/export/model/TableExportColumnModelFetcher.java
@@ -3,10 +3,9 @@ package com.softicar.platform.emf.data.table.export.model;
 import com.softicar.platform.common.container.matrix.simple.SimpleMatrix;
 import com.softicar.platform.common.string.Imploder;
 import com.softicar.platform.dom.DomI18n;
-import com.softicar.platform.dom.elements.AbstractDomCell;
-import com.softicar.platform.dom.elements.DomChildElementFinder;
 import com.softicar.platform.dom.elements.DomRow;
 import com.softicar.platform.dom.elements.DomTable;
+import com.softicar.platform.dom.elements.IDomCell;
 import com.softicar.platform.dom.elements.tables.pageable.DomPageableTable;
 import com.softicar.platform.emf.data.table.export.column.preselection.ITableExportColumnPreselector;
 import com.softicar.platform.emf.data.table.export.conversion.ITableExportNodeConverter;
@@ -107,7 +106,7 @@ public class TableExportColumnModelFetcher {
 		for (DomRow headerRow: headerRows) {
 			List<TableExportSpanningCell> headerSpanningCells = new ArrayList<>();
 
-			for (AbstractDomCell cell: DomChildElementFinder.getCells(headerRow)) {
+			for (IDomCell cell: TableExportChildElementFetcher.getCells(headerRow)) {
 				headerSpanningCells
 					.add(new TableExportSpanningCell(cell, TableExportSpanFetcher.getColspanFromCell(cell), TableExportSpanFetcher.getRowspanFromCell(cell)));
 			}
@@ -128,10 +127,10 @@ public class TableExportColumnModelFetcher {
 		for (Entry<Integer, SortedMap<Integer, TableExportSpanningCell>> outerEntry: placedSpanningObjects.entrySet()) {
 			for (Entry<Integer, TableExportSpanningCell> innerEntry: outerEntry.getValue().entrySet()) {
 
-				AbstractDomCell abstractDomCell = innerEntry.getValue().get();
-				String label = textConverter.convertNode(abstractDomCell).getContent().getString();
+				IDomCell domCell = innerEntry.getValue().get();
+				String label = textConverter.convertNode(domCell).getContent().getString();
 
-				result.addValue(outerEntry.getKey(), innerEntry.getKey(), new TableExportNamedDomCell(label, abstractDomCell));
+				result.addValue(outerEntry.getKey(), innerEntry.getKey(), new TableExportNamedDomCell(label, domCell));
 			}
 		}
 
@@ -160,7 +159,7 @@ public class TableExportColumnModelFetcher {
 		for (DomRow row: rows) {
 			int numColumnsInRow = 0;
 
-			for (AbstractDomCell cell: DomChildElementFinder.getCells(row)) {
+			for (IDomCell cell: TableExportChildElementFetcher.getCells(row)) {
 				numColumnsInRow += TableExportSpanFetcher.getColspanFromCell(cell);
 			}
 

--- a/platform-emf/src/main/java/com/softicar/platform/emf/data/table/export/model/TableExportTableModel.java
+++ b/platform-emf/src/main/java/com/softicar/platform/emf/data/table/export/model/TableExportTableModel.java
@@ -1,7 +1,6 @@
 package com.softicar.platform.emf.data.table.export.model;
 
 import com.softicar.platform.dom.elements.DomTable;
-import com.softicar.platform.emf.EmfI18n;
 import com.softicar.platform.emf.data.table.export.column.preselection.TableExportDefaultColumnPreselector;
 import java.util.List;
 import java.util.Map;
@@ -9,12 +8,8 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.TreeMap;
-import java.util.stream.Collectors;
 
 public class TableExportTableModel {
-
-	//TODO Find a better way to get rid of the actions column
-	private static final String ACTIONS_LABEL = EmfI18n.ACTIONS.toString();
 
 	private final DomTable table;
 	private final Optional<String> tableName;
@@ -29,11 +24,7 @@ public class TableExportTableModel {
 
 		this.table = Objects.requireNonNull(table);
 		this.tableName = Optional.ofNullable(tableName);
-		this.tableColumnModels = TableExportColumnModelFetcher
-			.fetchColumnModels(table, new TableExportDefaultColumnPreselector())
-			.stream()
-			.filter(model -> !model.getName().equals(ACTIONS_LABEL))
-			.collect(Collectors.toList());
+		this.tableColumnModels = TableExportColumnModelFetcher.fetchColumnModels(table, new TableExportDefaultColumnPreselector());
 	}
 
 	public DomTable getTable() {
@@ -57,11 +48,7 @@ public class TableExportTableModel {
 			TableExportColumnModel columnModel = this.tableColumnModels.get(i);
 
 			if (selectedColumnIndexes != null) {
-				if (selectedColumnIndexes.contains(i)) {
-					columnModel.setSelected(true);
-				} else {
-					columnModel.setSelected(false);
-				}
+				columnModel.setSelected(selectedColumnIndexes.contains(i));
 			}
 
 			else {

--- a/platform-emf/src/main/java/com/softicar/platform/emf/data/table/export/spanning/TableExportSpanFetcher.java
+++ b/platform-emf/src/main/java/com/softicar/platform/emf/data/table/export/spanning/TableExportSpanFetcher.java
@@ -3,10 +3,11 @@ package com.softicar.platform.emf.data.table.export.spanning;
 import com.softicar.platform.common.core.number.parser.IntegerParser;
 import com.softicar.platform.dom.attribute.IDomAttribute;
 import com.softicar.platform.dom.elements.AbstractDomCell;
+import com.softicar.platform.dom.elements.IDomCell;
 
 /**
  * Determines col- and rowspans from {@link AbstractDomCell}s.
- * 
+ *
  * @author Alexander Schmidt
  */
 public class TableExportSpanFetcher {
@@ -14,12 +15,12 @@ public class TableExportSpanFetcher {
 	private static final String COLSPAN_HTML_ATTRIBUTE_NAME = "colspan";
 	private static final String ROWSPAN_HTML_ATTRIBUTE_NAME = "rowspan";
 
-	public static int getColspanFromCell(AbstractDomCell cell) {
+	public static int getColspanFromCell(IDomCell cell) {
 
 		return getAttributeOrOneFromCell(cell, COLSPAN_HTML_ATTRIBUTE_NAME);
 	}
 
-	public static int getRowspanFromCell(AbstractDomCell cell) {
+	public static int getRowspanFromCell(IDomCell cell) {
 
 		return getAttributeOrOneFromCell(cell, ROWSPAN_HTML_ATTRIBUTE_NAME);
 	}
@@ -31,7 +32,7 @@ public class TableExportSpanFetcher {
 	 *         attribute is not set, 1 is returned. Guaranteed to return at
 	 *         least 1 in any case.
 	 */
-	private static int getAttributeOrOneFromCell(AbstractDomCell cell, String attributeName) {
+	private static int getAttributeOrOneFromCell(IDomCell cell, String attributeName) {
 
 		int colSpanValue = 0;
 		IDomAttribute attribute = cell.getAttribute(attributeName);

--- a/platform-emf/src/main/java/com/softicar/platform/emf/data/table/export/spanning/element/TableExportSpanningCell.java
+++ b/platform-emf/src/main/java/com/softicar/platform/emf/data/table/export/spanning/element/TableExportSpanningCell.java
@@ -1,16 +1,17 @@
 package com.softicar.platform.emf.data.table.export.spanning.element;
 
 import com.softicar.platform.dom.elements.AbstractDomCell;
+import com.softicar.platform.dom.elements.IDomCell;
 
 /**
  * An {@link AbstractDomCell} with explicitly defined col- and rowspan.
- * 
+ *
  * @author Alexander Schmidt
  */
-public class TableExportSpanningCell extends TableExportSpanningNode<AbstractDomCell> {
+public class TableExportSpanningCell extends TableExportSpanningNode<IDomCell> {
 
-	public TableExportSpanningCell(AbstractDomCell element, int colspan, int rowspan) {
+	public TableExportSpanningCell(IDomCell cell, int colspan, int rowspan) {
 
-		super(element, colspan, rowspan);
+		super(cell, colspan, rowspan);
 	}
 }


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/15086658/210570300-1c8833fe-3eea-449f-b64c-93f325fafcf9.png)

Table headers are now correctly positioned above their respective data columns. This was a regression since `EmfDataTableRow.ActionCell` no longer extended `AbstractDomCell`, due to [PLAT-1053](https://github.com/softicar/platform/pull/398).

Notes:
The empty leading column will be removed in an upcoming PR. That issue already existed before the regression which is fixed here. Particularly, we always had an empty leading column in table exports since we stopped captioning the first column with "Actions".