### PR TITLE
EXP-2296-2 Table export: Basic code cleanup

### DIFF
--- a/platform-emf/src/main/java/com/softicar/platform/emf/data/table/export/engine/AbstractTableExportEngine.java
+++ b/platform-emf/src/main/java/com/softicar/platform/emf/data/table/export/engine/AbstractTableExportEngine.java
@@ -1,6 +1,5 @@
 package com.softicar.platform.emf.data.table.export.engine;
 
-import com.softicar.platform.common.core.exceptions.SofticarDeveloperException;
 import com.softicar.platform.common.core.exceptions.SofticarUserException;
 import com.softicar.platform.common.io.mime.MimeType;
 import com.softicar.platform.common.io.zip.ZipLib;
@@ -27,7 +26,6 @@ import com.softicar.platform.emf.data.table.export.model.TableExportTableModel;
 import com.softicar.platform.emf.data.table.export.node.TableExportTypedNodeValue;
 import com.softicar.platform.emf.data.table.export.precondition.TableExportPreconditionResult.Level;
 import com.softicar.platform.emf.data.table.export.precondition.TableExportPreconditionResultContainer;
-import com.softicar.platform.emf.data.table.export.util.TableExportLib;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
@@ -36,6 +34,7 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
@@ -75,9 +74,7 @@ public abstract class AbstractTableExportEngine<CT> implements ITableExportEngin
 	public AbstractTableExportEngine(TableExportEngineConfiguration configuration, ITableExportEngineFactory<? extends ITableExportEngine<CT>> creatingFactory,
 			TableExportNodeConverterFactoryConfiguration<CT> nodeConverterFactoryConfiguration) {
 
-		if (configuration == null) {
-			throw new SofticarDeveloperException("The given %s must not be null.", TableExportEngineConfiguration.class.getSimpleName());
-		}
+		Objects.requireNonNull(configuration);
 
 		this.fileExtension = configuration.getFileNameExtension();
 		this.appendTimestamp = configuration.isAppendTimestamp();
@@ -119,12 +116,10 @@ public abstract class AbstractTableExportEngine<CT> implements ITableExportEngin
 		// check preconditions
 		//
 
-		TableExportLib.Timing.begin("000 Preconditions");
 		TableExportPreconditionResultContainer errorMessages = getCreatingFactory().checkPreconditions(tableModels);
 		if (errorMessages == null) {
 			errorMessages = new TableExportPreconditionResultContainer();
 		}
-		TableExportLib.Timing.end("000 Preconditions");
 
 		if (!errorMessages.getAllByLevel(Level.ERROR).isEmpty()) {
 			throw new SofticarUserException(DomI18n.EXPORT_PRECONDITIONS_WERE_NOT_MET);
@@ -174,8 +169,6 @@ public abstract class AbstractTableExportEngine<CT> implements ITableExportEngin
 			}
 
 			exportFinalization(buffer);
-
-			TableExportLib.Timing.log();
 
 			outputFileName = this.fileNameCreator
 				.createFileName(

--- a/platform-emf/src/main/java/com/softicar/platform/emf/data/table/export/engine/AbstractTableExportSubdividedEngine.java
+++ b/platform-emf/src/main/java/com/softicar/platform/emf/data/table/export/engine/AbstractTableExportSubdividedEngine.java
@@ -9,7 +9,6 @@ import com.softicar.platform.emf.data.table.export.engine.configuration.TableExp
 import com.softicar.platform.emf.data.table.export.engine.configuration.TableExportTableConfiguration;
 import com.softicar.platform.emf.data.table.export.engine.factory.ITableExportEngineFactory;
 import com.softicar.platform.emf.data.table.export.node.TableExportTypedNodeValue;
-import com.softicar.platform.emf.data.table.export.util.TableExportLib;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.util.Collection;
@@ -56,9 +55,7 @@ public abstract class AbstractTableExportSubdividedEngine<CT> extends AbstractTa
 	protected void exportPreparation(OutputStream targetOutputStream, Collection<TableExportTableConfiguration<CT>> tablesWithColumnModel) {
 
 		try {
-			TableExportLib.Timing.begin("100 Prepare");
 			prepare(targetOutputStream, tablesWithColumnModel);
-			TableExportLib.Timing.end("100 Prepare");
 		} catch (Exception exception) {
 			throw new SofticarUserException(exception, DomI18n.FAILED_TO_PREPARE_THE_FILE_FOR_EXPORT);
 		}
@@ -73,17 +70,13 @@ public abstract class AbstractTableExportSubdividedEngine<CT> extends AbstractTa
 		prepareTable(tableConfiguration);
 
 		try {
-			TableExportLib.Timing.begin("200 Header");
 			appendHeader(table, columnConfiguration);
-			TableExportLib.Timing.end("200 Header");
 		} catch (Exception exception) {
 			throw new SofticarUserException(exception, DomI18n.FAILED_TO_GENERATE_TABLE_HEADER);
 		}
 
 		try {
-			TableExportLib.Timing.begin("300 Body");
 			appendBody(table, columnConfiguration);
-			TableExportLib.Timing.end("300 Body");
 		} catch (Exception exception) {
 			throw new SofticarUserException(exception, DomI18n.FAILED_TO_GENERATE_TABLE_BODY);
 		}
@@ -95,9 +88,7 @@ public abstract class AbstractTableExportSubdividedEngine<CT> extends AbstractTa
 	protected void exportFinalization(OutputStream targetOutputStream) {
 
 		try {
-			TableExportLib.Timing.begin("400 Finish");
 			finish(targetOutputStream);
-			TableExportLib.Timing.end("400 Finish");
 		} catch (Exception exception) {
 			throw new SofticarUserException(exception, DomI18n.FAILED_TO_FINISH_THE_FILE_FOR_EXPORT);
 		}

--- a/platform-emf/src/main/java/com/softicar/platform/emf/data/table/export/spanning/algorithm/TableExportSpanningElementColumnFilterer.java
+++ b/platform-emf/src/main/java/com/softicar/platform/emf/data/table/export/spanning/algorithm/TableExportSpanningElementColumnFilterer.java
@@ -2,7 +2,6 @@ package com.softicar.platform.emf.data.table.export.spanning.algorithm;
 
 import com.softicar.platform.common.core.exceptions.SofticarDeveloperException;
 import com.softicar.platform.emf.data.table.export.spanning.element.ITableExportSpanningElement;
-import com.softicar.platform.emf.data.table.export.util.TableExportLib;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Map;
@@ -62,44 +61,6 @@ public class TableExportSpanningElementColumnFilterer<OT extends ITableExportSpa
 	}
 
 	/**
-	 * @param rowsWithCells
-	 *            A List of Lists of {@link ITableExportSpanningElement}s. Each
-	 *            inner List represents a row, while each element of each inner
-	 *            List is an {@link ITableExportSpanningElement} (e.g. an HTML
-	 *            cell) in the respective row.
-	 * @param initialRowIndex
-	 *            An initial row index offset to be applied to the result.
-	 * @param retainColumns
-	 *            A zero-based Set of column indexes to be retained (i.e.
-	 *            columns with indexes not contained in the Set are dropped). If
-	 *            the Set is null, no columns are dropped.
-	 * @return A shallow matrix of {@link ITableExportSpanningElement}s. The
-	 *         keys in the outer map are row indexes while the keys in the inner
-	 *         map are column indexes. The respective referenced
-	 *         {@link ITableExportSpanningElement} 's top-left corner is to be
-	 *         placed at the corresponding indexes.
-	 */
-	public Map<Integer, Map<Integer, TableExportSpanningElementFilterResult<OT>>> filter(TableExportSpanningElementListList<OT> rowsWithCells,
-			int initialRowIndex, Set<Integer> retainColumns) {
-
-		TableExportLib.Timing.begin("AAA row map creation");
-		SortedMap<Integer, SortedMap<Integer, OT>> rowMap = this.layouter.placeSpanningElements(rowsWithCells, initialRowIndex);
-		TableExportLib.Timing.end("AAA row map creation");
-
-		RowMapFilterExecutor rowMapFilterExecutor = new RowMapFilterExecutor();
-
-		if (!rowMap.isEmpty()) {
-			Integer lastRowIndex = rowMap.lastKey();
-
-			for (int r = 0; r <= lastRowIndex; r++) {
-				rowMapFilterExecutor.processRow(rowMap, r, retainColumns);
-			}
-		}
-
-		return rowMapFilterExecutor.getFilteredRowMap();
-	}
-
-	/**
 	 * Creates a filtered row map by consecutive calls of
 	 * {@link #processRow(Map, int, Set)}.
 	 *
@@ -116,8 +77,6 @@ public class TableExportSpanningElementColumnFilterer<OT extends ITableExportSpa
 
 		public void processRow(Map<Integer, SortedMap<Integer, OT>> originalRowMap, int rowIndex, Set<Integer> retainColumns) {
 
-			TableExportLib.Timing.begin("BAA row iteration");
-
 			SortedMap<Integer, OT> colMap = originalRowMap.get(rowIndex);
 
 			if (colMap != null && !colMap.isEmpty()) {
@@ -126,7 +85,6 @@ public class TableExportSpanningElementColumnFilterer<OT extends ITableExportSpa
 				OT lastCell = null;
 				int processedColsOfLastCell = 0;
 
-				TableExportLib.Timing.begin("BBA cell iteration #1");
 				for (int colIndex = 0; colIndex <= lastColIndex; colIndex++) {
 					++processedColsOfLastCell;
 
@@ -147,11 +105,9 @@ public class TableExportSpanningElementColumnFilterer<OT extends ITableExportSpa
 						}
 					}
 				}
-				TableExportLib.Timing.end("BBA cell iteration #1");
 
 				int targetColCounter = 0;
 
-				TableExportLib.Timing.begin("BBB cell iteration #2");
 				for (int colIndex = 0; colIndex <= lastColIndex; colIndex++) {
 					OT cell = colMap.get(colIndex);
 
@@ -182,10 +138,7 @@ public class TableExportSpanningElementColumnFilterer<OT extends ITableExportSpa
 						}
 					}
 				}
-				TableExportLib.Timing.end("BBB cell iteration #2");
 			}
-
-			TableExportLib.Timing.end("BAA row iteration");
 		}
 	}
 
@@ -194,10 +147,7 @@ public class TableExportSpanningElementColumnFilterer<OT extends ITableExportSpa
 	//
 
 	public static class TableExportSpanningElementList<OT extends ITableExportSpanningElement<?>> extends ArrayList<OT> {
-		// nothing
-	}
 
-	public static class TableExportSpanningElementListList<OT extends ITableExportSpanningElement<?>> extends ArrayList<ArrayList<OT>> {
 		// nothing
 	}
 }

--- a/platform-emf/src/main/java/com/softicar/platform/emf/data/table/export/util/TableExportLib.java
+++ b/platform-emf/src/main/java/com/softicar/platform/emf/data/table/export/util/TableExportLib.java
@@ -1,7 +1,6 @@
 package com.softicar.platform.emf.data.table.export.util;
 
 import com.softicar.platform.common.core.exceptions.SofticarDeveloperException;
-import com.softicar.platform.common.core.logging.TimingLog;
 import com.softicar.platform.common.string.regex.PatternFinder;
 import com.softicar.platform.dom.elements.DomTable;
 import com.softicar.platform.dom.elements.tables.pageable.DomPageableTable;
@@ -16,7 +15,6 @@ import java.util.TreeSet;
  */
 public class TableExportLib {
 
-	public static final boolean MASTER_SWITCH_TIMING = false;
 	public static final String FILE_NAME_INVALID_CHARS = "\\/:*?\"<>|";
 	public static final String DEFLATE_COMPRESSION_FILE_NAME_EXTENSION = "zip";
 
@@ -85,32 +83,6 @@ public class TableExportLib {
 
 		else {
 			return null;
-		}
-	}
-
-	// ----
-
-	public static class Timing {
-
-		public static void begin(String name) {
-
-			if (MASTER_SWITCH_TIMING) {
-				TimingLog.begin(name);
-			}
-		}
-
-		public static void end(String name) {
-
-			if (MASTER_SWITCH_TIMING) {
-				TimingLog.end(name);
-			}
-		}
-
-		public static void log() {
-
-			if (MASTER_SWITCH_TIMING) {
-				TimingLog.log();
-			}
 		}
 	}
 }


### PR DESCRIPTION
- Simplified non-null assertions.
- Removed timing log code.
- Removed some orphaned code.
- Fixed some variable names.
