### PR TITLE
PLAT-1267 Fix default navigation behavior

### DIFF
--- a/platform-core-module/src/main/java/com/softicar/platform/core/module/user/preferences/UserPreferences.java
+++ b/platform-core-module/src/main/java/com/softicar/platform/core/module/user/preferences/UserPreferences.java
@@ -10,7 +10,7 @@ package com.softicar.platform.core.module.user.preferences;
  */
 public class UserPreferences {
 
-	public boolean automaticallyCollapseFolders = false;
-	public boolean recursivelyCollapseFolders = false;
+	public boolean automaticallyCollapseFolders = true;
+	public boolean recursivelyCollapseFolders = true;
 	public UserPreferencesPreferredPopupPlacement preferredPopupPlacement = UserPreferencesPreferredPopupPlacement.AT_EVENT_COORDINATES;
 }

--- a/platform-core-module/src/test/java/com/softicar/platform/core/module/user/preferences/UserPreferencesManagerTest.java
+++ b/platform-core-module/src/test/java/com/softicar/platform/core/module/user/preferences/UserPreferencesManagerTest.java
@@ -21,15 +21,15 @@ public class UserPreferencesManagerTest extends AbstractCoreTest {
 
 		// setup
 		user.setPreferencesJson("""
-				{"automaticallyCollapseFolders":true,"recursivelyCollapseFolders":true,"preferredPopupPlacement":"CENTERED"}
+				{"automaticallyCollapseFolders":false,"recursivelyCollapseFolders":false,"preferredPopupPlacement":"CENTERED"}
 				""").save();
 
 		// execute
 		var preferences = manager.getPreferences();
 
 		// assert results
-		assertTrue(preferences.automaticallyCollapseFolders);
-		assertTrue(preferences.recursivelyCollapseFolders);
+		assertFalse(preferences.automaticallyCollapseFolders);
+		assertFalse(preferences.recursivelyCollapseFolders);
 		assertEquals(UserPreferencesPreferredPopupPlacement.CENTERED, preferences.preferredPopupPlacement);
 	}
 
@@ -43,8 +43,8 @@ public class UserPreferencesManagerTest extends AbstractCoreTest {
 		var preferences = manager.getPreferences();
 
 		// assert results
-		assertFalse(preferences.automaticallyCollapseFolders);
-		assertFalse(preferences.recursivelyCollapseFolders);
+		assertTrue(preferences.automaticallyCollapseFolders);
+		assertTrue(preferences.recursivelyCollapseFolders);
 		assertEquals(UserPreferencesPreferredPopupPlacement.AT_EVENT_COORDINATES, preferences.preferredPopupPlacement);
 	}
 
@@ -58,8 +58,8 @@ public class UserPreferencesManagerTest extends AbstractCoreTest {
 		var preferences = manager.getPreferences();
 
 		// assert results
-		assertFalse(preferences.automaticallyCollapseFolders);
-		assertFalse(preferences.recursivelyCollapseFolders);
+		assertTrue(preferences.automaticallyCollapseFolders);
+		assertTrue(preferences.recursivelyCollapseFolders);
 		assertEquals(UserPreferencesPreferredPopupPlacement.AT_EVENT_COORDINATES, preferences.preferredPopupPlacement);
 	}
 
@@ -92,8 +92,8 @@ public class UserPreferencesManagerTest extends AbstractCoreTest {
 
 		// setup
 		var preferences = new UserPreferences();
-		preferences.automaticallyCollapseFolders = true;
-		preferences.recursivelyCollapseFolders = true;
+		preferences.automaticallyCollapseFolders = false;
+		preferences.recursivelyCollapseFolders = false;
 		preferences.preferredPopupPlacement = UserPreferencesPreferredPopupPlacement.CENTERED;
 
 		// execute
@@ -101,8 +101,8 @@ public class UserPreferencesManagerTest extends AbstractCoreTest {
 
 		// assert results
 		assertFalse(user.getPreferencesJson().isEmpty());
-		assertTrue(manager.getPreferences().automaticallyCollapseFolders);
-		assertTrue(manager.getPreferences().recursivelyCollapseFolders);
+		assertFalse(manager.getPreferences().automaticallyCollapseFolders);
+		assertFalse(manager.getPreferences().recursivelyCollapseFolders);
 		assertEquals(UserPreferencesPreferredPopupPlacement.CENTERED, manager.getPreferences().preferredPopupPlacement);
 	}
 

--- a/platform-core-module/src/test/java/com/softicar/platform/core/module/user/profile/UserProfilePreferencesDivTest.java
+++ b/platform-core-module/src/test/java/com/softicar/platform/core/module/user/profile/UserProfilePreferencesDivTest.java
@@ -18,32 +18,37 @@ public class UserProfilePreferencesDivTest extends AbstractCoreTest {
 	public void testInitialState() {
 
 		var preferences = new UserPreferences();
-		preferences.automaticallyCollapseFolders = true;
-		preferences.recursivelyCollapseFolders = true;
+		preferences.automaticallyCollapseFolders = false;
+		preferences.recursivelyCollapseFolders = false;
 		preferences.preferredPopupPlacement = UserPreferencesPreferredPopupPlacement.CENTERED;
 		CurrentUser.get().savePreferences(preferences);
 
-		findCheckbox(CoreTestMarker.USER_PREFERENCES_AUTOMATICALLY_COLLAPSE_FOLDERS_CHECKBOX).assertChecked(true).assertNodeDisabled(false);
-		findCheckbox(CoreTestMarker.USER_PREFERENCES_RECURSIVELY_COLLAPSE_FOLDERS_CHECKBOX).assertChecked(true).assertNodeDisabled(true);
+		findCheckbox(CoreTestMarker.USER_PREFERENCES_AUTOMATICALLY_COLLAPSE_FOLDERS_CHECKBOX).assertChecked(false).assertNodeDisabled(false);
+		findCheckbox(CoreTestMarker.USER_PREFERENCES_RECURSIVELY_COLLAPSE_FOLDERS_CHECKBOX).assertChecked(false).assertNodeDisabled(false);
 		findCheckboxGroup(CoreTestMarker.USER_PREFERENCES_PREFERRED_POPUP_PLACEMENT).assertValue(UserPreferencesPreferredPopupPlacement.CENTERED);
-		assertTrue(getUserPreferences().automaticallyCollapseFolders);
-		assertTrue(getUserPreferences().recursivelyCollapseFolders);
+		assertFalse(getUserPreferences().automaticallyCollapseFolders);
+		assertFalse(getUserPreferences().recursivelyCollapseFolders);
 		assertEquals(UserPreferencesPreferredPopupPlacement.CENTERED, getUserPreferences().preferredPopupPlacement);
 	}
 
 	@Test
 	public void testInitialStateWithDefaults() {
 
-		findCheckbox(CoreTestMarker.USER_PREFERENCES_AUTOMATICALLY_COLLAPSE_FOLDERS_CHECKBOX).assertChecked(false).assertNodeDisabled(false);
-		findCheckbox(CoreTestMarker.USER_PREFERENCES_RECURSIVELY_COLLAPSE_FOLDERS_CHECKBOX).assertChecked(false).assertNodeDisabled(false);
+		findCheckbox(CoreTestMarker.USER_PREFERENCES_AUTOMATICALLY_COLLAPSE_FOLDERS_CHECKBOX).assertChecked(true).assertNodeDisabled(false);
+		findCheckbox(CoreTestMarker.USER_PREFERENCES_RECURSIVELY_COLLAPSE_FOLDERS_CHECKBOX).assertChecked(true).assertNodeDisabled(true);
 		findCheckboxGroup(CoreTestMarker.USER_PREFERENCES_PREFERRED_POPUP_PLACEMENT).assertValue(UserPreferencesPreferredPopupPlacement.AT_EVENT_COORDINATES);
-		assertFalse(getUserPreferences().automaticallyCollapseFolders);
-		assertFalse(getUserPreferences().recursivelyCollapseFolders);
+		assertTrue(getUserPreferences().automaticallyCollapseFolders);
+		assertTrue(getUserPreferences().recursivelyCollapseFolders);
 		assertEquals(UserPreferencesPreferredPopupPlacement.AT_EVENT_COORDINATES, getUserPreferences().preferredPopupPlacement);
 	}
 
 	@Test
-	public void testWithClickOnAutomaticallyCollapseFoldersCheckbox() {
+	public void testWithTogglingAutomaticallyCollapseFolders() {
+
+		CurrentUser.get().updatePreferences(preferences -> {
+			preferences.automaticallyCollapseFolders = false;
+			preferences.recursivelyCollapseFolders = false;
+		});
 
 		findCheckbox(CoreTestMarker.USER_PREFERENCES_AUTOMATICALLY_COLLAPSE_FOLDERS_CHECKBOX).click();
 
@@ -59,7 +64,12 @@ public class UserProfilePreferencesDivTest extends AbstractCoreTest {
 	}
 
 	@Test
-	public void testWithClickOnAutomaticallyCollapseFoldersCheckboxTwice() {
+	public void testWithTogglingAutomaticallyCollapseFoldersAgain() {
+
+		CurrentUser.get().updatePreferences(preferences -> {
+			preferences.automaticallyCollapseFolders = false;
+			preferences.recursivelyCollapseFolders = false;
+		});
 
 		findCheckbox(CoreTestMarker.USER_PREFERENCES_AUTOMATICALLY_COLLAPSE_FOLDERS_CHECKBOX).click().click();
 
@@ -75,7 +85,12 @@ public class UserProfilePreferencesDivTest extends AbstractCoreTest {
 	}
 
 	@Test
-	public void testWithClickOnRecursivelyCollapseFoldersCheckbox() {
+	public void testWithTogglingRecursivelyCollapseFolders() {
+
+		CurrentUser.get().updatePreferences(preferences -> {
+			preferences.automaticallyCollapseFolders = false;
+			preferences.recursivelyCollapseFolders = false;
+		});
 
 		findCheckbox(CoreTestMarker.USER_PREFERENCES_RECURSIVELY_COLLAPSE_FOLDERS_CHECKBOX).click();
 


### PR DESCRIPTION
This fixes an unintended change in navigation folder collapsing default behavior, caused by #636 / `PLAT-1260-1`.

- Navigation folders will now collapse again by default, for new users.
- Note: Even before #636 the default values (`automatic=true` & `recursive=false`) were inconsistent, i.e. they specified the sole invalid combination of modes.
