### PR TITLE
PLAT-1270 WorkflowAutoTransitionExecutionProgram: Use VERBOSE log level instead of INFO

### DIFF
--- a/platform-workflow-module/src/main/java/com/softicar/platform/workflow/module/workflow/transition/program/WorkflowAutoTransitionExecutionProgram.java
+++ b/platform-workflow-module/src/main/java/com/softicar/platform/workflow/module/workflow/transition/program/WorkflowAutoTransitionExecutionProgram.java
@@ -25,13 +25,13 @@ public class WorkflowAutoTransitionExecutionProgram implements IProgram {
 	@Override
 	public void executeProgram() {
 
-		Log.finfo("Looking for items with possible auto transitions.");
+		Log.fverbose("Looking for items with possible auto transitions.");
 		var itemToTransitionsMap = loadItemsAndTransitionsToProcess();
 
 		if (itemToTransitionsMap.isEmpty()) {
-			Log.finfo("No items with auto transitions found.");
+			Log.fverbose("No items with auto transitions found.");
 		} else {
-			Log.finfo("Evaluating auto transitions for %s items.", itemToTransitionsMap.size());
+			Log.fverbose("Evaluating auto transitions for %s items.", itemToTransitionsMap.size());
 			executeAutoTransitions(itemToTransitionsMap);
 		}
 	}
@@ -41,11 +41,11 @@ public class WorkflowAutoTransitionExecutionProgram implements IProgram {
 		ExceptionsCollector exceptionsCollector = new ExceptionsCollector();
 		for (AGWorkflowItem item: itemToTransitionsMap.keySet()) {
 			try {
-				Log.finfo("Evaluating auto transition for %s.", item.toDisplayWithoutId());
+				Log.fverbose("Evaluating auto transition for %s.", item.toDisplayWithoutId());
 				new WorkflowAutoTransitionExecutor(item, itemToTransitionsMap.get(item)).evaluateAndExecute();
-				Log.finfo("Execution successful.");
+				Log.fverbose("Execution successful.");
 			} catch (Throwable throwable) {
-				Log.finfo("FAILURE -- see exceptions below");
+				Log.fverbose("FAILURE -- see exceptions below");
 				exceptionsCollector.add(throwable);
 			}
 		}


### PR DESCRIPTION
Default log level is INFO, so persistent program execution logs should not be spammed any longer.
