### PR TITLE
PLAT-1276 IDataTable: Remove default implementation of getIdentifier()

### DIFF
--- a/platform-common/src/main/java/com/softicar/platform/common/container/data/table/DataTableIdentifier.java
+++ b/platform-common/src/main/java/com/softicar/platform/common/container/data/table/DataTableIdentifier.java
@@ -21,4 +21,9 @@ public class DataTableIdentifier {
 
 		return text;
 	}
+
+	public static DataTableIdentifier empty() {
+
+		return new DataTableIdentifier("");
+	}
 }

--- a/platform-common/src/main/java/com/softicar/platform/common/container/data/table/IDataTable.java
+++ b/platform-common/src/main/java/com/softicar/platform/common/container/data/table/IDataTable.java
@@ -12,13 +12,16 @@ public interface IDataTable<R> extends IDataTableRowMethods<R> {
 
 	/**
 	 * Returns a {@link DataTableIdentifier} for this {@link IDataTable}.
+	 * <p>
+	 * The identifier will be used to restore previously saved user-specific
+	 * settings when this table is displayed. It must therefore be guaranteed to
+	 * uniquely identify this table. If user-specific settings shall not be
+	 * restored for this table, {@link DataTableIdentifier#empty()} can be
+	 * returned.
 	 *
 	 * @return the {@link DataTableIdentifier} (never <i>null</i>)
 	 */
-	default DataTableIdentifier getIdentifier() {
-
-		return new DataTableIdentifier("");
-	}
+	DataTableIdentifier getIdentifier();
 
 	// -------------------- columns -------------------- //
 

--- a/platform-common/src/main/java/com/softicar/platform/common/container/matrix/data/table/MatrixDataTable.java
+++ b/platform-common/src/main/java/com/softicar/platform/common/container/matrix/data/table/MatrixDataTable.java
@@ -1,5 +1,6 @@
 package com.softicar.platform.common.container.matrix.data.table;
 
+import com.softicar.platform.common.container.data.table.DataTableIdentifier;
 import com.softicar.platform.common.container.data.table.IDataTable;
 import com.softicar.platform.common.container.data.table.in.memory.AbstractInMemoryDataTable;
 import com.softicar.platform.common.container.matrix.IMatrix;
@@ -36,6 +37,12 @@ public class MatrixDataTable<R, C, V> extends AbstractInMemoryDataTable<MatrixDa
 		for (R row: matrix.getRows()) {
 			this.rows.add(new MatrixDataTableRow<>(row, matrix.getRowMap(row)));
 		}
+	}
+
+	@Override
+	public DataTableIdentifier getIdentifier() {
+
+		return DataTableIdentifier.empty();
 	}
 
 	@Override

--- a/platform-common/src/test/java/com/softicar/platform/common/container/data/table/in/memory/AbstractInMemoryDataTableTest.java
+++ b/platform-common/src/test/java/com/softicar/platform/common/container/data/table/in/memory/AbstractInMemoryDataTableTest.java
@@ -1,5 +1,6 @@
 package com.softicar.platform.common.container.data.table.in.memory;
 
+import com.softicar.platform.common.container.data.table.DataTableIdentifier;
 import com.softicar.platform.common.core.i18n.IDisplayString;
 import com.softicar.platform.common.testing.AbstractTest;
 import java.util.Arrays;
@@ -50,6 +51,12 @@ public class AbstractInMemoryDataTableTest extends AbstractTest {
 				.setGetter(it -> it)
 				.setTitle(IDisplayString.create("Foo"))
 				.addColumn();
+		}
+
+		@Override
+		public DataTableIdentifier getIdentifier() {
+
+			return DataTableIdentifier.empty();
 		}
 
 		@Override

--- a/platform-core-module/src/main/java/com/softicar/platform/core/module/component/external/ExternalComponentsPageNode.java
+++ b/platform-core-module/src/main/java/com/softicar/platform/core/module/component/external/ExternalComponentsPageNode.java
@@ -1,6 +1,7 @@
 package com.softicar.platform.core.module.component.external;
 
 import com.softicar.platform.common.container.comparator.OrderDirection;
+import com.softicar.platform.common.container.data.table.DataTableIdentifier;
 import com.softicar.platform.common.container.data.table.IDataTableColumn;
 import com.softicar.platform.common.container.data.table.in.memory.AbstractInMemoryDataTable;
 import com.softicar.platform.common.core.i18n.IDisplayable;
@@ -57,6 +58,12 @@ class ExternalComponentsPageNode extends DomDiv {
 				.setGetter(IExternalComponent::getLicense)
 				.setTitle(CoreI18n.LICENSE)
 				.addColumn();
+		}
+
+		@Override
+		public DataTableIdentifier getIdentifier() {
+
+			return new DataTableIdentifier("21362d1f-33a7-4a2c-9f54-5c8c1fa213c8");
 		}
 
 		@Override

--- a/platform-core-module/src/main/java/com/softicar/platform/core/module/daemon/watchdog/state/DaemonWatchdogStatePageDiv.java
+++ b/platform-core-module/src/main/java/com/softicar/platform/core/module/daemon/watchdog/state/DaemonWatchdogStatePageDiv.java
@@ -1,5 +1,6 @@
 package com.softicar.platform.core.module.daemon.watchdog.state;
 
+import com.softicar.platform.common.container.data.table.DataTableIdentifier;
 import com.softicar.platform.common.container.data.table.IDataTableColumn;
 import com.softicar.platform.common.container.data.table.in.memory.AbstractInMemoryDataTable;
 import com.softicar.platform.common.core.clock.CurrentClock;
@@ -162,6 +163,12 @@ public class DaemonWatchdogStatePageDiv extends DomDiv {
 		}
 
 		@Override
+		public DataTableIdentifier getIdentifier() {
+
+			return new DataTableIdentifier("c6fd7f6b-8ab2-4411-880f-a661cd0bdaf9");
+		}
+
+		@Override
 		protected Iterable<DaemonWatchdogLogEntry> getTableRows() {
 
 			return rows;
@@ -224,6 +231,12 @@ public class DaemonWatchdogStatePageDiv extends DomDiv {
 				.setGetter(this::getKillTimeoutAsString)
 				.setTitle(CoreI18n.TIMEOUT)
 				.addColumn();
+		}
+
+		@Override
+		public DataTableIdentifier getIdentifier() {
+
+			return new DataTableIdentifier("c4f9f2ae-4471-477e-b082-21d7d6cb8ab2");
 		}
 
 		@Override

--- a/platform-core-module/src/main/java/com/softicar/platform/core/module/file/stored/overview/StoredFileOverviewDataTable.java
+++ b/platform-core-module/src/main/java/com/softicar/platform/core/module/file/stored/overview/StoredFileOverviewDataTable.java
@@ -1,5 +1,6 @@
 package com.softicar.platform.core.module.file.stored.overview;
 
+import com.softicar.platform.common.container.data.table.DataTableIdentifier;
 import com.softicar.platform.common.container.data.table.IDataTableColumn;
 import com.softicar.platform.common.container.data.table.in.memory.AbstractInMemoryDataTable;
 import com.softicar.platform.common.core.item.ItemId;
@@ -31,6 +32,12 @@ class StoredFileOverviewDataTable extends AbstractInMemoryDataTable<StoredFileOv
 			.setGetter(StoredFileOverviewRow::getFileHashString)
 			.setTitle(EmfI18n.SHA_1_HASH)
 			.addColumn();
+	}
+
+	@Override
+	public DataTableIdentifier getIdentifier() {
+
+		return new DataTableIdentifier("7114faf0-737f-4223-8498-dbc9f52d6d5a");
 	}
 
 	@Override

--- a/platform-core-module/src/main/java/com/softicar/platform/core/module/module/overview/ModuleOverviewTable.java
+++ b/platform-core-module/src/main/java/com/softicar/platform/core/module/module/overview/ModuleOverviewTable.java
@@ -1,5 +1,6 @@
 package com.softicar.platform.core.module.module.overview;
 
+import com.softicar.platform.common.container.data.table.DataTableIdentifier;
 import com.softicar.platform.common.container.data.table.IDataTableColumn;
 import com.softicar.platform.common.container.data.table.in.memory.AbstractInMemoryDataTable;
 import com.softicar.platform.core.module.CoreI18n;
@@ -33,7 +34,13 @@ public class ModuleOverviewTable extends AbstractInMemoryDataTable<IEmfModule<?>
 	}
 
 	@Override
-	public Iterable<IEmfModule<?>> getTableRows() {
+	public DataTableIdentifier getIdentifier() {
+
+		return new DataTableIdentifier("d749484b-d48b-44fc-a3ee-29b920b48414");
+	}
+
+	@Override
+	protected Iterable<IEmfModule<?>> getTableRows() {
 
 		return IEmfModuleRegistry.get().getAllModules();
 	}

--- a/platform-core-module/src/main/java/com/softicar/platform/core/module/module/overview/ModulePagesTable.java
+++ b/platform-core-module/src/main/java/com/softicar/platform/core/module/module/overview/ModulePagesTable.java
@@ -1,5 +1,6 @@
 package com.softicar.platform.core.module.module.overview;
 
+import com.softicar.platform.common.container.data.table.DataTableIdentifier;
 import com.softicar.platform.common.container.data.table.IDataTableColumn;
 import com.softicar.platform.common.container.data.table.in.memory.AbstractInMemoryDataTable;
 import com.softicar.platform.common.core.i18n.IDisplayString;
@@ -44,15 +45,21 @@ public class ModulePagesTable extends AbstractInMemoryDataTable<IEmfPage<?>> {
 			.addColumn();
 	}
 
-	public IDataTableColumn<IEmfPage<?>, EmfPermissionWrapper> getRequiredPermissionColumn() {
+	@Override
+	public DataTableIdentifier getIdentifier() {
 
-		return requiredPermissionColumn;
+		return new DataTableIdentifier("c578da61-b743-469a-b077-da504a54e2bc");
 	}
 
 	@Override
 	protected Iterable<IEmfPage<?>> getTableRows() {
 
 		return new ArrayList<>(EmfPages.getPages(module));
+	}
+
+	public IDataTableColumn<IEmfPage<?>, EmfPermissionWrapper> getRequiredPermissionColumn() {
+
+		return requiredPermissionColumn;
 	}
 
 	private EmfPermissionWrapper getPermissionFromPage(IEmfPage<?> page) {

--- a/platform-core-module/src/main/java/com/softicar/platform/core/module/user/session/UserSessionsTable.java
+++ b/platform-core-module/src/main/java/com/softicar/platform/core/module/user/session/UserSessionsTable.java
@@ -1,5 +1,6 @@
 package com.softicar.platform.core.module.user.session;
 
+import com.softicar.platform.common.container.data.table.DataTableIdentifier;
 import com.softicar.platform.common.container.data.table.IDataTableColumn;
 import com.softicar.platform.common.container.data.table.in.memory.AbstractInMemoryDataTable;
 import com.softicar.platform.common.date.DayTime;
@@ -42,15 +43,21 @@ public class UserSessionsTable extends AbstractInMemoryDataTable<HttpSession> {
 			.addColumn();
 	}
 
-	public IDataTableColumn<HttpSession, AGUser> getUserColumn() {
+	@Override
+	public DataTableIdentifier getIdentifier() {
 
-		return userColumn;
+		return new DataTableIdentifier("507403ff-b130-414c-bbb5-5626353b56d1");
 	}
 
 	@Override
 	protected Iterable<HttpSession> getTableRows() {
 
 		return new UserSessionManager().getAllSessions();
+	}
+
+	public IDataTableColumn<HttpSession, AGUser> getUserColumn() {
+
+		return userColumn;
 	}
 
 	private AGUser getUserFromSession(HttpSession session) {

--- a/platform-emf/src/main/java/com/softicar/platform/emf/attribute/input/auto/complete/EmfAutoCompleteBrowseTable.java
+++ b/platform-emf/src/main/java/com/softicar/platform/emf/attribute/input/auto/complete/EmfAutoCompleteBrowseTable.java
@@ -1,5 +1,6 @@
 package com.softicar.platform.emf.attribute.input.auto.complete;
 
+import com.softicar.platform.common.container.data.table.DataTableIdentifier;
 import com.softicar.platform.common.container.data.table.IDataTableColumn;
 import com.softicar.platform.common.container.data.table.in.memory.AbstractInMemoryDataTable;
 import com.softicar.platform.dom.elements.input.auto.IDomAutoCompleteInputEngine;
@@ -20,9 +21,10 @@ class EmfAutoCompleteBrowseTable<T> extends AbstractInMemoryDataTable<T> {
 			.addColumn();
 	}
 
-	public IDataTableColumn<T, String> getNameColumn() {
+	@Override
+	public DataTableIdentifier getIdentifier() {
 
-		return nameColumn;
+		return DataTableIdentifier.empty();
 	}
 
 	@Override
@@ -31,5 +33,10 @@ class EmfAutoCompleteBrowseTable<T> extends AbstractInMemoryDataTable<T> {
 		return inputEngine//
 			.findMatches("", Integer.MAX_VALUE)
 			.getAllValues();
+	}
+
+	public IDataTableColumn<T, String> getNameColumn() {
+
+		return nameColumn;
 	}
 }

--- a/platform-emf/src/main/java/com/softicar/platform/emf/data/table/configuration/EmfDataTableConfigurationTable.java
+++ b/platform-emf/src/main/java/com/softicar/platform/emf/data/table/configuration/EmfDataTableConfigurationTable.java
@@ -1,5 +1,6 @@
 package com.softicar.platform.emf.data.table.configuration;
 
+import com.softicar.platform.common.container.data.table.DataTableIdentifier;
 import com.softicar.platform.common.container.data.table.IDataTableColumn;
 import com.softicar.platform.common.container.data.table.in.memory.AbstractInMemoryDataTable;
 import com.softicar.platform.emf.data.table.EmfDataTableI18n;
@@ -30,6 +31,12 @@ class EmfDataTableConfigurationTable<R> extends AbstractInMemoryDataTable<EmfDat
 			.setGetter(EmfDataTableConfigurationTableRow::getIndex)
 			.setTitle(EmfDataTableI18n.ORDERING_PRIORITY)
 			.addColumn();
+	}
+
+	@Override
+	public DataTableIdentifier getIdentifier() {
+
+		return DataTableIdentifier.empty();
 	}
 
 	@Override

--- a/platform-emf/src/main/java/com/softicar/platform/emf/data/table/export/column/selection/TableExportColumnSelectionTable.java
+++ b/platform-emf/src/main/java/com/softicar/platform/emf/data/table/export/column/selection/TableExportColumnSelectionTable.java
@@ -1,5 +1,6 @@
 package com.softicar.platform.emf.data.table.export.column.selection;
 
+import com.softicar.platform.common.container.data.table.DataTableIdentifier;
 import com.softicar.platform.common.container.data.table.IDataTableColumn;
 import com.softicar.platform.common.container.data.table.in.memory.AbstractInMemoryDataTable;
 import com.softicar.platform.common.core.i18n.IDisplayString;
@@ -33,6 +34,24 @@ class TableExportColumnSelectionTable extends AbstractInMemoryDataTable<TableExp
 			.addColumn();
 	}
 
+	@Override
+	public DataTableIdentifier getIdentifier() {
+
+		return DataTableIdentifier.empty();
+	}
+
+	@Override
+	protected Iterable<TableExportColumnSelectionTableRow> getTableRows() {
+
+		List<TableExportColumnSelectionTableRow> rows = new ArrayList<>();
+		List<TableExportColumnModel> columnModels = tableModel.getTableColumnModels();
+
+		for (int index = 0; index < columnModels.size(); index++) {
+			rows.add(new TableExportColumnSelectionTableRow(columnModels.get(index).getName(), index));
+		}
+		return rows;
+	}
+
 	public IDataTableColumn<TableExportColumnSelectionTableRow, Integer> getPositionColumn() {
 
 		return positionColumn;
@@ -46,17 +65,5 @@ class TableExportColumnSelectionTable extends AbstractInMemoryDataTable<TableExp
 	public IDataTableColumn<TableExportColumnSelectionTableRow, TableExportColumnSelectionTableRow> getConversionColumn() {
 
 		return conversionColumn;
-	}
-
-	@Override
-	protected Iterable<TableExportColumnSelectionTableRow> getTableRows() {
-
-		List<TableExportColumnSelectionTableRow> rows = new ArrayList<>();
-		List<TableExportColumnModel> columnModels = tableModel.getTableColumnModels();
-
-		for (int index = 0; index < columnModels.size(); index++) {
-			rows.add(new TableExportColumnSelectionTableRow(columnModels.get(index).getName(), index));
-		}
-		return rows;
 	}
 }

--- a/platform-emf/src/main/java/com/softicar/platform/emf/entity/table/action/EmfTableActionOverviewTable.java
+++ b/platform-emf/src/main/java/com/softicar/platform/emf/entity/table/action/EmfTableActionOverviewTable.java
@@ -1,5 +1,6 @@
 package com.softicar.platform.emf.entity.table.action;
 
+import com.softicar.platform.common.container.data.table.DataTableIdentifier;
 import com.softicar.platform.common.container.data.table.IDataTableColumn;
 import com.softicar.platform.common.container.data.table.in.memory.AbstractInMemoryDataTable;
 import com.softicar.platform.common.core.i18n.IDisplayString;
@@ -48,6 +49,21 @@ public class EmfTableActionOverviewTable extends AbstractInMemoryDataTable<IEmfA
 			.addColumn();
 	}
 
+	@Override
+	public DataTableIdentifier getIdentifier() {
+
+		return new DataTableIdentifier("7fc2be5f-59ce-4789-a44a-d10698e76ca5");
+	}
+
+	@Override
+	protected Iterable<IEmfAction<?>> getTableRows() {
+
+		List<IEmfAction<?>> actionList = new ArrayList<>();
+		table.getPrimaryActions().forEach(action -> actionList.add(action));
+		table.getCommonActions().forEach(action -> addActionAndCheckForAggregatingActions(action, actionList));
+		return actionList;
+	}
+
 	public IDataTableColumn<IEmfAction<?>, IResource> getIconColumn() {
 
 		return iconColumn;
@@ -71,15 +87,6 @@ public class EmfTableActionOverviewTable extends AbstractInMemoryDataTable<IEmfA
 	public IDataTableColumn<IEmfAction<?>, EmfPermissionWrapper> getRequiredPermissionColumn() {
 
 		return requiredPermissionColumn;
-	}
-
-	@Override
-	protected Iterable<IEmfAction<?>> getTableRows() {
-
-		List<IEmfAction<?>> actionList = new ArrayList<>();
-		table.getPrimaryActions().forEach(action -> actionList.add(action));
-		table.getCommonActions().forEach(action -> addActionAndCheckForAggregatingActions(action, actionList));
-		return actionList;
 	}
 
 	private void addActionAndCheckForAggregatingActions(IEmfCommonAction<?> action, List<IEmfAction<?>> actionList) {

--- a/platform-emf/src/main/java/com/softicar/platform/emf/entity/table/attribute/EmfTableAttributeOverviewTable.java
+++ b/platform-emf/src/main/java/com/softicar/platform/emf/entity/table/attribute/EmfTableAttributeOverviewTable.java
@@ -1,5 +1,6 @@
 package com.softicar.platform.emf.entity.table.attribute;
 
+import com.softicar.platform.common.container.data.table.DataTableIdentifier;
 import com.softicar.platform.common.container.data.table.IDataTableColumn;
 import com.softicar.platform.common.container.data.table.in.memory.AbstractInMemoryDataTable;
 import com.softicar.platform.common.core.i18n.IDisplayString;
@@ -56,7 +57,18 @@ public class EmfTableAttributeOverviewTable extends AbstractInMemoryDataTable<IE
 			.setGetter(attribute -> new EmfPredicateWrapper(attribute.getPredicateMandatory()))
 			.setTitle(EmfI18n.MANDATORINESS_PREDICATE)
 			.addColumn();
+	}
 
+	@Override
+	public DataTableIdentifier getIdentifier() {
+
+		return new DataTableIdentifier("fc54f4cb-ba83-44dc-9f3c-8ea2b727c0b9");
+	}
+
+	@Override
+	protected Iterable<IEmfAttribute<?, ?>> getTableRows() {
+	
+		return new ArrayList<>(table.getAttributes());
 	}
 
 	public IDataTableColumn<IEmfAttribute<?, ?>, IDisplayString> getTitleColumn() {
@@ -97,11 +109,5 @@ public class EmfTableAttributeOverviewTable extends AbstractInMemoryDataTable<IE
 	public IDataTableColumn<IEmfAttribute<?, ?>, EmfPredicateWrapper> getPredicateMandatoryColumn() {
 
 		return predicateMandatoryColumn;
-	}
-
-	@Override
-	protected Iterable<IEmfAttribute<?, ?>> getTableRows() {
-
-		return new ArrayList<>(table.getAttributes());
 	}
 }

--- a/platform-emf/src/main/java/com/softicar/platform/emf/entity/table/overview/EmfTableOverviewTable.java
+++ b/platform-emf/src/main/java/com/softicar/platform/emf/entity/table/overview/EmfTableOverviewTable.java
@@ -1,5 +1,6 @@
 package com.softicar.platform.emf.entity.table.overview;
 
+import com.softicar.platform.common.container.data.table.DataTableIdentifier;
 import com.softicar.platform.common.container.data.table.IDataTableColumn;
 import com.softicar.platform.common.container.data.table.in.memory.AbstractInMemoryDataTable;
 import com.softicar.platform.common.core.i18n.IDisplayString;
@@ -70,6 +71,20 @@ public class EmfTableOverviewTable extends AbstractInMemoryDataTable<IEmfTable<?
 			.addColumn();
 	}
 
+	@Override
+	public DataTableIdentifier getIdentifier() {
+
+		return new DataTableIdentifier("588e9590-0cdb-44bb-8152-f2fa12f96e5c");
+	}
+
+	@Override
+	protected Iterable<IEmfTable<?, ?, ?>> getTableRows() {
+	
+		return EmfTableRegistry//
+			.getInstance()
+			.getTables(IEmfModuleRegistry.get().getModule(module.getAnnotatedUuid()).get());
+	}
+
 	public IDataTableColumn<IEmfTable<?, ?, ?>, IResource> getIconColumn() {
 
 		return iconColumn;
@@ -118,13 +133,5 @@ public class EmfTableOverviewTable extends AbstractInMemoryDataTable<IEmfTable<?
 	public IDataTableColumn<IEmfTable<?, ?, ?>, Boolean> getHasChangeLoggersColumn() {
 
 		return hasChangeLoggersColumn;
-	}
-
-	@Override
-	protected Iterable<IEmfTable<?, ?, ?>> getTableRows() {
-
-		return EmfTableRegistry//
-			.getInstance()
-			.getTables(IEmfModuleRegistry.get().getModule(module.getAnnotatedUuid()).get());
 	}
 }

--- a/platform-emf/src/main/java/com/softicar/platform/emf/log/viewer/table/EmfLogDataTable.java
+++ b/platform-emf/src/main/java/com/softicar/platform/emf/log/viewer/table/EmfLogDataTable.java
@@ -1,6 +1,7 @@
 package com.softicar.platform.emf.log.viewer.table;
 
 import com.softicar.platform.common.container.comparator.OrderDirection;
+import com.softicar.platform.common.container.data.table.DataTableIdentifier;
 import com.softicar.platform.common.container.data.table.IDataTableColumn;
 import com.softicar.platform.common.container.data.table.in.memory.AbstractInMemoryDataTable;
 import com.softicar.platform.common.core.user.IBasicUser;
@@ -48,6 +49,12 @@ class EmfLogDataTable<R extends IEmfTableRow<R, ?>> extends AbstractInMemoryData
 		this.loggedAttributes = loader.getLoggedAttributes();
 
 		addColumns(tableRow);
+	}
+
+	@Override
+	public DataTableIdentifier getIdentifier() {
+
+		return DataTableIdentifier.empty();
 	}
 
 	@Override

--- a/platform-emf/src/main/java/com/softicar/platform/emf/management/importing/submit/EmfImportSubmitDiv.java
+++ b/platform-emf/src/main/java/com/softicar/platform/emf/management/importing/submit/EmfImportSubmitDiv.java
@@ -1,5 +1,6 @@
 package com.softicar.platform.emf.management.importing.submit;
 
+import com.softicar.platform.common.container.data.table.DataTableIdentifier;
 import com.softicar.platform.common.container.data.table.in.memory.AbstractInMemoryDataTable;
 import com.softicar.platform.db.runtime.field.IDbField;
 import com.softicar.platform.dom.elements.DomDiv;
@@ -64,6 +65,12 @@ public class EmfImportSubmitDiv<R extends IEmfTableRow<R, P>, P, S> extends DomD
 			for (IDbField<R, ?> field: engine.getTable().getAllFields()) {
 				addFieldColumn(field);
 			}
+		}
+
+		@Override
+		public DataTableIdentifier getIdentifier() {
+
+			return DataTableIdentifier.empty();
 		}
 
 		@Override

--- a/platform-emf/src/main/java/com/softicar/platform/emf/management/importing/upload/EmfImportUploadDiv.java
+++ b/platform-emf/src/main/java/com/softicar/platform/emf/management/importing/upload/EmfImportUploadDiv.java
@@ -1,5 +1,6 @@
 package com.softicar.platform.emf.management.importing.upload;
 
+import com.softicar.platform.common.container.data.table.DataTableIdentifier;
 import com.softicar.platform.common.container.data.table.in.memory.AbstractInMemoryDataTable;
 import com.softicar.platform.common.core.exceptions.SofticarUserException;
 import com.softicar.platform.common.string.charset.Charsets;
@@ -79,6 +80,12 @@ public class EmfImportUploadDiv<R extends IEmfTableRow<R, P>, P, S> extends DomD
 		public UploadTable() {
 
 			engine.getFieldsToImport().forEach(this::addColumn);
+		}
+
+		@Override
+		public DataTableIdentifier getIdentifier() {
+
+			return DataTableIdentifier.empty();
 		}
 
 		@Override

--- a/platform-emf/src/main/java/com/softicar/platform/emf/management/importing/upload/EmfImportViewUploadedDataDiv.java
+++ b/platform-emf/src/main/java/com/softicar/platform/emf/management/importing/upload/EmfImportViewUploadedDataDiv.java
@@ -1,5 +1,6 @@
 package com.softicar.platform.emf.management.importing.upload;
 
+import com.softicar.platform.common.container.data.table.DataTableIdentifier;
 import com.softicar.platform.common.container.data.table.in.memory.AbstractInMemoryDataTable;
 import com.softicar.platform.db.runtime.field.IDbField;
 import com.softicar.platform.dom.elements.DomDiv;
@@ -67,6 +68,12 @@ public class EmfImportViewUploadedDataDiv<R extends IEmfTableRow<R, P>, P, S> ex
 				addColumn(field, index);
 				index++;
 			}
+		}
+
+		@Override
+		public DataTableIdentifier getIdentifier() {
+
+			return DataTableIdentifier.empty();
 		}
 
 		@Override

--- a/platform-emf/src/main/java/com/softicar/platform/emf/management/importing/variable/replace/EmfImportViewDataWithReplacementsDiv.java
+++ b/platform-emf/src/main/java/com/softicar/platform/emf/management/importing/variable/replace/EmfImportViewDataWithReplacementsDiv.java
@@ -1,5 +1,6 @@
 package com.softicar.platform.emf.management.importing.variable.replace;
 
+import com.softicar.platform.common.container.data.table.DataTableIdentifier;
 import com.softicar.platform.common.container.data.table.in.memory.AbstractInMemoryDataTable;
 import com.softicar.platform.db.runtime.field.IDbField;
 import com.softicar.platform.dom.elements.DomDiv;
@@ -68,6 +69,12 @@ public class EmfImportViewDataWithReplacementsDiv<R extends IEmfTableRow<R, P>, 
 				addColumn(field, index);
 				index++;
 			}
+		}
+
+		@Override
+		public DataTableIdentifier getIdentifier() {
+
+			return DataTableIdentifier.empty();
 		}
 
 		@Override

--- a/platform-emf/src/main/java/com/softicar/platform/emf/module/permission/EmfModulePermissionViewTable.java
+++ b/platform-emf/src/main/java/com/softicar/platform/emf/module/permission/EmfModulePermissionViewTable.java
@@ -1,5 +1,6 @@
 package com.softicar.platform.emf.module.permission;
 
+import com.softicar.platform.common.container.data.table.DataTableIdentifier;
 import com.softicar.platform.common.container.data.table.IDataTableColumn;
 import com.softicar.platform.common.container.data.table.in.memory.AbstractInMemoryDataTable;
 import com.softicar.platform.common.core.i18n.IDisplayString;
@@ -33,6 +34,18 @@ public class EmfModulePermissionViewTable extends AbstractInMemoryDataTable<IEmf
 			.addColumn();
 	}
 
+	@Override
+	public DataTableIdentifier getIdentifier() {
+
+		return new DataTableIdentifier("0da6cc2b-fa19-46b8-9271-1492db5f0895");
+	}
+
+	@Override
+	protected Iterable<IEmfPermission<?>> getTableRows() {
+	
+		return CurrentEmfPermissionRegistry.get().getAtomicPermissions(module);
+	}
+
 	public IDataTableColumn<IEmfPermission<?>, IDisplayString> getUsedPermissionColumn() {
 
 		return usedPermissionColumn;
@@ -46,11 +59,5 @@ public class EmfModulePermissionViewTable extends AbstractInMemoryDataTable<IEmf
 	public IDataTableColumn<IEmfPermission<?>, EmfPermissionWrapper> getPagesColumn() {
 
 		return pagesColumn;
-	}
-
-	@Override
-	protected Iterable<IEmfPermission<?>> getTableRows() {
-
-		return CurrentEmfPermissionRegistry.get().getAtomicPermissions(module);
 	}
 }

--- a/platform-emf/src/test/java/com/softicar/platform/emf/data/table/TestDataTable.java
+++ b/platform-emf/src/test/java/com/softicar/platform/emf/data/table/TestDataTable.java
@@ -1,5 +1,6 @@
 package com.softicar.platform.emf.data.table;
 
+import com.softicar.platform.common.container.data.table.DataTableIdentifier;
 import com.softicar.platform.common.container.data.table.IDataTableColumn;
 import com.softicar.platform.common.container.data.table.in.memory.AbstractInMemoryDataTable;
 import com.softicar.platform.common.core.i18n.IDisplayString;
@@ -27,6 +28,18 @@ public class TestDataTable extends AbstractInMemoryDataTable<TestDataTableRow> {
 			.addColumn();
 	}
 
+	@Override
+	public DataTableIdentifier getIdentifier() {
+
+		return new DataTableIdentifier("484f32ad-3733-4033-8a0d-b740bb196429");
+	}
+
+	@Override
+	protected Iterable<TestDataTableRow> getTableRows() {
+
+		return rows;
+	}
+
 	public IDataTableColumn<TestDataTableRow, Integer> getIntegerColumn() {
 
 		return integerColumn;
@@ -41,11 +54,5 @@ public class TestDataTable extends AbstractInMemoryDataTable<TestDataTableRow> {
 
 		rows.add(row);
 		return this;
-	}
-
-	@Override
-	public Iterable<TestDataTableRow> getTableRows() {
-
-		return rows;
 	}
 }

--- a/platform-emf/src/test/java/com/softicar/platform/emf/data/table/TestTable.java
+++ b/platform-emf/src/test/java/com/softicar/platform/emf/data/table/TestTable.java
@@ -69,7 +69,7 @@ public class TestTable extends AbstractInMemoryDataTable<TestTableRow> {
 			.addColumn();
 		this.rowSupplier = rowSupplier;
 
-		this.identifier = super.getIdentifier();
+		this.identifier = new DataTableIdentifier("04f98441-20ad-4b39-959e-50739c539d16");
 	}
 
 	@Override

--- a/platform-emf/src/test/java/com/softicar/platform/emf/data/table/configuration/EmfDataTableConfigurationPopupTest.java
+++ b/platform-emf/src/test/java/com/softicar/platform/emf/data/table/configuration/EmfDataTableConfigurationPopupTest.java
@@ -1,6 +1,7 @@
 package com.softicar.platform.emf.data.table.configuration;
 
 import com.softicar.platform.common.container.comparator.OrderDirection;
+import com.softicar.platform.common.container.data.table.DataTableIdentifier;
 import com.softicar.platform.common.container.data.table.IDataTableColumn;
 import com.softicar.platform.common.container.data.table.in.memory.AbstractInMemoryDataTable;
 import com.softicar.platform.common.core.i18n.IDisplayString;
@@ -569,6 +570,12 @@ public class EmfDataTableConfigurationPopupTest extends AbstractEmfTest {
 			addRow("bar", new BigDecimal("33.33"));
 			addRow("bar", new BigDecimal("11.11"));
 			addRow("baz", new BigDecimal("22.22"));
+		}
+
+		@Override
+		public DataTableIdentifier getIdentifier() {
+
+			return new DataTableIdentifier("8624bd05-ed90-4fd8-b77f-89efb1d7b11a");
 		}
 
 		@Override

--- a/platform-workflow-module/src/main/java/com/softicar/platform/workflow/module/workflow/item/message/WorkflowItemMessageDataTable.java
+++ b/platform-workflow-module/src/main/java/com/softicar/platform/workflow/module/workflow/item/message/WorkflowItemMessageDataTable.java
@@ -1,5 +1,6 @@
 package com.softicar.platform.workflow.module.workflow.item.message;
 
+import com.softicar.platform.common.container.data.table.DataTableIdentifier;
 import com.softicar.platform.common.container.data.table.IDataTableColumn;
 import com.softicar.platform.common.container.data.table.in.memory.AbstractInMemoryDataTable;
 import com.softicar.platform.common.date.DayTime;
@@ -33,6 +34,21 @@ public class WorkflowItemMessageDataTable extends AbstractInMemoryDataTable<Work
 			.addColumn();
 	}
 
+	@Override
+	public DataTableIdentifier getIdentifier() {
+
+		return new DataTableIdentifier("b3e48cc3-7f2c-41a4-87f4-2d882112d0f6");
+	}
+
+	@Override
+	protected Iterable<WorkflowItemMessageRow> getTableRows() {
+	
+		return rows//
+			.stream()
+			.filter(row -> showTransitions? true : !row.isTransition())
+			.collect(Collectors.toList());
+	}
+
 	public IDataTableColumn<WorkflowItemMessageRow, AGUser> getByColumn() {
 
 		return byColumn;
@@ -41,14 +57,5 @@ public class WorkflowItemMessageDataTable extends AbstractInMemoryDataTable<Work
 	public IDataTableColumn<WorkflowItemMessageRow, DayTime> getAtColumn() {
 
 		return atColumn;
-	}
-
-	@Override
-	protected Iterable<WorkflowItemMessageRow> getTableRows() {
-
-		return rows//
-			.stream()
-			.filter(row -> showTransitions? true : !row.isTransition())
-			.collect(Collectors.toList());
 	}
 }


### PR DESCRIPTION
The default method led to silent failures to restore user-specific configurations, all over the place.
