### PR TITLE
PLAT-1275 Upgrade netty to 4.1.86.Final

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -43,7 +43,7 @@ project.ext {
 		log4j: "2.17.2",
 		mariadbJavaClient: "2.7.0",
 		mockito: "4.3.1",
-		netty: "4.1.79.Final",
+		netty: "4.1.86.Final",
 		pdfbox: "2.0.25",
 		poi: "5.2.2",
 		selenium: "4.2.2",


### PR DESCRIPTION
`4.1.77.Final` had the following vulnerabilities:

**Direct vulnerabilities:**
[CVE-2022-41915](https://ossindex.sonatype.org/vulnerability/CVE-2022-41915?component-type=maven&component-name=io.netty%2Fnetty-codec&utm_source=ossindex-client&utm_medium=integration&utm_content=1.7.0)
[sonatype-2020-0026](https://ossindex.sonatype.org/vulnerability/sonatype-2020-0026?component-type=maven&component-name=io.netty%2Fnetty-handler&utm_source=ossindex-client&utm_medium=integration&utm_content=1.7.0)
