### PR TITLE
PLAT-1273 Upgrade jsoup to 1.15.3

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -38,7 +38,7 @@ project.ext {
 		jetty: "9.4.48.v20220622",
 		jsch: "0.1.55",
 		jsonPath: "2.7.0",
-		jsoup: "1.13.1",
+		jsoup: "1.15.3",
 		junit: "4.13.2",
 		log4j: "2.17.2",
 		mariadbJavaClient: "2.7.0",


### PR DESCRIPTION
`1.13.1` had the following vulnerabilities:

**Direct vulnerabilities:**
[CVE-2022-36033](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-36033)
[CVE-2021-37714](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-37714)

**Vulnerabilities from dependencies:**
[CVE-2022-25647](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-25647)
[CVE-2021-34428](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-34428)
[CVE-2020-27223](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-27223)
[CVE-2020-27218](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-27218)