### PR TITLE
EXP-2518-3 Specifiy source compatibility level for the root project

### DIFF
--- a/.classpath
+++ b/.classpath
@@ -1,10 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-15">
-		<attributes>
-			<attribute name="module" value="true"/>
-		</attributes>
-	</classpathentry>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-15/"/>
 	<classpathentry kind="con" path="org.eclipse.buildship.core.gradleclasspathcontainer"/>
 	<classpathentry kind="output" path="bin/default"/>
 </classpath>

--- a/build.gradle
+++ b/build.gradle
@@ -108,8 +108,10 @@ subprojects {
 
 // -------------------- compile -------------------- //
 
+sourceCompatibility = "15"
+
 subprojects {
-	apply plugin: 'com.softicar.gradle.java.library' 
+	apply plugin: 'com.softicar.gradle.java.library'
 
 	sourceCompatibility = "15"
 	targetCompatibility = "15"


### PR DESCRIPTION
Avoid that Buildship messes with the root project classpath and JDT prefs upon Gradle builds.
