### PR TITLE
PLAT-1296 AjaxDomDoubleClickEventTest: Add a delay to avoid a non-determinism

### DIFF
--- a/platform-ajax/src/test/java/com/softicar/platform/ajax/dom/event/click/AjaxDomDoubleClickEventTest.java
+++ b/platform-ajax/src/test/java/com/softicar/platform/ajax/dom/event/click/AjaxDomDoubleClickEventTest.java
@@ -24,6 +24,8 @@ public class AjaxDomDoubleClickEventTest extends AbstractAjaxSeleniumLowLevelTes
 	@Test
 	public void test() {
 
+		// TODO For unknown reasons, this delay in the test setup makes the final assertions (viewport size vs. window size from event) deterministic.
+		// TODO This should not be necessary.
 		Sleep.sleep(2000);
 
 		// click at specific location

--- a/platform-ajax/src/test/java/com/softicar/platform/ajax/dom/event/click/AjaxDomDoubleClickEventTest.java
+++ b/platform-ajax/src/test/java/com/softicar/platform/ajax/dom/event/click/AjaxDomDoubleClickEventTest.java
@@ -4,6 +4,7 @@ import com.softicar.platform.ajax.dom.event.AbstractAjaxDomEventTestDiv;
 import com.softicar.platform.ajax.testing.selenium.engine.common.geometry.AjaxSeleniumTestArea;
 import com.softicar.platform.ajax.testing.selenium.engine.common.geometry.AjaxSeleniumTestPoint;
 import com.softicar.platform.ajax.testing.selenium.engine.level.low.AbstractAjaxSeleniumLowLevelTest;
+import com.softicar.platform.common.core.thread.sleep.Sleep;
 import com.softicar.platform.dom.event.DomEventType;
 import com.softicar.platform.dom.event.IDomDoubleClickEventHandler;
 import com.softicar.platform.dom.event.IDomEvent;
@@ -22,6 +23,8 @@ public class AjaxDomDoubleClickEventTest extends AbstractAjaxSeleniumLowLevelTes
 
 	@Test
 	public void test() {
+
+		Sleep.sleep(2000);
 
 		// click at specific location
 		AjaxSeleniumTestArea viewportSize = getViewportSize();


### PR DESCRIPTION
`AjaxDomDoubleClickEventTest.test()` is racy for unknown reasons.
This must be a problem with the test setup, and we're currently heavily time-constrained. So we just manipulate the race for now.