### PR TITLE
PLAT-1260-3 Implement DomCheckboxGroup

### DIFF
--- a/platform-core-module/src/main/java/com/softicar/platform/core/module/user/profile/UserProfileChangeLocalizationDiv.java
+++ b/platform-core-module/src/main/java/com/softicar/platform/core/module/user/profile/UserProfileChangeLocalizationDiv.java
@@ -18,8 +18,7 @@ class UserProfileChangeLocalizationDiv extends DomDiv {
 	public UserProfileChangeLocalizationDiv() {
 
 		this.localizationInput = new LocalizationInput();
-		var labelGrid = new DomLabelGrid().add(CoreI18n.LOCALIZATION, localizationInput);
-		appendChild(labelGrid);
+		appendChild(new DomLabelGrid().add(CoreI18n.LOCALIZATION, localizationInput));
 		appendChild(new DomActionBar(new SaveButton()));
 	}
 

--- a/platform-core-module/src/main/java/com/softicar/platform/core/module/user/profile/UserProfileChangeLocalizationDiv.java
+++ b/platform-core-module/src/main/java/com/softicar/platform/core/module/user/profile/UserProfileChangeLocalizationDiv.java
@@ -2,25 +2,34 @@ package com.softicar.platform.core.module.user.profile;
 
 import com.softicar.platform.common.core.locale.CurrentLocale;
 import com.softicar.platform.core.module.CoreI18n;
-import com.softicar.platform.core.module.user.AGUser;
+import com.softicar.platform.core.module.localization.AGLocalization;
 import com.softicar.platform.core.module.user.CurrentUser;
 import com.softicar.platform.dom.elements.DomDiv;
 import com.softicar.platform.dom.elements.bar.DomActionBar;
 import com.softicar.platform.dom.elements.button.DomButton;
+import com.softicar.platform.dom.elements.checkbox.DomCheckboxGroup;
+import com.softicar.platform.dom.elements.label.DomLabelGrid;
 import com.softicar.platform.emf.EmfI18n;
-import com.softicar.platform.emf.editor.EmfAttributesDiv;
 
 class UserProfileChangeLocalizationDiv extends DomDiv {
 
-	private final EmfAttributesDiv<AGUser> attributesDiv;
+	private final DomCheckboxGroup<AGLocalization> localizationInput;
 
 	public UserProfileChangeLocalizationDiv() {
 
-		this.attributesDiv = new EmfAttributesDiv<>(CurrentUser.get(), true);
-		attributesDiv.addAttribute(AGUser.LOCALIZATION);
-
-		appendChild(attributesDiv);
+		this.localizationInput = new LocalizationInput();
+		var labelGrid = new DomLabelGrid().add(CoreI18n.LOCALIZATION, localizationInput);
+		appendChild(labelGrid);
 		appendChild(new DomActionBar(new SaveButton()));
+	}
+
+	private class LocalizationInput extends DomCheckboxGroup<AGLocalization> {
+
+		public LocalizationInput() {
+
+			AGLocalization.TABLE.loadAll().forEach(this::addOption);
+			setValue(CurrentUser.get().getLocalization());
+		}
 	}
 
 	private class SaveButton extends DomButton {
@@ -33,12 +42,11 @@ class UserProfileChangeLocalizationDiv extends DomDiv {
 
 		public void handleClick() {
 
-			if (attributesDiv.tryToApplyValidateAndSave()) {
-				CurrentLocale.set(CurrentUser.get().getLocale());
-				executeAlert(
-					CoreI18n.YOUR_LOCALIZATION_HAS_CHANGED//
-						.concatSentence(CoreI18n.PLEASE_PRESS_F5_TO_REFRESH));
-			}
+			CurrentUser.get().setLocalization(localizationInput.getValueOrThrow()).save();
+			CurrentLocale.set(CurrentUser.get().getLocale());
+			executeAlert(
+				CoreI18n.YOUR_LOCALIZATION_HAS_CHANGED//
+					.concatSentence(CoreI18n.PLEASE_PRESS_F5_TO_REFRESH));
 		}
 	}
 }

--- a/platform-dom/src/main/java/com/softicar/platform/dom/DomCssClasses.java
+++ b/platform-dom/src/main/java/com/softicar/platform/dom/DomCssClasses.java
@@ -31,6 +31,7 @@ public interface DomCssClasses {
 	ICssClass DOM_CHECKBOX = new CssClass("DomCheckbox", DomCssFiles.DOM_CHECKBOX_STYLE);
 	ICssClass DOM_CHECKBOX_BOX = new CssClass("DomCheckboxBox", DomCssFiles.DOM_CHECKBOX_STYLE);
 	ICssClass DOM_CHECKBOX_BOX_FILLER = new CssClass("DomCheckboxBoxFiller", DomCssFiles.DOM_CHECKBOX_STYLE);
+	ICssClass DOM_CHECKBOX_GROUP = new CssClass("DomCheckboxGroup", DomCssFiles.DOM_CHECKBOX_STYLE);
 	ICssClass DOM_CHECKBOX_LABEL = new CssClass("DomCheckboxLabel", DomCssFiles.DOM_CHECKBOX_STYLE);
 	ICssClass DOM_CHECKBOX_LIST = new CssClass("DomCheckboxList", DomCssFiles.DOM_CHECKBOX_STYLE);
 	ICssClass DOM_DATA_TABLE = new CssClass("DomDataTable", DomCssFiles.DOM_DATA_TABLE_STYLE);

--- a/platform-dom/src/main/java/com/softicar/platform/dom/elements/checkbox/DomCheckboxGroup.java
+++ b/platform-dom/src/main/java/com/softicar/platform/dom/elements/checkbox/DomCheckboxGroup.java
@@ -1,0 +1,267 @@
+package com.softicar.platform.dom.elements.checkbox;
+
+import com.softicar.platform.common.core.i18n.IDisplayString;
+import com.softicar.platform.common.core.i18n.IDisplayable;
+import com.softicar.platform.common.core.interfaces.INullaryVoidFunction;
+import com.softicar.platform.common.core.interfaces.NullaryVoidFunctionList;
+import com.softicar.platform.dom.DomCssClasses;
+import com.softicar.platform.dom.elements.DomDiv;
+import com.softicar.platform.dom.input.IDomValueInput;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.function.Supplier;
+
+/**
+ * A group of {@link DomCheckbox} nodes that mimic the behavior of grouped HTML
+ * checkboxes.
+ *
+ * @param <V>
+ *            the type of the values to be selected (should implement
+ *            {@code equals} and {@code hashCode})
+ * @author Alexander Schmidt
+ */
+public class DomCheckboxGroup<V> extends DomDiv implements IDomValueInput<V> {
+
+	private final Map<DomCheckbox, V> valueMap;
+	private final Map<V, DomCheckbox> checkboxMap;
+	private final NullaryVoidFunctionList callbacks;
+	private boolean disabled;
+
+	/**
+	 * Constructs a new {@link DomCheckboxGroup}.
+	 */
+	public DomCheckboxGroup() {
+
+		this(HashMap::new);
+	}
+
+	/**
+	 * Constructs a new {@link DomCheckboxGroup}, using the given {@link Map}
+	 * factory.
+	 * <p>
+	 * The created {@link Map} must support instances of the value type as keys.
+	 *
+	 * @param mapFactory
+	 *            the map factory (never <i>null</i>)
+	 */
+	public DomCheckboxGroup(Supplier<Map<V, DomCheckbox>> mapFactory) {
+
+		Objects.requireNonNull(mapFactory);
+
+		this.valueMap = new HashMap<>();
+		this.checkboxMap = mapFactory.get();
+		this.callbacks = new NullaryVoidFunctionList();
+		this.disabled = false;
+
+		setCssClass(DomCssClasses.DOM_CHECKBOX_GROUP);
+	}
+
+	/**
+	 * Adds an option for the given value, deriving the label from the given
+	 * value.
+	 * <p>
+	 * If the given type of the given value implements {@link IDisplayable}, the
+	 * return value of {@link IDisplayable#toDisplay()} will be used as a label.
+	 * <p>
+	 * The first added option is always preselected.
+	 *
+	 * @param value
+	 *            the value that is represented by the option (never
+	 *            <i>null</i>)
+	 * @return this
+	 */
+	public DomCheckboxGroup<V> addOption(V value) {
+
+		return addOption(value, createLabel(value));
+	}
+
+	/**
+	 * Adds an option for the given value, deriving the label from the given
+	 * value.
+	 * <p>
+	 * If the given type of the given value implements {@link IDisplayable}, the
+	 * return value of {@link IDisplayable#toDisplay()} will be used as a label.
+	 * <p>
+	 * The option may be preselected. If the option is preselected, all other
+	 * options will be un-selected (including previously preselected options).
+	 * <p>
+	 * The first added option is always preselected.
+	 *
+	 * @param value
+	 *            the value that is represented by the option (never
+	 *            <i>null</i>)
+	 * @param preselected
+	 *            <i>true</i> if the option shall be preselected; <i>false</i>
+	 *            otherwise
+	 * @return this
+	 */
+	public DomCheckboxGroup<V> addOption(V value, boolean preselected) {
+
+		return addOption(value, createLabel(value), preselected);
+	}
+
+	/**
+	 * Adds an option for the given value, with the given label.
+	 * <p>
+	 * The first added option is always preselected.
+	 *
+	 * @param value
+	 *            the value that is represented by the option (never
+	 *            <i>null</i>)
+	 * @param label
+	 *            the label to display next to the option (never <i>null</i>)
+	 * @return this
+	 */
+	public DomCheckboxGroup<V> addOption(V value, IDisplayString label) {
+
+		return addOption(value, label, false);
+	}
+
+	/**
+	 * Adds an option for the given value, with the given label.
+	 * <p>
+	 * The option may be preselected. If the option is preselected, all other
+	 * options will be un-selected (including previously preselected options).
+	 * <p>
+	 * The first added option is always preselected.
+	 *
+	 * @param value
+	 *            the value that is represented by the option (never
+	 *            <i>null</i>)
+	 * @param label
+	 *            the label to display next to the option (never <i>null</i>)
+	 * @param preselected
+	 *            <i>true</i> if the option shall be preselected; <i>false</i>
+	 *            otherwise
+	 * @return this
+	 */
+	public DomCheckboxGroup<V> addOption(V value, IDisplayString label, boolean preselected) {
+
+		Objects.requireNonNull(value);
+		Objects.requireNonNull(label);
+
+		if (valueMap.isEmpty()) {
+			preselected = true;
+		}
+
+		var checkbox = new Checkbox(label, preselected).setDisabled(disabled);
+		if (preselected) {
+			unselectOthers(checkbox);
+		}
+
+		valueMap.put(checkbox, value);
+		checkboxMap.put(value, checkbox);
+
+		appendChild(checkbox);
+
+		return this;
+	}
+
+	@Override
+	public DomCheckboxGroup<V> setDisabled(boolean disabled) {
+
+		this.disabled = disabled;
+		this.valueMap.keySet().forEach(it -> it.setDisabled(disabled));
+		return this;
+	}
+
+	@Override
+	public boolean isDisabled() {
+
+		return disabled;
+	}
+
+	@Override
+	public DomCheckboxGroup<V> setEnabled(boolean enabled) {
+
+		return setDisabled(!enabled);
+	}
+
+	@Override
+	public boolean isEnabled() {
+
+		return !isDisabled();
+	}
+
+	@Override
+	public Optional<V> getValue() {
+
+		return valueMap//
+			.keySet()
+			.stream()
+			.filter(DomCheckbox::isChecked)
+			.map(valueMap::get)
+			.findFirst();
+	}
+
+	/**
+	 * Selects the option that corresponds to the given value, and un-selects
+	 * all other options.
+	 * <p>
+	 * If no option can be found for the given value, or if the given value is
+	 * <i>null</i>, nothing will happen.
+	 *
+	 * @param value
+	 *            the value of the option to select (may be <i>null</i>)
+	 */
+	@Override
+	public void setValue(V value) {
+
+		if (value != null) {
+			var checkbox = checkboxMap.get(value);
+			if (checkbox != null) {
+				checkbox.setValueAndHandleChangeCallback(true);
+			}
+		}
+	}
+
+	@Override
+	public void setValueAndHandleChangeCallback(V value) {
+
+		setValue(value);
+		callbacks.apply();
+	}
+
+	@Override
+	public void addChangeCallback(INullaryVoidFunction callback) {
+
+		this.callbacks.add(callback);
+	}
+
+	private IDisplayString createLabel(V value) {
+
+		Objects.requireNonNull(value);
+		if (value instanceof IDisplayable) {
+			return ((IDisplayable) value).toDisplay();
+		} else {
+			return IDisplayString.create(value.toString());
+		}
+	}
+
+	private void unselectOthers(DomCheckbox checkbox) {
+
+		valueMap.keySet().stream().filter(it -> it != checkbox).forEach(it -> it.setValue(false));
+	}
+
+	private class Checkbox extends DomCheckbox {
+
+		public Checkbox(IDisplayString label, boolean checked) {
+
+			super(checked);
+			setLabel(label);
+			addChangeCallback(this::handleClicked);
+		}
+
+		private void handleClicked() {
+
+			if (isChecked()) {
+				unselectOthers(this);
+				callbacks.apply();
+			} else {
+				setValue(true);
+			}
+		}
+	}
+}

--- a/platform-dom/src/main/resources/com/softicar/platform/dom/dom-checkbox-style.css
+++ b/platform-dom/src/main/resources/com/softicar/platform/dom/dom-checkbox-style.css
@@ -79,8 +79,24 @@
 }
 
 /* ------------------------------ list ------------------------------ */
+
 .DomCheckboxList {
 	display: grid;
 	grid-auto-flow: row;
 	gap: var(--COLUMN_GAP);
+}
+
+/* ------------------------------ group ------------------------------ */
+
+.DomCheckboxGroup {
+	padding-top: 2px;
+	padding-bottom: 2px;
+}
+
+.DomCheckboxGroup .DomCheckboxBox {
+	border-radius: 10px;
+}
+
+.DomCheckboxGroup .DomCheckboxBox > .DomCheckboxBoxFiller {
+	border-radius: 5px;
 }

--- a/platform-dom/src/test/java/com/softicar/platform/dom/elements/checkbox/DomCheckboxGroupTest.java
+++ b/platform-dom/src/test/java/com/softicar/platform/dom/elements/checkbox/DomCheckboxGroupTest.java
@@ -1,0 +1,320 @@
+package com.softicar.platform.dom.elements.checkbox;
+
+import com.softicar.platform.common.core.i18n.IDisplayString;
+import com.softicar.platform.common.core.i18n.IDisplayable;
+import com.softicar.platform.common.core.interfaces.INullaryVoidFunction;
+import com.softicar.platform.common.testing.AbstractTest;
+import com.softicar.platform.dom.elements.DomDiv;
+import com.softicar.platform.dom.elements.testing.engine.IDomTestExecutionEngine;
+import com.softicar.platform.dom.elements.testing.engine.IDomTestExecutionEngineMethods;
+import com.softicar.platform.dom.elements.testing.engine.document.DomDocumentTestExecutionEngine;
+import java.util.List;
+import java.util.Objects;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class DomCheckboxGroupTest extends AbstractTest implements IDomTestExecutionEngineMethods {
+
+	private static final IDisplayString A = IDisplayString.create("A");
+	private static final IDisplayString B = IDisplayString.create("B");
+	private static final IDisplayString C = IDisplayString.create("C");
+
+	@Rule public IDomTestExecutionEngine engine = new DomDocumentTestExecutionEngine();
+
+	private final DomDiv node;
+
+	public DomCheckboxGroupTest() {
+
+		this.node = setNode(new DomDiv());
+	}
+
+	@Override
+	public IDomTestExecutionEngine getEngine() {
+
+		return engine;
+	}
+
+	@Test
+	public void testAddOption() {
+
+		var group = initializeGroup();
+
+		group.addOption(new Option(10), A);
+		group.addOption(new Option(20), B, true);
+		group.addOption(new Option(30), C);
+
+		new Asserter<>(group)//
+			.assertAvailableOptions(3)
+			.assertAvailableOptionLabels("A", "B", "C")
+			.assertSelectedOption(new Option(20))
+			.assertSelectedOptionNumber(2);
+	}
+
+	@Test
+	public void testAddDisplayableOption() {
+
+		var group = initializeDisplayableGroup();
+
+		group.addOption(new DisplayableOption(10, A));
+		group.addOption(new DisplayableOption(20, B), true);
+		group.addOption(new DisplayableOption(30, C));
+
+		new Asserter<>(group)//
+			.assertAvailableOptions(3)
+			.assertAvailableOptionLabels("A", "B", "C")
+			.assertSelectedOption(new DisplayableOption(20, B))
+			.assertSelectedOptionNumber(2);
+	}
+
+	@Test
+	public void testGetValueWithMultipleOptions() {
+
+		var group = initializeSimpleGroup();
+
+		var option = group.getValue().orElseThrow();
+
+		assertEquals(10, option.getInteger());
+		new Asserter<>(group).assertSelectedOptionNumber(1);
+	}
+
+	@Test
+	public void testGetValueWithSingleOption() {
+
+		var group = initializeGroup();
+		group.addOption(new Option(10), A);
+
+		var option = group.getValue().orElseThrow();
+
+		assertEquals(10, option.getInteger());
+		new Asserter<>(group).assertSelectedOptionNumber(1);
+	}
+
+	@Test
+	public void testGetValueWithoutOptions() {
+
+		var group = initializeGroup();
+
+		var option = group.getValue();
+
+		assertTrue(option.isEmpty());
+	}
+
+	@Test
+	public void testSetValue() {
+
+		var group = initializeSimpleGroup();
+
+		group.setValue(new Option(30));
+		group.setValue(new Option(20));
+
+		new Asserter<>(group)//
+			.assertSelectedOption(new Option(20))
+			.assertSelectedOptionNumber(2);
+	}
+
+	@Test
+	public void testSetValueWithUnknownOption() {
+
+		var group = initializeSimpleGroup();
+
+		group.setValue(new Option(20));
+		group.setValue(new Option(99));
+
+		new Asserter<>(group)//
+			.assertSelectedOption(new Option(20))
+			.assertSelectedOptionNumber(2);
+	}
+
+	@Test
+	public void testSetValueWithNull() {
+
+		var group = initializeSimpleGroup();
+
+		group.setValue(new Option(20));
+		group.setValue(null);
+
+		new Asserter<>(group)//
+			.assertSelectedOption(new Option(20))
+			.assertSelectedOptionNumber(2);
+	}
+
+	@Test
+	public void testSetValueWithCallback() {
+
+		var callback = new Callback();
+		var group = initializeSimpleGroup();
+		group.addChangeCallback(callback);
+
+		group.setValue(new Option(30));
+		group.setValue(new Option(20));
+		group.setValue(new Option(10));
+		group.setValue(new Option(20));
+
+		assertEquals(4, callback.getCallCount());
+	}
+
+	private DomCheckboxGroup<Option> initializeGroup() {
+
+		return node.appendChild(new DomCheckboxGroup<>());
+	}
+
+	private DomCheckboxGroup<Option> initializeSimpleGroup() {
+
+		return initializeGroup()//
+			.addOption(new Option(10), A)
+			.addOption(new Option(20), B)
+			.addOption(new Option(30), C);
+	}
+
+	private DomCheckboxGroup<DisplayableOption> initializeDisplayableGroup() {
+
+		return node.appendChild(new DomCheckboxGroup<>());
+	}
+
+	private static class Option {
+
+		private final Integer integer;
+
+		public Option(Integer integer) {
+
+			this.integer = integer;
+		}
+
+		@Override
+		public String toString() {
+
+			return integer + "";
+		}
+
+		@Override
+		public boolean equals(Object other) {
+
+			if (other instanceof Option) {
+				var otherOption = (Option) other;
+				return integer.equals(otherOption.integer);
+			} else {
+				return false;
+			}
+		}
+
+		@Override
+		public int hashCode() {
+
+			return Objects.hash(integer);
+		}
+
+		public Integer getInteger() {
+
+			return integer;
+		}
+	}
+
+	private static class DisplayableOption implements IDisplayable {
+
+		private final Integer integer;
+		private final IDisplayString label;
+
+		public DisplayableOption(Integer integer, IDisplayString label) {
+
+			this.integer = integer;
+			this.label = label;
+		}
+
+		@Override
+		public IDisplayString toDisplay() {
+
+			return label;
+		}
+
+		@Override
+		public boolean equals(Object other) {
+
+			if (other instanceof DisplayableOption) {
+				var otherOption = (DisplayableOption) other;
+				return integer.equals(otherOption.integer) && label.equals(otherOption.label);
+			} else {
+				return false;
+			}
+		}
+
+		@Override
+		public int hashCode() {
+
+			return Objects.hash(integer, label);
+		}
+	}
+
+	private class Callback implements INullaryVoidFunction {
+
+		private int callCount = 0;
+
+		@Override
+		public void apply() {
+
+			++callCount;
+		}
+
+		public int getCallCount() {
+
+			return callCount;
+		}
+	}
+
+	private class Asserter<V> {
+
+		private final DomCheckboxGroup<V> group;
+
+		public Asserter(DomCheckboxGroup<V> group) {
+
+			this.group = group;
+		}
+
+		public Asserter<V> assertAvailableOptions(int size) {
+
+			assertEquals(size, findCheckboxes().size());
+			return this;
+		}
+
+		public Asserter<V> assertAvailableOptionLabels(String...labels) {
+
+			List<String> actualLabels = asTester(group).getAllTextsInTree().collect(Collectors.toList());
+
+			assertEquals(labels.length, actualLabels.size());
+			for (int i = 0; i < labels.length; i++) {
+				assertEquals(labels[i], actualLabels.get(i));
+			}
+
+			return this;
+		}
+
+		public Asserter<V> assertSelectedOption(V value) {
+
+			assertEquals(value, group.getValueOrThrow());
+			return this;
+		}
+
+		public Asserter<V> assertSelectedOptionNumber(int number) {
+
+			var checkboxes = findCheckboxes();
+			assertTrue(number <= checkboxes.size());
+
+			for (int i = 0; i < checkboxes.size(); i++) {
+				var checkbox = checkboxes.get(i);
+				if (i + 1 == number) {
+					assertTrue("Expected the checkbox number %s to be checked but it was unchecked.".formatted(number), checkbox.isChecked());
+				} else {
+					assertFalse("Expected the checkbox number %s to be unchecked but it was checked.".formatted(number), checkbox.isChecked());
+				}
+			}
+
+			return this;
+		}
+
+		private List<DomCheckbox> findCheckboxes() {
+
+			return asTester(group).findNodes(DomCheckbox.class).toList(Function.identity());
+		}
+	}
+}

--- a/platform-dom/src/test/java/com/softicar/platform/dom/elements/checkbox/DomCheckboxGroupTest.java
+++ b/platform-dom/src/test/java/com/softicar/platform/dom/elements/checkbox/DomCheckboxGroupTest.java
@@ -155,6 +155,17 @@ public class DomCheckboxGroupTest extends AbstractTest implements IDomTestExecut
 		assertEquals(4, callback.getCallCount());
 	}
 
+	@Test
+	public void testSetValueWithoutOptions() {
+
+		var group = initializeGroup();
+
+		group.setValue(new Option(20));
+
+		var option = group.getValue();
+		assertTrue(option.isEmpty());
+	}
+
 	private DomCheckboxGroup<Option> initializeGroup() {
 
 		return node.appendChild(new DomCheckboxGroup<>());


### PR DESCRIPTION
Auto-Complete inputs are just not suited to choose among a small number of well-known options.
This PR therefore implements "Radio Button"-style checkbox groups, as an `IDomValueInput`.
While this already benefits the localization selector (as shown in the GIF below), the same kind of input will be required for a subsequent PR in this series.

**After this PR:**
![Peek 2023-01-10 12-52-after](https://user-images.githubusercontent.com/15086658/211545502-3d4497de-ca45-4c32-be59-1eb8598a137c.gif)

**Before this PR:**
![Peek 2023-01-10 12-54-before](https://user-images.githubusercontent.com/15086658/211545448-2928e377-22b1-4c4d-aedd-dc29e9acdbb0.gif)
