### PR TITLE
EXP-2296-6 Table export: Eliminate a superfluous type argument

### DIFF
--- a/platform-emf/src/main/java/com/softicar/platform/emf/data/table/EmfDataTableDiv.java
+++ b/platform-emf/src/main/java/com/softicar/platform/emf/data/table/EmfDataTableDiv.java
@@ -181,7 +181,7 @@ class EmfDataTableDiv<R> extends DomDiv implements IEmfDataTableDiv<R> {
 	// -------------------- export -------------------- //
 
 	@Override
-	public void export(ITableExportEngine<?> engine) {
+	public void export(ITableExportEngine engine) {
 
 		engine.export(table);
 	}

--- a/platform-emf/src/main/java/com/softicar/platform/emf/data/table/IEmfDataTableDiv.java
+++ b/platform-emf/src/main/java/com/softicar/platform/emf/data/table/IEmfDataTableDiv.java
@@ -57,5 +57,5 @@ public interface IEmfDataTableDiv<R> extends IDomElement, IRefreshable {
 
 	// -------------------- export -------------------- //
 
-	void export(ITableExportEngine<?> engine);
+	void export(ITableExportEngine engine);
 }

--- a/platform-emf/src/main/java/com/softicar/platform/emf/data/table/export/column/selection/TableExportColumnSelectionButton.java
+++ b/platform-emf/src/main/java/com/softicar/platform/emf/data/table/export/column/selection/TableExportColumnSelectionButton.java
@@ -11,10 +11,10 @@ import com.softicar.platform.emf.data.table.export.model.TableExportTableModel;
 public class TableExportColumnSelectionButton extends DomPopupButton implements IRefreshable {
 
 	private final TableExportTableModel tableModel;
-	private final ITableExportEngine<?> currentEngine;
+	private final ITableExportEngine currentEngine;
 	private TableExportColumnSelectionPopup columnSelectionPopup;
 
-	public TableExportColumnSelectionButton(TableExportTableModel tableModel, ITableExportEngine<?> currentEngine) {
+	public TableExportColumnSelectionButton(TableExportTableModel tableModel, ITableExportEngine currentEngine) {
 
 		this.tableModel = tableModel;
 		this.currentEngine = currentEngine;

--- a/platform-emf/src/main/java/com/softicar/platform/emf/data/table/export/column/selection/TableExportColumnSelectionPopup.java
+++ b/platform-emf/src/main/java/com/softicar/platform/emf/data/table/export/column/selection/TableExportColumnSelectionPopup.java
@@ -14,7 +14,7 @@ public class TableExportColumnSelectionPopup extends DomDismissablePopup {
 	private final TableExportTableModel tableModel;
 	private final TableExportColumnSelectionTableDiv tableDiv;
 
-	public TableExportColumnSelectionPopup(TableExportTableModel tableModel, IRefreshable refreshable, ITableExportEngine<?> currentEngine) {
+	public TableExportColumnSelectionPopup(TableExportTableModel tableModel, IRefreshable refreshable, ITableExportEngine currentEngine) {
 
 		this.tableModel = tableModel;
 		this.refreshable = refreshable;

--- a/platform-emf/src/main/java/com/softicar/platform/emf/data/table/export/column/selection/TableExportColumnSelectionTableDiv.java
+++ b/platform-emf/src/main/java/com/softicar/platform/emf/data/table/export/column/selection/TableExportColumnSelectionTableDiv.java
@@ -16,10 +16,10 @@ import java.util.stream.Collectors;
 
 class TableExportColumnSelectionTableDiv extends DomDiv {
 
-	private final ITableExportEngine<?> currentEngine;
+	private final ITableExportEngine currentEngine;
 	private final IEmfDataTableDiv<TableExportColumnSelectionTableRow> tableDiv;
 
-	public TableExportColumnSelectionTableDiv(TableExportTableModel tableModel, ITableExportEngine<?> currentEngine) {
+	public TableExportColumnSelectionTableDiv(TableExportTableModel tableModel, ITableExportEngine currentEngine) {
 
 		this.currentEngine = currentEngine;
 		TableExportColumnSelectionTable table = new TableExportColumnSelectionTable(tableModel);

--- a/platform-emf/src/main/java/com/softicar/platform/emf/data/table/export/conversion/ITableExportNodeConverter.java
+++ b/platform-emf/src/main/java/com/softicar/platform/emf/data/table/export/conversion/ITableExportNodeConverter.java
@@ -1,38 +1,37 @@
 package com.softicar.platform.emf.data.table.export.conversion;
 
 import com.softicar.platform.dom.node.IDomNode;
+import com.softicar.platform.emf.data.table.export.node.TableExportTypedNodeValue;
 
 /**
  * Implementations convert the content of the given {@link IDomNode} to an
  * object of the given type.
- * 
- * @param <CT>
- *            the type to which the content of a node is to be converted
+ *
  * @author Alexander Schmidt
  */
-public interface ITableExportNodeConverter<CT> {
+public interface ITableExportNodeConverter {
 
 	/**
 	 * @param node
 	 * @return A Pair of extracted node content and an integer number of lines
 	 *         this content comprises.
 	 */
-	NodeConverterResult<CT> convertNode(IDomNode node);
+	NodeConverterResult convertNode(IDomNode node);
 
 	// ----
 
-	public static class NodeConverterResult<CT> {
+	public static class NodeConverterResult {
 
-		private final CT content;
+		private final TableExportTypedNodeValue content;
 		private final int contentLineCount;
 
-		public NodeConverterResult(CT content, int contentLineCount) {
+		public NodeConverterResult(TableExportTypedNodeValue content, int contentLineCount) {
 
 			this.content = content;
 			this.contentLineCount = contentLineCount;
 		}
 
-		public CT getContent() {
+		public TableExportTypedNodeValue getContent() {
 
 			return content;
 		}

--- a/platform-emf/src/main/java/com/softicar/platform/emf/data/table/export/conversion/factory/ITableExportNodeConverterFactory.java
+++ b/platform-emf/src/main/java/com/softicar/platform/emf/data/table/export/conversion/factory/ITableExportNodeConverterFactory.java
@@ -10,13 +10,11 @@ import com.softicar.platform.emf.data.table.export.conversion.ITableExportNodeCo
  * {@link ITableExportNodeConverterFactory}s can be selected on a per-column
  * basis.
  *
- * @param <CT>
- *            content type
  * @author Alexander Schmidt
  */
-public interface ITableExportNodeConverterFactory<CT> {
+public interface ITableExportNodeConverterFactory {
 
-	ITableExportNodeConverter<CT> create();
+	ITableExportNodeConverter create();
 
 	IDisplayString getConverterDisplayString();
 

--- a/platform-emf/src/main/java/com/softicar/platform/emf/data/table/export/conversion/factory/TableExportDefaultNodeConverterFactory.java
+++ b/platform-emf/src/main/java/com/softicar/platform/emf/data/table/export/conversion/factory/TableExportDefaultNodeConverterFactory.java
@@ -5,7 +5,6 @@ import com.softicar.platform.dom.DomI18n;
 import com.softicar.platform.emf.data.table.export.conversion.ITableExportNodeConverter;
 import com.softicar.platform.emf.data.table.export.conversion.TableExportTypedNodeConverter;
 import com.softicar.platform.emf.data.table.export.node.ITableExportTypedNode;
-import com.softicar.platform.emf.data.table.export.node.TableExportTypedNodeValue;
 
 /**
  * Creates an {@link ITableExportNodeConverter} that performs type safe content
@@ -15,10 +14,10 @@ import com.softicar.platform.emf.data.table.export.node.TableExportTypedNodeValu
  *
  * @author Alexander Schmidt
  */
-public class TableExportDefaultNodeConverterFactory implements ITableExportNodeConverterFactory<TableExportTypedNodeValue> {
+public class TableExportDefaultNodeConverterFactory implements ITableExportNodeConverterFactory {
 
 	@Override
-	public ITableExportNodeConverter<TableExportTypedNodeValue> create() {
+	public ITableExportNodeConverter create() {
 
 		return new TableExportTypedNodeConverter();
 	}

--- a/platform-emf/src/main/java/com/softicar/platform/emf/data/table/export/conversion/factory/TableExportNodeConverterFactoryValueSelectBuilder.java
+++ b/platform-emf/src/main/java/com/softicar/platform/emf/data/table/export/conversion/factory/TableExportNodeConverterFactoryValueSelectBuilder.java
@@ -18,34 +18,33 @@ import java.util.List;
  *
  * @author Alexander Schmidt
  */
-public class TableExportNodeConverterFactoryValueSelectBuilder<CT> extends DomSimpleValueSelectBuilder<TableExportNodeConverterFactoryWrapper<CT>> {
+public class TableExportNodeConverterFactoryValueSelectBuilder extends DomSimpleValueSelectBuilder<TableExportNodeConverterFactoryWrapper> {
 
 	private final int targetColumn;
-	private final TableExportNodeConverterFactorySelectionModel<CT> nodeConverterFactorySelectionModel;
+	private final TableExportNodeConverterFactorySelectionModel nodeConverterFactorySelectionModel;
 	private final DomParentElement converterFactoryHelpElementParent;
 
-	private TableExportNodeConverterFactoryWrapper<CT> preselectedFactoryWrapper = null;
-	private TableExportNodeConverterFactoryWrapper<CT> defaultFactoryWrapper = null;
+	private TableExportNodeConverterFactoryWrapper preselectedFactoryWrapper = null;
+	private TableExportNodeConverterFactoryWrapper defaultFactoryWrapper = null;
 
-	public TableExportNodeConverterFactoryValueSelectBuilder(TableExportNodeConverterFactoryConfiguration<CT> nodeConverterFactoryConfiguration,
-			TableExportNodeConverterFactorySelectionModel<CT> nodeConverterFactorySelectionModel, int targetColumn,
+	public TableExportNodeConverterFactoryValueSelectBuilder(TableExportNodeConverterFactoryConfiguration nodeConverterFactoryConfiguration,
+			TableExportNodeConverterFactorySelectionModel nodeConverterFactorySelectionModel, int targetColumn,
 			DomParentElement converterFactoryHelpElementParent) {
 
 		this.targetColumn = targetColumn;
 		this.nodeConverterFactorySelectionModel = nodeConverterFactorySelectionModel;
 		this.converterFactoryHelpElementParent = converterFactoryHelpElementParent;
 
-		List<TableExportNodeConverterFactoryWrapper<CT>> factoryWrappers = new ArrayList<>();
+		List<TableExportNodeConverterFactoryWrapper> factoryWrappers = new ArrayList<>();
 
-		ITableExportNodeConverterFactory<CT> defaultFactory = nodeConverterFactoryConfiguration.getDefaultFactory();
-		List<ITableExportNodeConverterFactory<CT>> factories = nodeConverterFactoryConfiguration.getAvailableFactories();
-		ITableExportNodeConverterFactory<CT> preselectedFactory =
-				nodeConverterFactorySelectionModel.getSelectedConverterFactoriesByColumn().get(this.targetColumn);
+		ITableExportNodeConverterFactory defaultFactory = nodeConverterFactoryConfiguration.getDefaultFactory();
+		List<ITableExportNodeConverterFactory> factories = nodeConverterFactoryConfiguration.getAvailableFactories();
+		ITableExportNodeConverterFactory preselectedFactory = nodeConverterFactorySelectionModel.getSelectedConverterFactoriesByColumn().get(this.targetColumn);
 
 		for (int i = 0; i < factories.size(); i++) {
-			ITableExportNodeConverterFactory<CT> factory = factories.get(i);
+			ITableExportNodeConverterFactory factory = factories.get(i);
 
-			TableExportNodeConverterFactoryWrapper<CT> factoryWrapper = new TableExportNodeConverterFactoryWrapper<>(factory, i);
+			TableExportNodeConverterFactoryWrapper factoryWrapper = new TableExportNodeConverterFactoryWrapper(factory, i);
 			factoryWrappers.add(factoryWrapper);
 
 			if (factory.equals(defaultFactory)) {
@@ -63,9 +62,9 @@ public class TableExportNodeConverterFactoryValueSelectBuilder<CT> extends DomSi
 	}
 
 	@Override
-	public DomSimpleValueSelect<TableExportNodeConverterFactoryWrapper<CT>> build() {
+	public DomSimpleValueSelect<TableExportNodeConverterFactoryWrapper> build() {
 
-		DomSimpleValueSelect<TableExportNodeConverterFactoryWrapper<CT>> select = super.build();
+		DomSimpleValueSelect<TableExportNodeConverterFactoryWrapper> select = super.build();
 
 		ModelRefresher modelRefresher = new ModelRefresher(select);
 		HelpCellRefresher helpCellRefresher = new HelpCellRefresher(select);
@@ -89,9 +88,9 @@ public class TableExportNodeConverterFactoryValueSelectBuilder<CT> extends DomSi
 
 	private class ModelRefresher {
 
-		private final DomSimpleValueSelect<TableExportNodeConverterFactoryWrapper<CT>> select;
+		private final DomSimpleValueSelect<TableExportNodeConverterFactoryWrapper> select;
 
-		public ModelRefresher(DomSimpleValueSelect<TableExportNodeConverterFactoryWrapper<CT>> select) {
+		public ModelRefresher(DomSimpleValueSelect<TableExportNodeConverterFactoryWrapper> select) {
 
 			this.select = select;
 		}
@@ -100,7 +99,7 @@ public class TableExportNodeConverterFactoryValueSelectBuilder<CT> extends DomSi
 
 			var factoryWrapper = this.select.getSelectedValue();
 			if (factoryWrapper.isPresent()) {
-				ITableExportNodeConverterFactory<CT> converterFactory = factoryWrapper.get().getConverterFactory();
+				ITableExportNodeConverterFactory converterFactory = factoryWrapper.get().getConverterFactory();
 				nodeConverterFactorySelectionModel.selectConverterFactory(targetColumn, converterFactory);
 			} else {
 				nodeConverterFactorySelectionModel.unselectConverterFactory(targetColumn);
@@ -110,9 +109,9 @@ public class TableExportNodeConverterFactoryValueSelectBuilder<CT> extends DomSi
 
 	private class HelpCellRefresher {
 
-		private final DomSimpleValueSelect<TableExportNodeConverterFactoryWrapper<CT>> select;
+		private final DomSimpleValueSelect<TableExportNodeConverterFactoryWrapper> select;
 
-		public HelpCellRefresher(DomSimpleValueSelect<TableExportNodeConverterFactoryWrapper<CT>> select) {
+		public HelpCellRefresher(DomSimpleValueSelect<TableExportNodeConverterFactoryWrapper> select) {
 
 			this.select = select;
 		}
@@ -126,7 +125,7 @@ public class TableExportNodeConverterFactoryValueSelectBuilder<CT> extends DomSi
 
 			var selectedValue = select.getSelectedValue();
 			if (selectedValue.isPresent()) {
-				ITableExportNodeConverterFactory<CT> converterFactory = selectedValue.get().getConverterFactory();
+				ITableExportNodeConverterFactory converterFactory = selectedValue.get().getConverterFactory();
 
 				if (converterFactory != null) {
 					converterDescription = converterFactory.getConverterDescription();
@@ -135,10 +134,8 @@ public class TableExportNodeConverterFactoryValueSelectBuilder<CT> extends DomSi
 			}
 
 			if (converterDescription != null) {
-				DomButton helpButton = new DomHelpPopupButton(
-					DomI18n.HELP,
-					DomI18n.CONVERSION.concatFormat(": \"%s\"", converterDisplayString),
-					converterDescription);
+				DomButton helpButton =
+						new DomHelpPopupButton(DomI18n.HELP, DomI18n.CONVERSION.concatFormat(": \"%s\"", converterDisplayString), converterDescription);
 
 				converterFactoryHelpElementParent.appendChild(helpButton);
 			}

--- a/platform-emf/src/main/java/com/softicar/platform/emf/data/table/export/conversion/factory/TableExportNodeConverterFactoryWrapper.java
+++ b/platform-emf/src/main/java/com/softicar/platform/emf/data/table/export/conversion/factory/TableExportNodeConverterFactoryWrapper.java
@@ -5,18 +5,18 @@ import com.softicar.platform.common.core.i18n.IDisplayString;
 import com.softicar.platform.common.core.item.BasicItemComparator;
 import com.softicar.platform.common.core.item.IBasicItem;
 
-public class TableExportNodeConverterFactoryWrapper<CT> implements IEntity {
+public class TableExportNodeConverterFactoryWrapper implements IEntity {
 
-	private final ITableExportNodeConverterFactory<CT> converterFactory;
+	private final ITableExportNodeConverterFactory converterFactory;
 	private final int id;
 
-	public TableExportNodeConverterFactoryWrapper(ITableExportNodeConverterFactory<CT> converterFactory, int id) {
+	public TableExportNodeConverterFactoryWrapper(ITableExportNodeConverterFactory converterFactory, int id) {
 
 		this.converterFactory = converterFactory;
 		this.id = id;
 	}
 
-	public ITableExportNodeConverterFactory<CT> getConverterFactory() {
+	public ITableExportNodeConverterFactory getConverterFactory() {
 
 		return converterFactory;
 	}

--- a/platform-emf/src/main/java/com/softicar/platform/emf/data/table/export/conversion/factory/TableExportStrictNodeConverterFactory.java
+++ b/platform-emf/src/main/java/com/softicar/platform/emf/data/table/export/conversion/factory/TableExportStrictNodeConverterFactory.java
@@ -5,7 +5,6 @@ import com.softicar.platform.dom.DomI18n;
 import com.softicar.platform.emf.data.table.export.conversion.ITableExportNodeConverter;
 import com.softicar.platform.emf.data.table.export.conversion.TableExportTypedNodeConverter;
 import com.softicar.platform.emf.data.table.export.node.ITableExportTypedNode;
-import com.softicar.platform.emf.data.table.export.node.TableExportTypedNodeValue;
 
 /**
  * Creates an {@link ITableExportNodeConverter} that performs type safe content
@@ -16,10 +15,10 @@ import com.softicar.platform.emf.data.table.export.node.TableExportTypedNodeValu
  *
  * @author Alexander Schmidt
  */
-public class TableExportStrictNodeConverterFactory implements ITableExportNodeConverterFactory<TableExportTypedNodeValue> {
+public class TableExportStrictNodeConverterFactory implements ITableExportNodeConverterFactory {
 
 	@Override
-	public ITableExportNodeConverter<TableExportTypedNodeValue> create() {
+	public ITableExportNodeConverter create() {
 
 		return new TableExportTypedNodeConverter().setEnableAutomaticTypeConversion(false);
 	}

--- a/platform-emf/src/main/java/com/softicar/platform/emf/data/table/export/conversion/factory/TableExportTextOnlyNodeConverterFactory.java
+++ b/platform-emf/src/main/java/com/softicar/platform/emf/data/table/export/conversion/factory/TableExportTextOnlyNodeConverterFactory.java
@@ -5,7 +5,6 @@ import com.softicar.platform.dom.DomI18n;
 import com.softicar.platform.emf.data.table.export.conversion.ITableExportNodeConverter;
 import com.softicar.platform.emf.data.table.export.conversion.TableExportTypedNodeConverter;
 import com.softicar.platform.emf.data.table.export.node.ITableExportTypedNode;
-import com.softicar.platform.emf.data.table.export.node.TableExportTypedNodeValue;
 
 /**
  * Creates an {@link ITableExportNodeConverter} that converts all node contents
@@ -13,7 +12,7 @@ import com.softicar.platform.emf.data.table.export.node.TableExportTypedNodeValu
  *
  * @author Alexander Schmidt
  */
-public class TableExportTextOnlyNodeConverterFactory implements ITableExportNodeConverterFactory<TableExportTypedNodeValue> {
+public class TableExportTextOnlyNodeConverterFactory implements ITableExportNodeConverterFactory {
 
 	private final String cellContentSeparator;
 
@@ -28,7 +27,7 @@ public class TableExportTextOnlyNodeConverterFactory implements ITableExportNode
 	}
 
 	@Override
-	public ITableExportNodeConverter<TableExportTypedNodeValue> create() {
+	public ITableExportNodeConverter create() {
 
 		TableExportTypedNodeConverter converter = new TableExportTypedNodeConverter().setEnableAutomaticTypeConversion(false).setForceStringValues(true);
 

--- a/platform-emf/src/main/java/com/softicar/platform/emf/data/table/export/conversion/factory/configuration/TableExportNodeConverterFactoryConfiguration.java
+++ b/platform-emf/src/main/java/com/softicar/platform/emf/data/table/export/conversion/factory/configuration/TableExportNodeConverterFactoryConfiguration.java
@@ -6,18 +6,17 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
-public class TableExportNodeConverterFactoryConfiguration<CT> {
+public class TableExportNodeConverterFactoryConfiguration {
 
-	private final ITableExportNodeConverterFactory<CT> headerFactory;
-	private final ITableExportNodeConverterFactory<CT> defaultFactory;
-	private final List<ITableExportNodeConverterFactory<CT>> availableFactories = new ArrayList<>();
+	private final ITableExportNodeConverterFactory headerFactory;
+	private final ITableExportNodeConverterFactory defaultFactory;
+	private final List<ITableExportNodeConverterFactory> availableFactories = new ArrayList<>();
 
 	/**
 	 * @param headerFactory
 	 * @param defaultFactory
 	 */
-	public TableExportNodeConverterFactoryConfiguration(ITableExportNodeConverterFactory<CT> headerFactory,
-			ITableExportNodeConverterFactory<CT> defaultFactory) {
+	public TableExportNodeConverterFactoryConfiguration(ITableExportNodeConverterFactory headerFactory, ITableExportNodeConverterFactory defaultFactory) {
 
 		validateArgumentConverterFactory(headerFactory);
 		validateArgumentConverterFactory(defaultFactory);
@@ -29,7 +28,7 @@ public class TableExportNodeConverterFactoryConfiguration<CT> {
 	}
 
 	@SafeVarargs
-	public final TableExportNodeConverterFactoryConfiguration<CT> addAvailableFactories(ITableExportNodeConverterFactory<CT>...availableFactories) {
+	public final TableExportNodeConverterFactoryConfiguration addAvailableFactories(ITableExportNodeConverterFactory...availableFactories) {
 
 		if (availableFactories != null) {
 			this.availableFactories.addAll(Arrays.asList(availableFactories));
@@ -38,22 +37,22 @@ public class TableExportNodeConverterFactoryConfiguration<CT> {
 		return this;
 	}
 
-	public ITableExportNodeConverterFactory<CT> getHeaderFactory() {
+	public ITableExportNodeConverterFactory getHeaderFactory() {
 
 		return headerFactory;
 	}
 
-	public ITableExportNodeConverterFactory<CT> getDefaultFactory() {
+	public ITableExportNodeConverterFactory getDefaultFactory() {
 
 		return defaultFactory;
 	}
 
-	public List<ITableExportNodeConverterFactory<CT>> getAvailableFactories() {
+	public List<ITableExportNodeConverterFactory> getAvailableFactories() {
 
 		return availableFactories;
 	}
 
-	private static final void validateArgumentConverterFactory(ITableExportNodeConverterFactory<?> converter) {
+	private static final void validateArgumentConverterFactory(ITableExportNodeConverterFactory converter) {
 
 		if (converter == null) {
 			throw new SofticarDeveloperException("The given %s must not be null.", ITableExportNodeConverterFactory.class.getSimpleName());

--- a/platform-emf/src/main/java/com/softicar/platform/emf/data/table/export/conversion/factory/selection/TableExportNodeConverterFactorySelectionModel.java
+++ b/platform-emf/src/main/java/com/softicar/platform/emf/data/table/export/conversion/factory/selection/TableExportNodeConverterFactorySelectionModel.java
@@ -8,17 +8,17 @@ import java.util.Map;
 import java.util.Set;
 import java.util.TreeMap;
 
-public class TableExportNodeConverterFactorySelectionModel<CT> {
+public class TableExportNodeConverterFactorySelectionModel {
 
-	private final TableExportNodeConverterFactoryConfiguration<CT> nodeConverterFactoryConfiguration;
-	private final Map<Integer, ITableExportNodeConverterFactory<CT>> selectedConverterFactoriesByColumn = new TreeMap<>();
+	private final TableExportNodeConverterFactoryConfiguration nodeConverterFactoryConfiguration;
+	private final Map<Integer, ITableExportNodeConverterFactory> selectedConverterFactoriesByColumn = new TreeMap<>();
 
-	public TableExportNodeConverterFactorySelectionModel(TableExportNodeConverterFactoryConfiguration<CT> nodeConverterFactoryConfiguration) {
+	public TableExportNodeConverterFactorySelectionModel(TableExportNodeConverterFactoryConfiguration nodeConverterFactoryConfiguration) {
 
 		this.nodeConverterFactoryConfiguration = nodeConverterFactoryConfiguration;
 	}
 
-	public void selectConverterFactory(int column, ITableExportNodeConverterFactory<CT> converterFactory) {
+	public void selectConverterFactory(int column, ITableExportNodeConverterFactory converterFactory) {
 
 		if (converterFactory != null) {
 			if (this.nodeConverterFactoryConfiguration.getAvailableFactories().contains(converterFactory)) {
@@ -39,18 +39,18 @@ public class TableExportNodeConverterFactorySelectionModel<CT> {
 		selectConverterFactory(column, null);
 	}
 
-	public Map<Integer, ITableExportNodeConverterFactory<CT>> getSelectedConverterFactoriesByColumn() {
+	public Map<Integer, ITableExportNodeConverterFactory> getSelectedConverterFactoriesByColumn() {
 
 		return selectedConverterFactoriesByColumn;
 	}
 
-	public Map<Integer, ITableExportNodeConverter<CT>> fetchNodeConvertersByColumn(Set<Integer> selectedColumnIndexes) {
+	public Map<Integer, ITableExportNodeConverter> fetchNodeConvertersByColumn(Set<Integer> selectedColumnIndexes) {
 
-		Map<Integer, ITableExportNodeConverter<CT>> nodeConvertersByColumn = new TreeMap<>();
+		Map<Integer, ITableExportNodeConverter> nodeConvertersByColumn = new TreeMap<>();
 
 		for (Integer columnIndex: selectedColumnIndexes) {
-			ITableExportNodeConverterFactory<CT> selectedConverterFactory = this.selectedConverterFactoriesByColumn.get(columnIndex);
-			ITableExportNodeConverter<CT> nodeConverter;
+			ITableExportNodeConverterFactory selectedConverterFactory = this.selectedConverterFactoriesByColumn.get(columnIndex);
+			ITableExportNodeConverter nodeConverter;
 
 			if (selectedConverterFactory != null) {
 				nodeConverter = selectedConverterFactory.create();

--- a/platform-emf/src/main/java/com/softicar/platform/emf/data/table/export/engine/ITableExportEngine.java
+++ b/platform-emf/src/main/java/com/softicar/platform/emf/data/table/export/engine/ITableExportEngine.java
@@ -8,7 +8,6 @@ import com.softicar.platform.emf.data.table.export.conversion.factory.configurat
 import com.softicar.platform.emf.data.table.export.conversion.factory.selection.TableExportNodeConverterFactorySelectionModel;
 import com.softicar.platform.emf.data.table.export.engine.factory.ITableExportEngineFactory;
 import com.softicar.platform.emf.data.table.export.model.TableExportTableModel;
-import com.softicar.platform.emf.data.table.export.node.TableExportTypedNodeValue;
 import java.io.OutputStream;
 import java.util.Collection;
 import java.util.function.Supplier;
@@ -16,13 +15,9 @@ import java.util.function.Supplier;
 /**
  * Common interface of all table export engines.
  *
- * @param <CT>
- *            The type to which table cell contents get converted for the
- *            export. Though not mandatory, {@link TableExportTypedNodeValue} is
- *            recommended for any implementation.
  * @author Alexander Schmidt
  */
-public interface ITableExportEngine<CT> {
+public interface ITableExportEngine {
 
 	void export(DomTable table);
 
@@ -32,20 +27,20 @@ public interface ITableExportEngine<CT> {
 
 	void export(Collection<TableExportTableModel> tableModels);
 
-	ITableExportEngine<CT> setFileNamePrefix(String fileNamePrefix);
+	ITableExportEngine setFileNamePrefix(String fileNamePrefix);
 
-	ITableExportEngine<CT> setAppendTimestamp(boolean appendTimestamp);
+	ITableExportEngine setAppendTimestamp(boolean appendTimestamp);
 
-	ITableExportEngine<CT> setEnableDeflateCompression(boolean enableDeflateCompression);
+	ITableExportEngine setEnableDeflateCompression(boolean enableDeflateCompression);
 
-	ITableExportEngine<CT> setOutputStreamCreationFunction(Supplier<OutputStream> outputStreamSupplierFunction);
+	ITableExportEngine setOutputStreamCreationFunction(Supplier<OutputStream> outputStreamSupplierFunction);
 
-	ITableExportEngineFactory<? extends ITableExportEngine<CT>> getCreatingFactory();
+	ITableExportEngineFactory<? extends ITableExportEngine> getCreatingFactory();
 
-	TableExportNodeConverterFactoryConfiguration<CT> getNodeConverterFactoryConfiguration();
+	TableExportNodeConverterFactoryConfiguration getNodeConverterFactoryConfiguration();
 
-	TableExportNodeConverterFactorySelectionModel<CT> getNodeConverterFactorySelectionModel();
+	TableExportNodeConverterFactorySelectionModel getNodeConverterFactorySelectionModel();
 
-	DomSimpleValueSelectBuilder<TableExportNodeConverterFactoryWrapper<CT>> createConverterFactoryValueSelectBuiler(int targetColumn,
+	DomSimpleValueSelectBuilder<TableExportNodeConverterFactoryWrapper> createConverterFactoryValueSelectBuiler(int targetColumn,
 			DomParentElement converterFactoryHelpElementParent);
 }

--- a/platform-emf/src/main/java/com/softicar/platform/emf/data/table/export/engine/configuration/TableExportColumnConfiguration.java
+++ b/platform-emf/src/main/java/com/softicar/platform/emf/data/table/export/engine/configuration/TableExportColumnConfiguration.java
@@ -4,14 +4,14 @@ import com.softicar.platform.emf.data.table.export.conversion.ITableExportNodeCo
 import com.softicar.platform.emf.data.table.export.model.TableExportColumnModel;
 import java.util.Map;
 
-public class TableExportColumnConfiguration<CT> {
+public class TableExportColumnConfiguration {
 
 	private final Map<Integer, TableExportColumnModel> selectedColumnModels;
-	private final Map<Integer, ITableExportNodeConverter<CT>> nodeConvertersByColumn;
-	private final ITableExportNodeConverter<CT> headerConverter;
+	private final Map<Integer, ITableExportNodeConverter> nodeConvertersByColumn;
+	private final ITableExportNodeConverter headerConverter;
 
-	public TableExportColumnConfiguration(Map<Integer, TableExportColumnModel> selectedColumnModels, Map<Integer, ITableExportNodeConverter<CT>> nodeConvertersByColumn,
-			ITableExportNodeConverter<CT> headerConverter) {
+	public TableExportColumnConfiguration(Map<Integer, TableExportColumnModel> selectedColumnModels,
+			Map<Integer, ITableExportNodeConverter> nodeConvertersByColumn, ITableExportNodeConverter headerConverter) {
 
 		this.selectedColumnModels = selectedColumnModels;
 		this.nodeConvertersByColumn = nodeConvertersByColumn;
@@ -23,12 +23,12 @@ public class TableExportColumnConfiguration<CT> {
 		return selectedColumnModels;
 	}
 
-	public Map<Integer, ITableExportNodeConverter<CT>> getNodeConvertersByColumn() {
+	public Map<Integer, ITableExportNodeConverter> getNodeConvertersByColumn() {
 
 		return nodeConvertersByColumn;
 	}
 
-	public ITableExportNodeConverter<CT> getHeaderConverter() {
+	public ITableExportNodeConverter getHeaderConverter() {
 
 		return headerConverter;
 	}

--- a/platform-emf/src/main/java/com/softicar/platform/emf/data/table/export/engine/configuration/TableExportTableConfiguration.java
+++ b/platform-emf/src/main/java/com/softicar/platform/emf/data/table/export/engine/configuration/TableExportTableConfiguration.java
@@ -6,12 +6,12 @@ import com.softicar.platform.emf.data.table.export.model.TableExportTableModel;
 import com.softicar.platform.emf.data.table.export.node.style.TableExportTableCssClass;
 import java.util.Optional;
 
-public class TableExportTableConfiguration<CT> {
+public class TableExportTableConfiguration {
 
 	private final TableExportTableModel tableModel;
-	private final TableExportColumnConfiguration<CT> columnConfiguration;
+	private final TableExportColumnConfiguration columnConfiguration;
 
-	public TableExportTableConfiguration(TableExportTableModel tableModel, TableExportColumnConfiguration<CT> columnConfiguration) {
+	public TableExportTableConfiguration(TableExportTableModel tableModel, TableExportColumnConfiguration columnConfiguration) {
 
 		this.tableModel = tableModel;
 		this.columnConfiguration = columnConfiguration;
@@ -32,7 +32,7 @@ public class TableExportTableConfiguration<CT> {
 		return new TableExportTableCssClass(getTable());
 	}
 
-	public TableExportColumnConfiguration<CT> getColumnConfiguration() {
+	public TableExportColumnConfiguration getColumnConfiguration() {
 
 		return columnConfiguration;
 	}

--- a/platform-emf/src/main/java/com/softicar/platform/emf/data/table/export/engine/factory/AbstractTableExportEngineFactory.java
+++ b/platform-emf/src/main/java/com/softicar/platform/emf/data/table/export/engine/factory/AbstractTableExportEngineFactory.java
@@ -4,7 +4,7 @@ import com.softicar.platform.common.core.i18n.IDisplayString;
 import com.softicar.platform.emf.data.table.export.engine.ITableExportEngine;
 import com.softicar.platform.emf.data.table.export.engine.configuration.TableExportEngineConfiguration;
 
-public abstract class AbstractTableExportEngineFactory<ET extends ITableExportEngine<?>> implements ITableExportEngineFactory<ET> {
+public abstract class AbstractTableExportEngineFactory<ET extends ITableExportEngine> implements ITableExportEngineFactory<ET> {
 
 	protected final TableExportEngineConfiguration engineConfiguration;
 

--- a/platform-emf/src/main/java/com/softicar/platform/emf/data/table/export/engine/factory/ITableExportEngineFactory.java
+++ b/platform-emf/src/main/java/com/softicar/platform/emf/data/table/export/engine/factory/ITableExportEngineFactory.java
@@ -14,7 +14,7 @@ import java.util.Collection;
  *            the type of the {@link ITableExportEngine} to create
  * @author Alexander Schmidt
  */
-public interface ITableExportEngineFactory<ET extends ITableExportEngine<?>> extends IDisplayable {
+public interface ITableExportEngineFactory<ET extends ITableExportEngine> extends IDisplayable {
 
 	/**
 	 * @return a new instance of an {@link ITableExportEngine} (never null)

--- a/platform-emf/src/main/java/com/softicar/platform/emf/data/table/export/implementation/csv/TableExportCsvEngine.java
+++ b/platform-emf/src/main/java/com/softicar/platform/emf/data/table/export/implementation/csv/TableExportCsvEngine.java
@@ -31,7 +31,7 @@ import java.util.regex.Pattern;
  *
  * @author Alexander Schmidt
  */
-public class TableExportCsvEngine extends AbstractTableExportEngine<TableExportTypedNodeValue, CsvRow, CsvCell> {
+public class TableExportCsvEngine extends AbstractTableExportEngine<CsvRow, CsvCell> {
 
 	private static final String ALL_COMMA_SEPARATORS = "\\,\t;";
 	private static final char QUOTATION_CHAR = '"';
@@ -52,14 +52,13 @@ public class TableExportCsvEngine extends AbstractTableExportEngine<TableExportT
 	 *            Excel, that must be ';'.
 	 * @param prependByteOrderMark
 	 */
-	public TableExportCsvEngine(TableExportEngineConfiguration configuration,
-			ITableExportEngineFactory<? extends ITableExportEngine<TableExportTypedNodeValue>> creatingFactory, char outputSeparator,
-			boolean prependByteOrderMark) {
+	public TableExportCsvEngine(TableExportEngineConfiguration configuration, ITableExportEngineFactory<? extends ITableExportEngine> creatingFactory,
+			char outputSeparator, boolean prependByteOrderMark) {
 
 		super(
 			configuration, //
 			creatingFactory,
-			new TableExportNodeConverterFactoryConfiguration<>(//
+			new TableExportNodeConverterFactoryConfiguration(//
 				new TableExportTextOnlyNodeConverterFactory(),
 				new TableExportDefaultNodeConverterFactory()//
 			).addAvailableFactories(new TableExportStrictNodeConverterFactory(), new TableExportTextOnlyNodeConverterFactory())//
@@ -70,7 +69,7 @@ public class TableExportCsvEngine extends AbstractTableExportEngine<TableExportT
 	}
 
 	@Override
-	protected void prepareExport(OutputStream targetOutputStream, Collection<TableExportTableConfiguration<TableExportTypedNodeValue>> tableConfigurations) {
+	protected void prepareExport(OutputStream targetOutputStream, Collection<TableExportTableConfiguration> tableConfigurations) {
 
 		OutputStreamWriter outputStreamWriter = new OutputStreamWriter(targetOutputStream, OUTPUT_FILE_CHARSET);
 
@@ -89,7 +88,7 @@ public class TableExportCsvEngine extends AbstractTableExportEngine<TableExportT
 	}
 
 	@Override
-	protected void prepareTable(TableExportTableConfiguration<TableExportTypedNodeValue> tableConfiguration) {
+	protected void prepareTable(TableExportTableConfiguration tableConfiguration) {
 
 		// nothing to do
 	}
@@ -101,8 +100,8 @@ public class TableExportCsvEngine extends AbstractTableExportEngine<TableExportT
 	}
 
 	@Override
-	protected CsvCell createAndAppendCell(CsvRow documentRow, int targetColIndex, boolean isHeader,
-			NodeConverterResult<TableExportTypedNodeValue> convertedCellContent, TableExportNodeStyle exportNodeStyle) {
+	protected CsvCell createAndAppendCell(CsvRow documentRow, int targetColIndex, boolean isHeader, NodeConverterResult convertedCellContent,
+			TableExportNodeStyle exportNodeStyle) {
 
 		return documentRow.addCell(targetColIndex, new CsvCell(convertedCellContent.getContent()));
 	}

--- a/platform-emf/src/main/java/com/softicar/platform/emf/data/table/export/implementation/excel/TableExportExcelEngine.java
+++ b/platform-emf/src/main/java/com/softicar/platform/emf/data/table/export/implementation/excel/TableExportExcelEngine.java
@@ -49,7 +49,7 @@ import org.apache.poi.xssf.usermodel.XSSFWorkbook;
  *
  * @author Alexander Schmidt
  */
-public class TableExportExcelEngine extends AbstractTableExportEngine<TableExportTypedNodeValue, Row, Cell> {
+public class TableExportExcelEngine extends AbstractTableExportEngine<Row, Cell> {
 
 	public static final int NUM_TABLE_SPACER_ROWS = 2;
 
@@ -79,12 +79,12 @@ public class TableExportExcelEngine extends AbstractTableExportEngine<TableExpor
 	private int maxColumnIndex;
 
 	public TableExportExcelEngine(TableExportEngineConfiguration configuration, TableExportExcelExportConfiguration poiExportConfiguration,
-			ITableExportEngineFactory<? extends ITableExportEngine<TableExportTypedNodeValue>> creatingFactory) {
+			ITableExportEngineFactory<? extends ITableExportEngine> creatingFactory) {
 
 		super(
 			configuration,
 			creatingFactory,
-			new TableExportNodeConverterFactoryConfiguration<>(new TableExportTextOnlyNodeConverterFactory(), new TableExportDefaultNodeConverterFactory())
+			new TableExportNodeConverterFactoryConfiguration(new TableExportTextOnlyNodeConverterFactory(), new TableExportDefaultNodeConverterFactory())
 				.addAvailableFactories(new TableExportStrictNodeConverterFactory(), new TableExportTextOnlyNodeConverterFactory()));
 
 		this.poiExportConfiguration = poiExportConfiguration;
@@ -95,7 +95,7 @@ public class TableExportExcelEngine extends AbstractTableExportEngine<TableExpor
 	}
 
 	@Override
-	protected void prepareExport(OutputStream targetOutputStream, Collection<TableExportTableConfiguration<TableExportTypedNodeValue>> tableConfigurations) {
+	protected void prepareExport(OutputStream targetOutputStream, Collection<TableExportTableConfiguration> tableConfigurations) {
 
 		this.workbook = TableExportExcelWorkbookCreator.createWorkbook(poiExportConfiguration.getFormat());
 		assertStreamingWorkbook(this.workbook);
@@ -120,7 +120,7 @@ public class TableExportExcelEngine extends AbstractTableExportEngine<TableExpor
 	}
 
 	@Override
-	protected void prepareTable(TableExportTableConfiguration<TableExportTypedNodeValue> tableConfiguration) {
+	protected void prepareTable(TableExportTableConfiguration tableConfiguration) {
 
 		if (sheet == null || poiExportConfiguration.isSheetPerTable()) {
 			this.sheet = this.workbook.createSheet(getNextSheetTitle(tableConfiguration));
@@ -136,8 +136,8 @@ public class TableExportExcelEngine extends AbstractTableExportEngine<TableExpor
 	}
 
 	@Override
-	protected Cell createAndAppendCell(Row documentRow, int targetColIndex, boolean isHeader,
-			NodeConverterResult<TableExportTypedNodeValue> convertedCellContent, TableExportNodeStyle exportNodeStyle) {
+	protected Cell createAndAppendCell(Row documentRow, int targetColIndex, boolean isHeader, NodeConverterResult convertedCellContent,
+			TableExportNodeStyle exportNodeStyle) {
 
 		TableExportCellAlignment cellAlignment = exportNodeStyle.getAlignment();
 		IColor backgroundColor = exportNodeStyle.getBackgroundColor();
@@ -269,7 +269,7 @@ public class TableExportExcelEngine extends AbstractTableExportEngine<TableExpor
 		return (short) (fontHeight + spacing + VERTIAL_PADDING_COMPENSATION);
 	}
 
-	private String getNextSheetTitle(TableExportTableConfiguration<TableExportTypedNodeValue> tableConfiguration) {
+	private String getNextSheetTitle(TableExportTableConfiguration tableConfiguration) {
 
 		if (poiExportConfiguration.isSheetPerTable()) {
 			return tableConfiguration//

--- a/platform-emf/src/main/java/com/softicar/platform/emf/data/table/export/implementation/html/TableExportHtmlEngine.java
+++ b/platform-emf/src/main/java/com/softicar/platform/emf/data/table/export/implementation/html/TableExportHtmlEngine.java
@@ -31,7 +31,7 @@ import java.util.SortedMap;
 import java.util.TreeMap;
 import org.apache.commons.text.StringEscapeUtils;
 
-public class TableExportHtmlEngine extends AbstractTableExportEngine<TableExportTypedNodeValue, HtmlRow, HtmlCell> {
+public class TableExportHtmlEngine extends AbstractTableExportEngine<HtmlRow, HtmlCell> {
 
 	private static final Charset OUTPUT_FILE_CHARSET = StandardCharsets.UTF_8;
 	private static final Charset CSS_FILE_CHARSET = StandardCharsets.UTF_8;
@@ -43,13 +43,12 @@ public class TableExportHtmlEngine extends AbstractTableExportEngine<TableExport
 	private StringBuilder currentTableBodyBuilder = null;
 	private TableExportTableCssClass currentTableCssClass = null;
 
-	public TableExportHtmlEngine(TableExportEngineConfiguration configuration,
-			ITableExportEngineFactory<? extends ITableExportEngine<TableExportTypedNodeValue>> creatingFactory) {
+	public TableExportHtmlEngine(TableExportEngineConfiguration configuration, ITableExportEngineFactory<? extends ITableExportEngine> creatingFactory) {
 
 		super(
 			configuration, //
 			creatingFactory,
-			new TableExportNodeConverterFactoryConfiguration<>(//
+			new TableExportNodeConverterFactoryConfiguration(//
 				new TableExportTextOnlyNodeConverterFactory(),
 				new TableExportDefaultNodeConverterFactory()//
 			).addAvailableFactories(new TableExportStrictNodeConverterFactory(), new TableExportTextOnlyNodeConverterFactory())//
@@ -57,7 +56,7 @@ public class TableExportHtmlEngine extends AbstractTableExportEngine<TableExport
 	}
 
 	@Override
-	protected void prepareExport(OutputStream targetOutputStream, Collection<TableExportTableConfiguration<TableExportTypedNodeValue>> tableConfigurations) {
+	protected void prepareExport(OutputStream targetOutputStream, Collection<TableExportTableConfiguration> tableConfigurations) {
 
 		OutputStreamWriter outputStreamWriter = new OutputStreamWriter(targetOutputStream, OUTPUT_FILE_CHARSET);
 
@@ -90,7 +89,7 @@ public class TableExportHtmlEngine extends AbstractTableExportEngine<TableExport
 	}
 
 	@Override
-	protected void prepareTable(TableExportTableConfiguration<TableExportTypedNodeValue> tableConfiguration) {
+	protected void prepareTable(TableExportTableConfiguration tableConfiguration) {
 
 		this.currentTableCssClass = tableConfiguration.getTableCssClass();
 
@@ -121,8 +120,8 @@ public class TableExportHtmlEngine extends AbstractTableExportEngine<TableExport
 	 * export engine. Instead it uses {@link DomCssFiles#DOM_STYLE}.
 	 */
 	@Override
-	protected HtmlCell createAndAppendCell(HtmlRow documentRow, int targetColIndex, boolean isHeader,
-			NodeConverterResult<TableExportTypedNodeValue> convertedCellContent, TableExportNodeStyle exportNodeStyle) {
+	protected HtmlCell createAndAppendCell(HtmlRow documentRow, int targetColIndex, boolean isHeader, NodeConverterResult convertedCellContent,
+			TableExportNodeStyle exportNodeStyle) {
 
 		return documentRow.addCell(targetColIndex, new HtmlCell(convertedCellContent.getContent(), isHeader));
 	}

--- a/platform-emf/src/main/java/com/softicar/platform/emf/data/table/export/model/TableExportColumnModelFetcher.java
+++ b/platform-emf/src/main/java/com/softicar/platform/emf/data/table/export/model/TableExportColumnModelFetcher.java
@@ -12,7 +12,6 @@ import com.softicar.platform.emf.data.table.export.conversion.ITableExportNodeCo
 import com.softicar.platform.emf.data.table.export.conversion.factory.TableExportTextOnlyNodeConverterFactory;
 import com.softicar.platform.emf.data.table.export.element.TableExportChildElementFetcher;
 import com.softicar.platform.emf.data.table.export.element.TableExportNamedDomCell;
-import com.softicar.platform.emf.data.table.export.node.TableExportTypedNodeValue;
 import com.softicar.platform.emf.data.table.export.spanning.TableExportSpanFetcher;
 import com.softicar.platform.emf.data.table.export.spanning.algorithm.TableExportSpanningElementLayouter;
 import com.softicar.platform.emf.data.table.export.spanning.element.TableExportSpanningCell;
@@ -121,8 +120,7 @@ public class TableExportColumnModelFetcher {
 
 		SimpleMatrix<Integer, Integer, TableExportNamedDomCell> result = new SimpleMatrix<>(new TableExportNamedDomCell.NamedDomCellMatrixTraits());
 
-		ITableExportNodeConverter<TableExportTypedNodeValue> textConverter =
-				new TableExportTextOnlyNodeConverterFactory(HEADER_CELL_CONTENT_SEPARATOR).create();
+		ITableExportNodeConverter textConverter = new TableExportTextOnlyNodeConverterFactory(HEADER_CELL_CONTENT_SEPARATOR).create();
 
 		for (Entry<Integer, SortedMap<Integer, TableExportSpanningCell>> outerEntry: placedSpanningObjects.entrySet()) {
 			for (Entry<Integer, TableExportSpanningCell> innerEntry: outerEntry.getValue().entrySet()) {

--- a/platform-emf/src/main/java/com/softicar/platform/emf/data/table/export/popup/ITableExportPopupOptionsProvider.java
+++ b/platform-emf/src/main/java/com/softicar/platform/emf/data/table/export/popup/ITableExportPopupOptionsProvider.java
@@ -11,7 +11,7 @@ import com.softicar.platform.emf.data.table.export.engine.ITableExportEngine;
  */
 public interface ITableExportPopupOptionsProvider {
 
-	ITableExportEngine<?> getCurrentEngineOrNull();
+	ITableExportEngine getCurrentEngineOrNull();
 
 	DomPopup getColumnSelectionPopup();
 

--- a/platform-emf/src/main/java/com/softicar/platform/emf/data/table/export/popup/TableExportPopupConfigurationInputForm.java
+++ b/platform-emf/src/main/java/com/softicar/platform/emf/data/table/export/popup/TableExportPopupConfigurationInputForm.java
@@ -44,11 +44,11 @@ public class TableExportPopupConfigurationInputForm extends DomLabelGrid impleme
 	private final EmfBooleanInput inputEnableDeflateCompression;
 	private final FileNameSuffixDiv fileNameSuffixDiv;
 	private final DomSimpleValueSelect<ITableExportEngineFactory<?>> inputEngineFactorySelect;
-	private final Map<String, ITableExportEngine<?>> engineByFactoryClassName = new TreeMap<>();
+	private final Map<String, ITableExportEngine> engineByFactoryClassName = new TreeMap<>();
 
 	private TableExportColumnSelectionButton columnSelectionButton;
 
-	private ITableExportEngine<?> currentEngine = null;
+	private ITableExportEngine currentEngine = null;
 
 	public TableExportPopupConfigurationInputForm(TableExportTableModel mainTableModel, ITableExportFileNameSuffixCreator fileNameSuffixCreator,
 			TableExportPopupLowerMessageDiv lowerMessageDiv, boolean appendTimestamp, boolean enableDeflateCompression) {
@@ -78,7 +78,7 @@ public class TableExportPopupConfigurationInputForm extends DomLabelGrid impleme
 	}
 
 	@Override
-	public ITableExportEngine<?> getCurrentEngineOrNull() {
+	public ITableExportEngine getCurrentEngineOrNull() {
 
 		return this.currentEngine;
 	}
@@ -168,10 +168,10 @@ public class TableExportPopupConfigurationInputForm extends DomLabelGrid impleme
 	 * @param factory
 	 * @return An {@link ITableExportEngine} as created by the given factory.
 	 */
-	private ITableExportEngine<?> fetchOrCreateEngine(ITableExportEngineFactory<?> factory) {
+	private ITableExportEngine fetchOrCreateEngine(ITableExportEngineFactory<?> factory) {
 
 		String factoryClassName = factory.getClass().getCanonicalName();
-		ITableExportEngine<?> engine = this.engineByFactoryClassName.get(factoryClassName);
+		ITableExportEngine engine = this.engineByFactoryClassName.get(factoryClassName);
 
 		if (engine == null) {
 			engine = factory.create();

--- a/platform-emf/src/main/java/com/softicar/platform/emf/data/table/export/popup/TableExportPopupExecuteExportButton.java
+++ b/platform-emf/src/main/java/com/softicar/platform/emf/data/table/export/popup/TableExportPopupExecuteExportButton.java
@@ -35,7 +35,7 @@ class TableExportPopupExecuteExportButton extends DomButton {
 
 	private void handleClick() {
 
-		ITableExportEngine<?> engine = this.exportOptionsProvider.getCurrentEngineOrNull();
+		ITableExportEngine engine = this.exportOptionsProvider.getCurrentEngineOrNull();
 
 		if (engine != null) {
 			String fileNamePrefix = this.exportOptionsProvider.getFileNamePrefixOrNull();


### PR DESCRIPTION
Removed the `CT` "content type" type parameter from all table export classes, for the sake of simplicity.
The rationale behind that thing ceased to exist approx. 9 yrs ago.
