### PR TITLE
PLAT-1305 TesseractOcrTextExtractor: Enable selection of page segmentation modes

### DIFF
--- a/platform-common-ocr/src/main/java/com/softicar/platform/common/ocr/tesseract/TesseractPageSegmentationMode.java
+++ b/platform-common-ocr/src/main/java/com/softicar/platform/common/ocr/tesseract/TesseractPageSegmentationMode.java
@@ -1,0 +1,47 @@
+package com.softicar.platform.common.ocr.tesseract;
+
+/**
+ * Enumerates Tesseract page segmentation modes.
+ * <p>
+ * Copied from {@code "PSM_"}-prefixed constants in
+ * {@link org.bytedeco.tesseract.global.tesseract}
+ *
+ * @author Alexander Schmidt
+ */
+public enum TesseractPageSegmentationMode {
+
+	/**
+	 * Automatic page segmentation, but no OSD, or OCR.
+	 */
+	PSM_AUTO_ONLY(2),
+
+	/**
+	 * Fully automatic page segmentation, but no OSD.
+	 */
+	PSM_AUTO(3),
+
+	/**
+	 * Assume a single uniform block of text. (Default.)
+	 */
+	PSM_SINGLE_BLOCK(6),
+
+	/**
+	 * Find as much text as possible in no particular order.
+	 */
+	PSM_SPARSE_TEXT(11),
+
+	//
+	;
+
+	private final int modeIndex;
+
+	private TesseractPageSegmentationMode(int modeIndex) {
+
+		this.modeIndex = modeIndex;
+	}
+
+	public int getModeIndex() {
+
+		return modeIndex;
+	}
+}


### PR DESCRIPTION
- `TesseractPageSegmentationMode` now provides a subset of Tesseract's built-in segmentation mode options.
  - i.e. those which neither produce completely garbled output nor crash the JVM.
- `TesseractPageSegmentationMode.PSM_SPARSE_TEXT` will be particularly useful for a current purpose in a derived project.
- Tesseract's internal default is `PSM_SINGLE_BLOCK`, so we default to that as well (principle of least surprise).