### PR TITLE
PLAT-1274 Upgrade commons-net to 3.9.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,7 +21,7 @@ project.ext {
 		commonsCollections4: "4.4",
 		commonsCompress: "1.21",
 		commonsLang3: "3.12.0",
-		commonsNet: "3.7.2",
+		commonsNet: "3.9.0",
 		commonsText: "1.10.0",
 		flyingSaucerPdf: "9.1.22",
 		gson: "2.8.9",


### PR DESCRIPTION
`3.7.2` had the following vulnerabilities:

**Direct vulnerabilities:**
CVE-2021-37533

**Vulnerabilities from dependencies:**
CVE-2021-29425
