### PR TITLE
PLAT-1331-3 Enable StoredFileFileSystemContentStore

### DIFF
--- a/platform-core-module/src/main/java/com/softicar/platform/core/module/CoreI18n.java
+++ b/platform-core-module/src/main/java/com/softicar/platform/core/module/CoreI18n.java
@@ -70,6 +70,10 @@ public interface CoreI18n extends EmfI18n {
 		.de("Bereinigt außerdem verwaiste Einträge.");
 	I18n0 APR_1 = new I18n0("Apr 1")//
 		.de("Apr 1");
+	I18n1 ARG1_FOR_A_LOCAL_DIRECTORY = new I18n1("%s for a local directory")//
+		.de("%s für ein lokales Verzeichnis");
+	I18n1 ARG1_FOR_AN_SMB_SHARE = new I18n1("%s for an SMB share")//
+		.de("%s für eine SMB-Freigabe");
 	I18n1 ARG1_IS_AVAILABLE_AT_THE_FOLLOWING_ADDRESS = new I18n1("%s is available at the following address")//
 		.de("%s steht unter der folgenden Adresse zur Verfügung");
 	I18n1 ARG1_MESSAGES_FOUND_IN_INBOX = new I18n1("%s messages found in inbox.")//
@@ -455,6 +459,8 @@ public interface CoreI18n extends EmfI18n {
 		.de("Lizenz");
 	I18n0 LOCAL_ADDRESS = new I18n0("Local Address")//
 		.de("Lokale Adresse");
+	I18n0 LOCAL_FILE_STORE_DIRECTORY = new I18n0("Local File Store Directory")//
+		.de("Lokales Dateispeicher-Verzeichnis");
 	I18n0 LOCAL_NAME = new I18n0("Local Name")//
 		.de("Lokaler Name");
 	I18n0 LOCAL_PORT = new I18n0("Local Port")//
@@ -970,6 +976,8 @@ public interface CoreI18n extends EmfI18n {
 		.de("Super-Benutzer");
 	I18n0 SUPPORT_EMAIL_ADDRESS = new I18n0("Support Email Address")//
 		.de("Support-E-Mail-Adresse");
+	I18n0 SUPPORTED_URLS = new I18n0("Supported URLs")//
+		.de("Unterstützte URLs");
 	I18n0 SURPLUS_TOKENS = new I18n0("Surplus Tokens")//
 		.de("Überschüssige Zeichen");
 	I18n0 SYSTEM = new I18n0("System")//

--- a/platform-core-module/src/main/java/com/softicar/platform/core/module/file/smb/SmbCredentials.java
+++ b/platform-core-module/src/main/java/com/softicar/platform/core/module/file/smb/SmbCredentials.java
@@ -1,6 +1,6 @@
 package com.softicar.platform.core.module.file.smb;
 
-import java.util.Objects;
+import java.util.Optional;
 
 /**
  * Holds the credentials used for {@link ISmbClient} methods.
@@ -15,9 +15,9 @@ public class SmbCredentials {
 
 	public SmbCredentials(String domain, String username, String password) {
 
-		this.domain = Objects.requireNonNull(domain);
-		this.username = Objects.requireNonNull(username);
-		this.password = Objects.requireNonNull(password);
+		this.domain = Optional.ofNullable(domain).orElse("");
+		this.username = Optional.ofNullable(username).orElse("");
+		this.password = Optional.ofNullable(password).orElse("");
 	}
 
 	public String getDomain() {

--- a/platform-core-module/src/main/java/com/softicar/platform/core/module/file/stored/cleanup/StoredFileChunksToFileStoreMigrator.java
+++ b/platform-core-module/src/main/java/com/softicar/platform/core/module/file/stored/cleanup/StoredFileChunksToFileStoreMigrator.java
@@ -17,6 +17,7 @@ import java.io.InputStream;
 import java.security.MessageDigest;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Objects;
 
 class StoredFileChunksToFileStoreMigrator {
 
@@ -26,9 +27,9 @@ class StoredFileChunksToFileStoreMigrator {
 
 	private StoredFileChunksToFileStoreMigrator(IStoredFileDatabase database, IStoredFileContentStore store, AGStoredFile storedFile) {
 
-		this.database = database;
-		this.store = store;
-		this.storedFile = storedFile;
+		this.database = Objects.requireNonNull(database);
+		this.store = Objects.requireNonNull(store);
+		this.storedFile = Objects.requireNonNull(storedFile);
 	}
 
 	public static void migrateAll(IStoredFileDatabase database, IStoredFileContentStore store) {

--- a/platform-core-module/src/main/java/com/softicar/platform/core/module/file/stored/cleanup/StoredFileChunksToFileStoreMigrator.java
+++ b/platform-core-module/src/main/java/com/softicar/platform/core/module/file/stored/cleanup/StoredFileChunksToFileStoreMigrator.java
@@ -10,9 +10,7 @@ import com.softicar.platform.core.module.file.stored.chunk.AGStoredFileChunk;
 import com.softicar.platform.core.module.file.stored.content.StoredFileContentName;
 import com.softicar.platform.core.module.file.stored.content.StoredFileContentOutputStreamCreator;
 import com.softicar.platform.core.module.file.stored.content.database.IStoredFileDatabase;
-import com.softicar.platform.core.module.file.stored.content.database.StoredFileDatabase;
 import com.softicar.platform.core.module.file.stored.content.store.IStoredFileContentStore;
-import com.softicar.platform.core.module.file.stored.content.store.StoredFileSmbContentStore;
 import com.softicar.platform.core.module.file.stored.hash.IStoredFileHash;
 import java.io.IOException;
 import java.io.InputStream;
@@ -26,16 +24,11 @@ class StoredFileChunksToFileStoreMigrator {
 	private final IStoredFileContentStore store;
 	private final AGStoredFile storedFile;
 
-	public StoredFileChunksToFileStoreMigrator(IStoredFileDatabase database, IStoredFileContentStore store, AGStoredFile storedFile) {
+	private StoredFileChunksToFileStoreMigrator(IStoredFileDatabase database, IStoredFileContentStore store, AGStoredFile storedFile) {
 
 		this.database = database;
 		this.store = store;
 		this.storedFile = storedFile;
-	}
-
-	public static void migrateAll() {
-
-		migrateAll(new StoredFileDatabase(), new StoredFileSmbContentStore());
 	}
 
 	public static void migrateAll(IStoredFileDatabase database, IStoredFileContentStore store) {

--- a/platform-core-module/src/main/java/com/softicar/platform/core/module/file/stored/cleanup/StoredFilesCleanupProgram.java
+++ b/platform-core-module/src/main/java/com/softicar/platform/core/module/file/stored/cleanup/StoredFilesCleanupProgram.java
@@ -4,13 +4,18 @@ import com.softicar.platform.common.code.reference.point.SourceCodeReferencePoin
 import com.softicar.platform.common.core.i18n.IDisplayString;
 import com.softicar.platform.common.date.DayTime;
 import com.softicar.platform.core.module.CoreI18n;
+import com.softicar.platform.core.module.file.stored.AGStoredFile;
 import com.softicar.platform.core.module.file.stored.content.database.StoredFileDatabase;
-import com.softicar.platform.core.module.file.stored.content.store.StoredFileSmbContentStore;
+import com.softicar.platform.core.module.file.stored.content.store.StoredFileContentStores;
 import com.softicar.platform.core.module.program.IProgram;
 import java.util.Optional;
 
 /**
- * TODO add javadoc
+ * Performs cleanup operations for {@link AGStoredFile} and relates tables, as
+ * well as related file stores.
+ *
+ * @author Alexander Schmidt
+ * @author Oliver Richers
  */
 @SourceCodeReferencePointUuid("c748e8d1-fe5b-41dd-9d12-339177eda6e0")
 public class StoredFilesCleanupProgram implements IProgram {
@@ -18,19 +23,19 @@ public class StoredFilesCleanupProgram implements IProgram {
 	@Override
 	public void executeProgram() {
 
-		StoredFileSmbContentStore store = new StoredFileSmbContentStore();
+		var removeAtThreshold = DayTime.now();
+		var storedFileDatabase = new StoredFileDatabase();
+		var primaryContentStore = StoredFileContentStores.getPrimaryContentStore();
 
-		new FileStoreTmpFolderCleaner(store).cleanAll();
-
-		DayTime removeAtThreshold = DayTime.now();
+		primaryContentStore.ifPresent(store -> new FileStoreTmpFolderCleaner(store).cleanAll());
 
 		new StoredFileSetWithRemoveAtGarbageCollector(removeAtThreshold).collect();
 
 		new StoredFilesWithRemoveAtGarbageCollector(removeAtThreshold).collect();
 
-		new StoredFileStoreGarbageCollector(new StoredFileDatabase(), store).collect();
+		primaryContentStore.ifPresent(store -> new StoredFileStoreGarbageCollector(storedFileDatabase, store).collect());
 
-		StoredFileChunksToFileStoreMigrator.migrateAll();
+		primaryContentStore.ifPresent(store -> StoredFileChunksToFileStoreMigrator.migrateAll(storedFileDatabase, store));
 	}
 
 	@Override

--- a/platform-core-module/src/main/java/com/softicar/platform/core/module/file/stored/cleanup/StoredFilesCleanupProgram.java
+++ b/platform-core-module/src/main/java/com/softicar/platform/core/module/file/stored/cleanup/StoredFilesCleanupProgram.java
@@ -11,7 +11,7 @@ import com.softicar.platform.core.module.program.IProgram;
 import java.util.Optional;
 
 /**
- * Performs cleanup operations for {@link AGStoredFile} and relates tables, as
+ * Performs cleanup operations for {@link AGStoredFile} and related tables, as
  * well as related file stores.
  *
  * @author Alexander Schmidt
@@ -27,15 +27,15 @@ public class StoredFilesCleanupProgram implements IProgram {
 		var storedFileDatabase = new StoredFileDatabase();
 		var primaryContentStore = StoredFileContentStores.getPrimaryContentStore();
 
-		primaryContentStore.ifPresent(store -> new FileStoreTmpFolderCleaner(store).cleanAll());
-
 		new StoredFileSetWithRemoveAtGarbageCollector(removeAtThreshold).collect();
 
 		new StoredFilesWithRemoveAtGarbageCollector(removeAtThreshold).collect();
 
-		primaryContentStore.ifPresent(store -> new StoredFileStoreGarbageCollector(storedFileDatabase, store).collect());
-
-		primaryContentStore.ifPresent(store -> StoredFileChunksToFileStoreMigrator.migrateAll(storedFileDatabase, store));
+		primaryContentStore.ifPresent(store -> {
+			new FileStoreTmpFolderCleaner(store).cleanAll();
+			new StoredFileStoreGarbageCollector(storedFileDatabase, store).collect();
+			StoredFileChunksToFileStoreMigrator.migrateAll(storedFileDatabase, store);
+		});
 	}
 
 	@Override

--- a/platform-core-module/src/main/java/com/softicar/platform/core/module/file/stored/cleanup/UnreferencedStoredFileCleaner.java
+++ b/platform-core-module/src/main/java/com/softicar/platform/core/module/file/stored/cleanup/UnreferencedStoredFileCleaner.java
@@ -9,7 +9,6 @@ import com.softicar.platform.common.date.Duration;
 import com.softicar.platform.common.string.formatting.MemoryFormatting;
 import com.softicar.platform.core.module.file.stored.content.StoredFileContentName;
 import com.softicar.platform.core.module.file.stored.content.store.IStoredFileContentStore;
-import com.softicar.platform.core.module.file.stored.content.store.StoredFileSmbContentStore;
 import com.softicar.platform.core.module.file.stored.hash.AGStoredFileSha1;
 import java.util.Map;
 import java.util.Set;
@@ -18,15 +17,15 @@ class UnreferencedStoredFileCleaner {
 
 	static final int MINIMUM_DAYS_BEFORE_REMOVAL = 7;
 	private static final long MINIMUM_AGE_BEFORE_REMOVAL = MINIMUM_DAYS_BEFORE_REMOVAL * 24 * 60 * 60;
+	private final IStoredFileContentStore store;
 	private final Set<byte[]> filesInDatabase;
 	private final Map<byte[], StoredFileContentName> filesOnFileStore;
-	private final IStoredFileContentStore store;
 
-	public UnreferencedStoredFileCleaner() {
+	public UnreferencedStoredFileCleaner(IStoredFileContentStore store) {
 
+		this.store = store;
 		this.filesOnFileStore = MapFactory.createTreeMap(ByteArrayComparator.get());
 		this.filesInDatabase = SetFactory.createTreeSet(ByteArrayComparator.get());
-		this.store = new StoredFileSmbContentStore();
 	}
 
 	public void cleanAll() {

--- a/platform-core-module/src/main/java/com/softicar/platform/core/module/file/stored/cleanup/UnreferencedStoredFileCleanerProgram.java
+++ b/platform-core-module/src/main/java/com/softicar/platform/core/module/file/stored/cleanup/UnreferencedStoredFileCleanerProgram.java
@@ -3,12 +3,14 @@ package com.softicar.platform.core.module.file.stored.cleanup;
 import com.softicar.platform.common.code.reference.point.SourceCodeReferencePointUuid;
 import com.softicar.platform.common.core.i18n.IDisplayString;
 import com.softicar.platform.core.module.CoreI18n;
+import com.softicar.platform.core.module.file.stored.content.store.StoredFileContentStores;
 import com.softicar.platform.core.module.program.IProgram;
 import java.util.Optional;
 
 /**
  * This class is only used manually on occasion.
  *
+ * @author Alexander Schmidt
  * @author Oliver Richers
  */
 @SourceCodeReferencePointUuid("04e5d280-83a1-4464-b376-3a2fa0ab5473")
@@ -17,7 +19,9 @@ public class UnreferencedStoredFileCleanerProgram implements IProgram {
 	@Override
 	public void executeProgram() {
 
-		new UnreferencedStoredFileCleaner().cleanAll();
+		StoredFileContentStores//
+			.getPrimaryContentStore()
+			.ifPresent(store -> new UnreferencedStoredFileCleaner(store).cleanAll());
 	}
 
 	@Override

--- a/platform-core-module/src/main/java/com/softicar/platform/core/module/file/stored/content/StoredFileContentInputStreamCreator.java
+++ b/platform-core-module/src/main/java/com/softicar/platform/core/module/file/stored/content/StoredFileContentInputStreamCreator.java
@@ -7,9 +7,8 @@ import com.softicar.platform.core.module.file.stored.chunk.AGStoredFileChunk;
 import com.softicar.platform.core.module.file.stored.content.database.IStoredFileDatabase;
 import com.softicar.platform.core.module.file.stored.content.database.StoredFileDatabase;
 import com.softicar.platform.core.module.file.stored.content.store.IStoredFileContentStore;
-import com.softicar.platform.core.module.file.stored.content.store.StoredFileSmbContentStore;
+import com.softicar.platform.core.module.file.stored.content.store.StoredFileContentStores;
 import com.softicar.platform.core.module.file.stored.hash.IStoredFileHash;
-import com.softicar.platform.core.module.file.stored.repository.AGStoredFileRepository;
 import com.softicar.platform.core.module.log.LogDb;
 import java.io.ByteArrayOutputStream;
 import java.io.InputStream;
@@ -23,6 +22,7 @@ import java.util.Collection;
  * stores. Only if none of the content stores contains the file, the content
  * will be fetched from {@link AGStoredFileChunk}.
  *
+ * @author Alexander Schmidt
  * @author Oliver Richers
  */
 public class StoredFileContentInputStreamCreator {
@@ -37,10 +37,8 @@ public class StoredFileContentInputStreamCreator {
 		this.database = new StoredFileDatabase();
 		this.contentStores = new ArrayList<>();
 
-		AGStoredFileRepository//
-			.getAllActiveWithPrimaryFirst()
-			.stream()
-			.map(StoredFileSmbContentStore::new)
+		StoredFileContentStores//
+			.getAvailableContentStores()
 			.forEach(this::addContentStore);
 	}
 
@@ -54,7 +52,7 @@ public class StoredFileContentInputStreamCreator {
 
 		IStoredFileHash hash = getFileHash();
 		if (hash != null) {
-			return readFromSmbStore(hash);
+			return readFromStores(hash);
 		} else {
 			InputStream inputStream = readFromDatabase(storedFile);
 			if (inputStream != null) {
@@ -83,13 +81,13 @@ public class StoredFileContentInputStreamCreator {
 		return database.getFileHash(storedFile);
 	}
 
-	private InputStream readFromSmbStore(IStoredFileHash hash) {
+	private InputStream readFromStores(IStoredFileHash hash) {
 
-		ExceptionsCollector exceptionsCollector = new ExceptionsCollector();
-		StoredFileContentName contentName = new StoredFileContentName(hash.getHash());
+		var exceptionsCollector = new ExceptionsCollector();
+		var contentName = new StoredFileContentName(hash.getHash());
 		for (IStoredFileContentStore store: contentStores) {
 			try {
-				if (store.exists(contentName.getFullFilename())) {
+				if (store.isAvailable() && store.exists(contentName.getFullFilename())) {
 					return store.getFileInputStream(contentName.getFullFilename());
 				}
 			} catch (Exception exception) {

--- a/platform-core-module/src/main/java/com/softicar/platform/core/module/file/stored/content/StoredFileContentInputStreamCreator.java
+++ b/platform-core-module/src/main/java/com/softicar/platform/core/module/file/stored/content/StoredFileContentInputStreamCreator.java
@@ -38,14 +38,8 @@ public class StoredFileContentInputStreamCreator {
 		this.contentStores = new ArrayList<>();
 
 		StoredFileContentStores//
-			.getAvailableContentStores()
+			.getAccessibleContentStores()
 			.forEach(this::addContentStore);
-	}
-
-	public StoredFileContentInputStreamCreator addContentStore(IStoredFileContentStore store) {
-
-		contentStores.add(store);
-		return this;
 	}
 
 	public InputStream create() {
@@ -76,6 +70,12 @@ public class StoredFileContentInputStreamCreator {
 		}
 	}
 
+	StoredFileContentInputStreamCreator addContentStore(IStoredFileContentStore store) {
+
+		contentStores.add(store);
+		return this;
+	}
+
 	private IStoredFileHash getFileHash() {
 
 		return database.getFileHash(storedFile);
@@ -87,7 +87,7 @@ public class StoredFileContentInputStreamCreator {
 		var contentName = new StoredFileContentName(hash.getHash());
 		for (IStoredFileContentStore store: contentStores) {
 			try {
-				if (store.isAvailable() && store.exists(contentName.getFullFilename())) {
+				if (store.exists(contentName.getFullFilename())) {
 					return store.getFileInputStream(contentName.getFullFilename());
 				}
 			} catch (Exception exception) {

--- a/platform-core-module/src/main/java/com/softicar/platform/core/module/file/stored/content/StoredFileContentOutputStreamCreator.java
+++ b/platform-core-module/src/main/java/com/softicar/platform/core/module/file/stored/content/StoredFileContentOutputStreamCreator.java
@@ -6,38 +6,40 @@ import com.softicar.platform.core.module.file.stored.AGStoredFile;
 import com.softicar.platform.core.module.file.stored.content.database.IStoredFileDatabase;
 import com.softicar.platform.core.module.file.stored.content.database.StoredFileDatabase;
 import com.softicar.platform.core.module.file.stored.content.store.IStoredFileContentStore;
-import com.softicar.platform.core.module.file.stored.content.store.StoredFileSmbContentStore;
+import com.softicar.platform.core.module.file.stored.content.store.StoredFileContentStores;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.util.Optional;
 
 /**
  * Creates an output stream to write the content of an {@link AGStoredFile}.
  *
+ * @author Alexander Schmidt
  * @author Oliver Richers
  */
 public class StoredFileContentOutputStreamCreator {
 
 	private final AGStoredFile storedFile;
 	private final IStoredFileDatabase database;
-	private IStoredFileContentStore store;
+	private Optional<IStoredFileContentStore> store;
 
 	public StoredFileContentOutputStreamCreator(AGStoredFile storedFile) {
 
 		this.storedFile = storedFile;
 		this.database = new StoredFileDatabase();
-		this.store = new StoredFileSmbContentStore();
+		this.store = StoredFileContentStores.getPreferredAvailableContentStore();
 	}
 
 	public StoredFileContentOutputStreamCreator setStore(IStoredFileContentStore store) {
 
-		this.store = store;
+		this.store = Optional.ofNullable(store);
 		return this;
 	}
 
 	public OutputStream create() {
 
-		return new StoredFileContentUploader(database, store, storedFile).createOutputStream();
+		return new StoredFileContentUploader(database, storedFile, store).createOutputStream();
 	}
 
 	public void upload(InputStream inputStream) {

--- a/platform-core-module/src/main/java/com/softicar/platform/core/module/file/stored/content/StoredFileContentOutputStreamCreator.java
+++ b/platform-core-module/src/main/java/com/softicar/platform/core/module/file/stored/content/StoredFileContentOutputStreamCreator.java
@@ -10,7 +10,7 @@ import com.softicar.platform.core.module.file.stored.content.store.StoredFileCon
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
-import java.util.Optional;
+import java.util.Objects;
 
 /**
  * Creates an output stream to write the content of an {@link AGStoredFile}.
@@ -22,18 +22,18 @@ public class StoredFileContentOutputStreamCreator {
 
 	private final AGStoredFile storedFile;
 	private final IStoredFileDatabase database;
-	private Optional<IStoredFileContentStore> store;
+	private IStoredFileContentStore store;
 
 	public StoredFileContentOutputStreamCreator(AGStoredFile storedFile) {
 
-		this.storedFile = storedFile;
+		this.storedFile = Objects.requireNonNull(storedFile);
 		this.database = new StoredFileDatabase();
-		this.store = StoredFileContentStores.getPreferredAvailableContentStore();
+		this.store = StoredFileContentStores.getPrimaryContentStore().orElse(null);
 	}
 
 	public StoredFileContentOutputStreamCreator setStore(IStoredFileContentStore store) {
 
-		this.store = Optional.ofNullable(store);
+		this.store = store;
 		return this;
 	}
 

--- a/platform-core-module/src/main/java/com/softicar/platform/core/module/file/stored/content/StoredFileContentUploader.java
+++ b/platform-core-module/src/main/java/com/softicar/platform/core/module/file/stored/content/StoredFileContentUploader.java
@@ -11,6 +11,7 @@ import com.softicar.platform.core.module.file.stored.content.store.IStoredFileCo
 import com.softicar.platform.core.module.file.stored.hash.AGStoredFileSha1;
 import com.softicar.platform.core.module.log.LogDb;
 import java.io.OutputStream;
+import java.util.Optional;
 
 /**
  * This class manages the upload of the content of a stored file to the file
@@ -32,35 +33,43 @@ class StoredFileContentUploader {
 	private static final String TEMPORARY_FILE_FOLDER = "/tmp";
 
 	private final IStoredFileDatabase database;
-	private final IStoredFileContentStore store;
 	private final AGStoredFile storedFile;
+	private final Optional<IStoredFileContentStore> store;
 
-	public StoredFileContentUploader(IStoredFileDatabase database, IStoredFileContentStore store, AGStoredFile storedFile) {
+	public StoredFileContentUploader(IStoredFileDatabase database, AGStoredFile storedFile, IStoredFileContentStore store) {
+
+		this(database, storedFile, Optional.ofNullable(store));
+	}
+
+	public StoredFileContentUploader(IStoredFileDatabase database, AGStoredFile storedFile, Optional<IStoredFileContentStore> store) {
 
 		this.database = database;
-		this.store = store;
 		this.storedFile = storedFile;
+		this.store = store;
 	}
 
 	public OutputStream createOutputStream() {
 
-		if (!store.isEnabled()) {
+		if (!store.isPresent()) {
 			return useChunks();
 		}
 
-		if (store.isReady()) {
-			long freeDiskSpace = store.getFreeDiskSpace();
+		if (store.get().isAvailable()) {
+			long freeDiskSpace = store.get().getFreeDiskSpace();
 			if (freeDiskSpace >= MINIMUM_FREE_SPACE) {
 				return useStore();
 			} else {
 				String message = "File store '%s' has not enough free space (%s free space required but only %s available). Falling back to database store."
-					.formatted(store.getLocation(), MemoryFormatting.formatMemory(MINIMUM_FREE_SPACE, 1), MemoryFormatting.formatMemory(freeDiskSpace, 1));
+					.formatted(
+						store.get().getLocation(),
+						MemoryFormatting.formatMemory(MINIMUM_FREE_SPACE, 1),
+						MemoryFormatting.formatMemory(freeDiskSpace, 1));
 				Log.ferror(message);
 				LogDb.panic(message);
 				return useChunks();
 			}
 		} else {
-			String message = "File store '%s' is not available. Falling back to database store.".formatted(store.getLocation());
+			String message = "File store '%s' is not available. Falling back to database store.".formatted(store.get().getLocation());
 			Log.ferror(message);
 			LogDb.panic(message);
 			return useChunks();
@@ -74,9 +83,9 @@ class StoredFileContentUploader {
 
 	private OutputStream useStore() {
 
-		store.createDirectories(TEMPORARY_FILE_FOLDER);
+		store.get().createDirectories(TEMPORARY_FILE_FOLDER);
 
-		HashingOutputStream outputStream = new HashingOutputStream(() -> store.getFileOutputStream(getTemporaryFileName()), StoredFileUtils.FILE_HASH);
+		HashingOutputStream outputStream = new HashingOutputStream(() -> store.get().getFileOutputStream(getTemporaryFileName()), StoredFileUtils.FILE_HASH);
 		outputStream.setOnCloseCallback(this::onClose);
 		return outputStream;
 	}
@@ -105,26 +114,25 @@ class StoredFileContentUploader {
 
 	private void createFolders(String folderName) {
 
-		store.createDirectories(folderName);
+		store.get().createDirectories(folderName);
 	}
 
 	private void moveFileToFolder(String targetName) {
 
 		String sourceName = getTemporaryFileName();
 
-		if (store.exists(targetName)) {
-
+		if (store.get().exists(targetName)) {
 			verifyFileSizes(sourceName, targetName);
-			store.deleteFile(sourceName);
+			store.get().deleteFile(sourceName);
 		} else {
-			store.moveFile(sourceName, targetName);
+			store.get().moveFile(sourceName, targetName);
 		}
 	}
 
 	private void verifyFileSizes(String sourceName, String targetName) {
 
-		long sourceSize = store.getFileSize(sourceName);
-		long targetSize = store.getFileSize(targetName);
+		long sourceSize = store.get().getFileSize(sourceName);
+		long targetSize = store.get().getFileSize(targetName);
 
 		if (sourceSize != targetSize) {
 			throw new SofticarDeveloperException(//

--- a/platform-core-module/src/main/java/com/softicar/platform/core/module/file/stored/content/database/IStoredFileDatabase.java
+++ b/platform-core-module/src/main/java/com/softicar/platform/core/module/file/stored/content/database/IStoredFileDatabase.java
@@ -46,7 +46,7 @@ public interface IStoredFileDatabase {
 	/**
 	 * Creates an {@link OutputStream} for the given file into the database.
 	 * <p>
-	 * This method should be used if the usual file store is not available. The
+	 * This method should be used if the usual file store is not accessible. The
 	 * content is saved into small data chunks.
 	 *
 	 * @param storedFile

--- a/platform-core-module/src/main/java/com/softicar/platform/core/module/file/stored/content/store/IStoredFileContentStore.java
+++ b/platform-core-module/src/main/java/com/softicar/platform/core/module/file/stored/content/store/IStoredFileContentStore.java
@@ -34,7 +34,7 @@ public interface IStoredFileContentStore {
 	 * @return <i>true</i> if this content store is technically ready;
 	 *         <i>false</i> otherwise
 	 */
-	boolean isAvailable();
+	boolean isAccessible();
 
 	/**
 	 * Determines the disk space in bytes that is still available in this

--- a/platform-core-module/src/main/java/com/softicar/platform/core/module/file/stored/content/store/IStoredFileContentStore.java
+++ b/platform-core-module/src/main/java/com/softicar/platform/core/module/file/stored/content/store/IStoredFileContentStore.java
@@ -28,31 +28,13 @@ public interface IStoredFileContentStore {
 	String getLocation();
 
 	/**
-	 * Determines whether this content store should be used, according to some
-	 * configuration.
+	 * Determines whether this content store is technically ready to receive and
+	 * provide data.
 	 *
-	 * @return <i>true</i> if this content store should be used; <i>false</i>
-	 *         otherwise
-	 */
-	boolean isEnabled();
-
-	/**
-	 * Determines whether this content store is ready to be used, from a
-	 * technical perspective.
-	 *
-	 * @return <i>true</i> if this content store is ready to be used;
+	 * @return <i>true</i> if this content store is technically ready;
 	 *         <i>false</i> otherwise
 	 */
-	boolean isReady();
-
-	/**
-	 * @deprecated use {@link #isReady()} instead
-	 */
-	@Deprecated
-	default boolean isAvailable() {
-
-		return isReady();
-	}
+	boolean isAvailable();
 
 	/**
 	 * Determines the disk space in bytes that is still available in this

--- a/platform-core-module/src/main/java/com/softicar/platform/core/module/file/stored/content/store/StoredFileContentStoreFactory.java
+++ b/platform-core-module/src/main/java/com/softicar/platform/core/module/file/stored/content/store/StoredFileContentStoreFactory.java
@@ -30,6 +30,15 @@ class StoredFileContentStoreFactory {
 		return Optional.empty();
 	}
 
+	/**
+	 * Represents a URL in one of the following formats:
+	 *
+	 * <pre>
+	 * file:///dir/subdir  - an absolute path
+	 * file://dir/subdir   - a relative path
+	 * file:/dir/subdir    - an absolute path (short form)
+	 * </pre>
+	 */
 	private static class SimpleUrl {
 
 		private static final Pattern PATTERN = Pattern.compile("([a-z]+):(.+)");

--- a/platform-core-module/src/main/java/com/softicar/platform/core/module/file/stored/content/store/StoredFileContentStoreFactory.java
+++ b/platform-core-module/src/main/java/com/softicar/platform/core/module/file/stored/content/store/StoredFileContentStoreFactory.java
@@ -1,0 +1,61 @@
+package com.softicar.platform.core.module.file.stored.content.store;
+
+import com.softicar.platform.common.core.logging.Log;
+import com.softicar.platform.common.string.Trim;
+import com.softicar.platform.common.string.formatting.StackTraceFormatting;
+import com.softicar.platform.core.module.file.stored.repository.AGStoredFileRepository;
+import java.net.MalformedURLException;
+import java.util.Optional;
+import java.util.regex.Pattern;
+
+class StoredFileContentStoreFactory {
+
+	public Optional<IStoredFileContentStore> create(AGStoredFileRepository repository) {
+
+		try {
+			var url = new SimpleUrl(repository.getUrl());
+			String protocol = url.getProtocol();
+			switch (protocol) {
+			case "smb":
+				return Optional.of(new StoredFileSmbContentStore(repository));
+			case "file":
+				return Optional.of(new StoredFileFileSystemContentStore(url.getPath()));
+			default:
+				Log.ferror("Cannot handle content store URLs that start with '%s'.", protocol);
+			}
+		} catch (MalformedURLException exception) {
+			Log.ferror("Invalid file repository URL: %s", StackTraceFormatting.getStackTraceAsString(exception));
+		}
+
+		return Optional.empty();
+	}
+
+	private static class SimpleUrl {
+
+		private static final Pattern PATTERN = Pattern.compile("([a-z]+):(.+)");
+		private final String protocol;
+		private final String path;
+
+		public SimpleUrl(String text) throws MalformedURLException {
+
+			var matcher = PATTERN.matcher(text);
+			matcher.find();
+			if (matcher.groupCount() != 2) {
+				throw new MalformedURLException("Illegal URL: '%s'".formatted(text));
+			}
+
+			this.protocol = matcher.group(1).toLowerCase();
+			this.path = Trim.trimPrefix(matcher.group(2), "//");
+		}
+
+		public String getProtocol() {
+
+			return protocol;
+		}
+
+		public String getPath() {
+
+			return path;
+		}
+	}
+}

--- a/platform-core-module/src/main/java/com/softicar/platform/core/module/file/stored/content/store/StoredFileContentStores.java
+++ b/platform-core-module/src/main/java/com/softicar/platform/core/module/file/stored/content/store/StoredFileContentStores.java
@@ -1,0 +1,85 @@
+package com.softicar.platform.core.module.file.stored.content.store;
+
+import com.softicar.platform.core.module.file.stored.repository.AGStoredFileRepository;
+import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+/**
+ * Provides utility methods for {@link IStoredFileContentStore} instances.
+ *
+ * @author Alexander Schmidt
+ */
+public class StoredFileContentStores {
+
+	private StoredFileContentStores() {
+
+		// do not instantiate
+	}
+
+	/**
+	 * Determines all content stores that are currently available.
+	 * <p>
+	 * If there is a primary content store that is <i>available</i> (according
+	 * to {@link IStoredFileContentStore#isAvailable()}), that content store
+	 * will be the first element in the returned {@link Collection}.
+	 * <p>
+	 * If no content store can be determined, an empty {@link Collection} is
+	 * returned.
+	 *
+	 * @return all currently available content stores
+	 * @see IStoredFileContentStore#isAvailable()
+	 */
+	public static Collection<IStoredFileContentStore> getAvailableContentStores() {
+
+		return getAllContentStores()//
+			.stream()
+			.filter(store -> store.isAvailable())
+			.collect(Collectors.toList());
+	}
+
+	/**
+	 * Determines the currently preferred and available content store.
+	 * <p>
+	 * If there is a primary content store that is <i>available</i> (according
+	 * to {@link IStoredFileContentStore#isAvailable()}), that content store
+	 * will be returned. Otherwise, an available non-primary content store may
+	 * be returned.
+	 * <p>
+	 * If no content store can be determined, {@link Optional#empty()} is
+	 * returned.
+	 *
+	 * @return the currently preferred and available content store
+	 * @see IStoredFileContentStore#isAvailable()
+	 */
+	public static Optional<IStoredFileContentStore> getPreferredAvailableContentStore() {
+
+		return getAvailableContentStores()//
+			.stream()
+			.findFirst();
+	}
+
+	/**
+	 * Returns the primary content store if it is defined and available.
+	 *
+	 * @return the available primary content store
+	 */
+	public static Optional<IStoredFileContentStore> getPrimaryContentStore() {
+
+		return AGStoredFileRepository//
+			.getPrimaryIfActive()
+			.flatMap(new StoredFileContentStoreFactory()::create)
+			.filter(store -> store.isAvailable());
+	}
+
+	private static List<IStoredFileContentStore> getAllContentStores() {
+
+		return AGStoredFileRepository//
+			.getAllActiveWithPrimaryFirst()
+			.stream()
+			.map(new StoredFileContentStoreFactory()::create)
+			.flatMap(Optional::stream)
+			.collect(Collectors.toList());
+	}
+}

--- a/platform-core-module/src/main/java/com/softicar/platform/core/module/file/stored/content/store/StoredFileContentStores.java
+++ b/platform-core-module/src/main/java/com/softicar/platform/core/module/file/stored/content/store/StoredFileContentStores.java
@@ -11,66 +11,40 @@ import java.util.stream.Collectors;
  *
  * @author Alexander Schmidt
  */
-public class StoredFileContentStores {
-
-	private StoredFileContentStores() {
-
-		// do not instantiate
-	}
+public interface StoredFileContentStores {
 
 	/**
-	 * Determines all content stores that are currently available.
+	 * Determines all content stores that are currently accessible.
 	 * <p>
-	 * If there is a primary content store that is <i>available</i> (according
-	 * to {@link IStoredFileContentStore#isAvailable()}), that content store
+	 * If there is a primary content store that is <i>accessible</i> (according
+	 * to {@link IStoredFileContentStore#isAccessible()}), that content store
 	 * will be the first element in the returned {@link Collection}.
 	 * <p>
 	 * If no content store can be determined, an empty {@link Collection} is
 	 * returned.
 	 *
-	 * @return all currently available content stores
-	 * @see IStoredFileContentStore#isAvailable()
+	 * @return all currently accessible content stores
+	 * @see IStoredFileContentStore#isAccessible()
 	 */
-	public static Collection<IStoredFileContentStore> getAvailableContentStores() {
+	public static Collection<IStoredFileContentStore> getAccessibleContentStores() {
 
 		return getAllContentStores()//
 			.stream()
-			.filter(store -> store.isAvailable())
+			.filter(store -> store.isAccessible())
 			.collect(Collectors.toList());
 	}
 
 	/**
-	 * Determines the currently preferred and available content store.
-	 * <p>
-	 * If there is a primary content store that is <i>available</i> (according
-	 * to {@link IStoredFileContentStore#isAvailable()}), that content store
-	 * will be returned. Otherwise, an available non-primary content store may
-	 * be returned.
-	 * <p>
-	 * If no content store can be determined, {@link Optional#empty()} is
-	 * returned.
+	 * Returns the primary content store if it is defined and accessible.
 	 *
-	 * @return the currently preferred and available content store
-	 * @see IStoredFileContentStore#isAvailable()
-	 */
-	public static Optional<IStoredFileContentStore> getPreferredAvailableContentStore() {
-
-		return getAvailableContentStores()//
-			.stream()
-			.findFirst();
-	}
-
-	/**
-	 * Returns the primary content store if it is defined and available.
-	 *
-	 * @return the available primary content store
+	 * @return the accessible primary content store
 	 */
 	public static Optional<IStoredFileContentStore> getPrimaryContentStore() {
 
 		return AGStoredFileRepository//
 			.getPrimaryIfActive()
 			.flatMap(new StoredFileContentStoreFactory()::create)
-			.filter(store -> store.isAvailable());
+			.filter(store -> store.isAccessible());
 	}
 
 	private static List<IStoredFileContentStore> getAllContentStores() {

--- a/platform-core-module/src/main/java/com/softicar/platform/core/module/file/stored/content/store/StoredFileFileSystemContentStore.java
+++ b/platform-core-module/src/main/java/com/softicar/platform/core/module/file/stored/content/store/StoredFileFileSystemContentStore.java
@@ -51,7 +51,7 @@ public class StoredFileFileSystemContentStore implements IStoredFileContentStore
 	}
 
 	@Override
-	public boolean isAvailable() {
+	public boolean isAccessible() {
 
 		return directory != null && directory.isDirectory() && directory.canWrite();
 	}

--- a/platform-core-module/src/main/java/com/softicar/platform/core/module/file/stored/content/store/StoredFileFileSystemContentStore.java
+++ b/platform-core-module/src/main/java/com/softicar/platform/core/module/file/stored/content/store/StoredFileFileSystemContentStore.java
@@ -1,7 +1,9 @@
 package com.softicar.platform.core.module.file.stored.content.store;
 
+import com.softicar.platform.common.core.exceptions.SofticarException;
 import com.softicar.platform.common.core.exceptions.SofticarIOException;
 import com.softicar.platform.common.date.DayTime;
+import com.softicar.platform.common.string.Trim;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
@@ -12,7 +14,6 @@ import java.io.OutputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Collection;
-import java.util.Objects;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -27,34 +28,30 @@ public class StoredFileFileSystemContentStore implements IStoredFileContentStore
 	private final File directory;
 
 	/**
-	 * Constructs a new {@link StoredFileFileSystemContentStore}.
+	 * Constructs a new {@link StoredFileFileSystemContentStore} for the given
+	 * directory.
 	 *
-	 * @param directory
-	 *            an existing, writable directory (never <i>null</i>)
+	 * @param absolutePath
+	 *            the absolute path to an existing, writable directory (never
+	 *            <i>null</i>)
 	 */
-	public StoredFileFileSystemContentStore(File directory) {
+	StoredFileFileSystemContentStore(String absolutePath) {
 
-		this.directory = Objects.requireNonNull(directory);
+		if (!absolutePath.startsWith("/")) {
+			throw new IllegalArgumentException("Expected an absolute path but encountered: '%s'".formatted(absolutePath));
+		}
+
+		this.directory = new File(absolutePath);
 	}
 
 	@Override
 	public String getLocation() {
 
-		try {
-			return directory.getCanonicalPath();
-		} catch (IOException exception) {
-			throw new SofticarIOException(exception);
-		}
+		return directory.getPath();
 	}
 
 	@Override
-	public boolean isEnabled() {
-
-		return true;
-	}
-
-	@Override
-	public boolean isReady() {
+	public boolean isAvailable() {
 
 		return directory != null && directory.isDirectory() && directory.canWrite();
 	}
@@ -69,6 +66,9 @@ public class StoredFileFileSystemContentStore implements IStoredFileContentStore
 	public void createDirectories(String directoryPath) {
 
 		resolveFile(directoryPath).mkdirs();
+		if (!exists(directoryPath)) {
+			throw new SofticarException("Failed to create directory '%s' in the content store.", directoryPath);
+		}
 	}
 
 	@Override
@@ -152,6 +152,7 @@ public class StoredFileFileSystemContentStore implements IStoredFileContentStore
 
 	private Path resolvePath(String name) {
 
+		name = Trim.trimLeft(name, '/');
 		return directory.toPath().resolve(name);
 	}
 

--- a/platform-core-module/src/main/java/com/softicar/platform/core/module/file/stored/content/store/StoredFileInMemoryContentStore.java
+++ b/platform-core-module/src/main/java/com/softicar/platform/core/module/file/stored/content/store/StoredFileInMemoryContentStore.java
@@ -33,7 +33,7 @@ public class StoredFileInMemoryContentStore implements IStoredFileContentStore {
 	}
 
 	@Override
-	public boolean isAvailable() {
+	public boolean isAccessible() {
 
 		return true;
 	}

--- a/platform-core-module/src/main/java/com/softicar/platform/core/module/file/stored/content/store/StoredFileInMemoryContentStore.java
+++ b/platform-core-module/src/main/java/com/softicar/platform/core/module/file/stored/content/store/StoredFileInMemoryContentStore.java
@@ -33,13 +33,7 @@ public class StoredFileInMemoryContentStore implements IStoredFileContentStore {
 	}
 
 	@Override
-	public boolean isEnabled() {
-
-		return true;
-	}
-
-	@Override
-	public boolean isReady() {
+	public boolean isAvailable() {
 
 		return true;
 	}

--- a/platform-core-module/src/main/java/com/softicar/platform/core/module/file/stored/content/store/StoredFileSmbContentStore.java
+++ b/platform-core-module/src/main/java/com/softicar/platform/core/module/file/stored/content/store/StoredFileSmbContentStore.java
@@ -1,6 +1,5 @@
 package com.softicar.platform.core.module.file.stored.content.store;
 
-import com.softicar.platform.common.core.exceptions.SofticarDeveloperException;
 import com.softicar.platform.common.core.utils.DevNull;
 import com.softicar.platform.common.date.DayTime;
 import com.softicar.platform.common.string.Trim;
@@ -14,7 +13,7 @@ import com.softicar.platform.core.module.file.stored.repository.AGStoredFileRepo
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.util.Collection;
-import java.util.Optional;
+import java.util.Objects;
 import java.util.stream.Collectors;
 
 /**
@@ -27,37 +26,21 @@ import java.util.stream.Collectors;
  */
 public class StoredFileSmbContentStore implements IStoredFileContentStore {
 
-	private final Optional<AGStoredFileRepository> repository;
+	private final AGStoredFileRepository repository;
 
-	public StoredFileSmbContentStore() {
+	StoredFileSmbContentStore(AGStoredFileRepository repository) {
 
-		this(AGStoredFileRepository.getPrimary());
-	}
-
-	public StoredFileSmbContentStore(AGStoredFileRepository repository) {
-
-		this(Optional.ofNullable(repository));
-	}
-
-	public StoredFileSmbContentStore(Optional<AGStoredFileRepository> repository) {
-
-		this.repository = repository;
+		this.repository = Objects.requireNonNull(repository);
 	}
 
 	@Override
 	public String getLocation() {
 
-		return getRepositoryOrThrow().getUrl();
+		return repository.getUrl();
 	}
 
 	@Override
-	public boolean isEnabled() {
-
-		return repository.isPresent();
-	}
-
-	@Override
-	public boolean isReady() {
+	public boolean isAvailable() {
 
 		try {
 			return createSmbEntry("/").exists();
@@ -156,17 +139,11 @@ public class StoredFileSmbContentStore implements IStoredFileContentStore {
 
 	private String createSmbUrl(String name) {
 
-		return Trim.trimRight(getRepositoryOrThrow().getUrl(), '/') + "/" + Trim.trimLeft(name, '/');
+		return Trim.trimRight(repository.getUrl(), '/') + "/" + Trim.trimLeft(name, '/');
 	}
 
 	private SmbCredentials getSmbCredentials() {
 
-		AGStoredFileRepository fileRepository = getRepositoryOrThrow();
-		return new SmbCredentials(fileRepository.getDomain(), fileRepository.getUsername(), fileRepository.getPassword());
-	}
-
-	private AGStoredFileRepository getRepositoryOrThrow() {
-
-		return repository.orElseThrow(() -> new SofticarDeveloperException("File repository was not defined."));
+		return new SmbCredentials(repository.getDomain(), repository.getUsername(), repository.getPassword());
 	}
 }

--- a/platform-core-module/src/main/java/com/softicar/platform/core/module/file/stored/content/store/StoredFileSmbContentStore.java
+++ b/platform-core-module/src/main/java/com/softicar/platform/core/module/file/stored/content/store/StoredFileSmbContentStore.java
@@ -40,7 +40,7 @@ public class StoredFileSmbContentStore implements IStoredFileContentStore {
 	}
 
 	@Override
-	public boolean isAvailable() {
+	public boolean isAccessible() {
 
 		try {
 			return createSmbEntry("/").exists();

--- a/platform-core-module/src/main/java/com/softicar/platform/core/module/file/stored/repository/AGStoredFileRepository.java
+++ b/platform-core-module/src/main/java/com/softicar/platform/core/module/file/stored/repository/AGStoredFileRepository.java
@@ -25,7 +25,7 @@ public class AGStoredFileRepository extends AGStoredFileRepositoryGenerated impl
 	public static List<AGStoredFileRepository> getAllActiveWithPrimaryFirst() {
 
 		List<AGStoredFileRepository> repositories = new ArrayList<>();
-		Optional<AGStoredFileRepository> primaryRepository = getPrimary().filter(AGStoredFileRepository::isActive);
+		Optional<AGStoredFileRepository> primaryRepository = getPrimaryIfActive();
 		primaryRepository.ifPresent(repositories::add);
 		AGStoredFileRepository.TABLE//
 			.createSelect()
@@ -41,5 +41,10 @@ public class AGStoredFileRepository extends AGStoredFileRepositoryGenerated impl
 		return Optional//
 			.ofNullable(AGCoreModuleInstance.getInstance())
 			.map(AGCoreModuleInstance::getPrimaryFileRepository);
+	}
+
+	public static Optional<AGStoredFileRepository> getPrimaryIfActive() {
+
+		return getPrimary().filter(AGStoredFileRepository::isActive);
 	}
 }

--- a/platform-core-module/src/main/java/com/softicar/platform/core/module/file/stored/repository/AGStoredFileRepository.sqml
+++ b/platform-core-module/src/main/java/com/softicar/platform/core/module/file/stored/repository/AGStoredFileRepository.sqml
@@ -4,7 +4,7 @@ TABLE AGStoredFileRepository 'Core.StoredFileRepository' {
 	PK Integer id = SERIAL
 	Boolean active = TRUE
 	String url [MAXLENGTH=255]
-	String domain [MAXLENGTH=255]
-	String username [MAXLENGTH=255]
-	String password [MAXLENGTH=255]
+	String domain = '' [MAXLENGTH=255]
+	String username = '' [MAXLENGTH=255]
+	String password = '' [MAXLENGTH=255]
 }

--- a/platform-core-module/src/main/java/com/softicar/platform/core/module/file/stored/repository/AGStoredFileRepositoryGenerated.java
+++ b/platform-core-module/src/main/java/com/softicar/platform/core/module/file/stored/repository/AGStoredFileRepositoryGenerated.java
@@ -29,9 +29,9 @@ public class AGStoredFileRepositoryGenerated extends AbstractDbObject<AGStoredFi
 	public static final IDbIdField<AGStoredFileRepository> ID = BUILDER.addIdField("id", o->o.m_id, (o,v)->o.m_id=v).setTitle(CoreI18n.ID);
 	public static final IDbBooleanField<AGStoredFileRepository> ACTIVE = BUILDER.addBooleanField("active", o->o.m_active, (o,v)->o.m_active=v).setTitle(CoreI18n.ACTIVE).setDefault(true);
 	public static final IDbStringField<AGStoredFileRepository> URL = BUILDER.addStringField("url", o->o.m_url, (o,v)->o.m_url=v).setTitle(CoreI18n.URL).setMaximumLength(255);
-	public static final IDbStringField<AGStoredFileRepository> DOMAIN = BUILDER.addStringField("domain", o->o.m_domain, (o,v)->o.m_domain=v).setTitle(CoreI18n.DOMAIN).setMaximumLength(255);
-	public static final IDbStringField<AGStoredFileRepository> USERNAME = BUILDER.addStringField("username", o->o.m_username, (o,v)->o.m_username=v).setTitle(CoreI18n.USERNAME).setMaximumLength(255);
-	public static final IDbStringField<AGStoredFileRepository> PASSWORD = BUILDER.addStringField("password", o->o.m_password, (o,v)->o.m_password=v).setTitle(CoreI18n.PASSWORD).setMaximumLength(255);
+	public static final IDbStringField<AGStoredFileRepository> DOMAIN = BUILDER.addStringField("domain", o->o.m_domain, (o,v)->o.m_domain=v).setTitle(CoreI18n.DOMAIN).setDefault("").setMaximumLength(255);
+	public static final IDbStringField<AGStoredFileRepository> USERNAME = BUILDER.addStringField("username", o->o.m_username, (o,v)->o.m_username=v).setTitle(CoreI18n.USERNAME).setDefault("").setMaximumLength(255);
+	public static final IDbStringField<AGStoredFileRepository> PASSWORD = BUILDER.addStringField("password", o->o.m_password, (o,v)->o.m_password=v).setTitle(CoreI18n.PASSWORD).setDefault("").setMaximumLength(255);
 	public static final AGStoredFileRepositoryTable TABLE = new AGStoredFileRepositoryTable(BUILDER);
 	// @formatter:on
 

--- a/platform-core-module/src/main/java/com/softicar/platform/core/module/file/stored/repository/AGStoredFileRepositoryTable.java
+++ b/platform-core-module/src/main/java/com/softicar/platform/core/module/file/stored/repository/AGStoredFileRepositoryTable.java
@@ -1,10 +1,13 @@
 package com.softicar.platform.core.module.file.stored.repository;
 
 import com.softicar.platform.core.module.AGCoreModuleInstance;
+import com.softicar.platform.core.module.CoreI18n;
 import com.softicar.platform.core.module.CoreImages;
 import com.softicar.platform.core.module.CoreModule;
 import com.softicar.platform.core.module.CorePermissions;
 import com.softicar.platform.db.runtime.object.IDbObjectTableBuilder;
+import com.softicar.platform.dom.element.IDomElement;
+import com.softicar.platform.dom.elements.wiki.DomWikiDivBuilder;
 import com.softicar.platform.emf.attribute.IEmfAttributeList;
 import com.softicar.platform.emf.authorizer.EmfAuthorizer;
 import com.softicar.platform.emf.log.EmfChangeLoggerSet;
@@ -36,13 +39,13 @@ public class AGStoredFileRepositoryTable extends EmfObjectTable<AGStoredFileRepo
 	@Override
 	public void customizeAttributeProperties(IEmfAttributeList<AGStoredFileRepository> attributes) {
 
-		attributes.editAttribute(AGStoredFileRepository.URL).setPredicateMandatory(EmfPredicates.always());
-		attributes.editAttribute(AGStoredFileRepository.DOMAIN).setPredicateMandatory(EmfPredicates.always());
-		attributes.editAttribute(AGStoredFileRepository.USERNAME).setPredicateMandatory(EmfPredicates.always());
+		attributes//
+			.editAttribute(AGStoredFileRepository.URL)
+			.setHelpDisplayFactory(this::createUrlHelpElement)
+			.setPredicateMandatory(EmfPredicates.always());
 		attributes//
 			.editStringAttribute(AGStoredFileRepository.PASSWORD)
-			.setPasswordMode(true)
-			.setPredicateMandatory(EmfPredicates.always());
+			.setPasswordMode(true);
 	}
 
 	@Override
@@ -55,5 +58,14 @@ public class AGStoredFileRepositoryTable extends EmfObjectTable<AGStoredFileRepo
 			.addMapping(AGStoredFileRepository.DOMAIN, AGStoredFileRepositoryLog.DOMAIN)
 			.addMapping(AGStoredFileRepository.USERNAME, AGStoredFileRepositoryLog.USERNAME)
 			.addMapping(AGStoredFileRepository.PASSWORD, AGStoredFileRepositoryLog.PASSWORD);
+	}
+
+	private IDomElement createUrlHelpElement() {
+
+		return new DomWikiDivBuilder()
+			.addLine(CoreI18n.SUPPORTED_URLS.concatColon())
+			.addUnorderedListItem(CoreI18n.ARG1_FOR_A_LOCAL_DIRECTORY.toDisplay("<code>file:///absolute/path</code>"))
+			.addUnorderedListItem(CoreI18n.ARG1_FOR_AN_SMB_SHARE.toDisplay("<code>smb://host/share</code>"))
+			.build();
 	}
 }

--- a/platform-core-module/src/test/java/com/softicar/platform/core/module/file/stored/content/StoredFileContentInputStreamCreatorTest.java
+++ b/platform-core-module/src/test/java/com/softicar/platform/core/module/file/stored/content/StoredFileContentInputStreamCreatorTest.java
@@ -160,6 +160,7 @@ public class StoredFileContentInputStreamCreatorTest extends AbstractDbTest impl
 	private static IStoredFileContentStore createBrokenStore() {
 
 		IStoredFileContentStore brokenStore = Mockito.mock(IStoredFileContentStore.class);
+		Mockito.when(brokenStore.isAvailable()).thenReturn(true);
 		Mockito.when(brokenStore.exists(Mockito.any())).thenThrow(new RuntimeException());
 		Mockito.when(brokenStore.getFileInputStream(Mockito.any())).thenThrow(new RuntimeException());
 		return brokenStore;

--- a/platform-core-module/src/test/java/com/softicar/platform/core/module/file/stored/content/StoredFileContentInputStreamCreatorTest.java
+++ b/platform-core-module/src/test/java/com/softicar/platform/core/module/file/stored/content/StoredFileContentInputStreamCreatorTest.java
@@ -160,7 +160,7 @@ public class StoredFileContentInputStreamCreatorTest extends AbstractDbTest impl
 	private static IStoredFileContentStore createBrokenStore() {
 
 		IStoredFileContentStore brokenStore = Mockito.mock(IStoredFileContentStore.class);
-		Mockito.when(brokenStore.isAvailable()).thenReturn(true);
+		Mockito.when(brokenStore.isAccessible()).thenReturn(true);
 		Mockito.when(brokenStore.exists(Mockito.any())).thenThrow(new RuntimeException());
 		Mockito.when(brokenStore.getFileInputStream(Mockito.any())).thenThrow(new RuntimeException());
 		return brokenStore;

--- a/platform-core-module/src/test/java/com/softicar/platform/core/module/file/stored/content/StoredFileContentUploaderTest.java
+++ b/platform-core-module/src/test/java/com/softicar/platform/core/module/file/stored/content/StoredFileContentUploaderTest.java
@@ -51,7 +51,7 @@ public class StoredFileContentUploaderTest extends AbstractDbTest implements Cor
 	@SuppressWarnings("resource")
 	private void setupMocking() {
 
-		Mockito.when(store.isAvailable()).thenReturn(true);
+		Mockito.when(store.isAccessible()).thenReturn(true);
 		Mockito.when(store.getFreeDiskSpace()).thenReturn(Long.MAX_VALUE);
 		Mockito.when(store.getFileOutputStream(ArgumentMatchers.anyString())).thenReturn(output);
 		Mockito.when(database.createChunksOutputStream(storedFile)).thenReturn(output);
@@ -125,10 +125,10 @@ public class StoredFileContentUploaderTest extends AbstractDbTest implements Cor
 
 	@SuppressWarnings("resource")
 	@Test
-	public void usesDatabaseOutputStreamIfFileStoreNotAvailable() {
+	public void usesDatabaseOutputStreamIfFileStoreNotAccessible() {
 
 		setupPanicLogging();
-		Mockito.when(store.isAvailable()).thenReturn(false);
+		Mockito.when(store.isAccessible()).thenReturn(false);
 
 		upload();
 
@@ -137,10 +137,10 @@ public class StoredFileContentUploaderTest extends AbstractDbTest implements Cor
 	}
 
 	@Test
-	public void sendsPanicIfFileStoreNotAvailable() {
+	public void sendsPanicIfFileStoreNotAccessible() {
 
 		setupPanicLogging();
-		Mockito.when(store.isAvailable()).thenReturn(false);
+		Mockito.when(store.isAccessible()).thenReturn(false);
 
 		upload();
 
@@ -159,10 +159,10 @@ public class StoredFileContentUploaderTest extends AbstractDbTest implements Cor
 	}
 
 	@Test
-	public void doesNotSaveHashIfFileStoreNotAvailable() {
+	public void doesNotSaveHashIfFileStoreNotAccessible() {
 
 		setupPanicLogging();
-		Mockito.when(store.isAvailable()).thenReturn(false);
+		Mockito.when(store.isAccessible()).thenReturn(false);
 
 		upload();
 

--- a/platform-core-module/src/test/java/com/softicar/platform/core/module/file/stored/content/StoredFileContentUploaderTest.java
+++ b/platform-core-module/src/test/java/com/softicar/platform/core/module/file/stored/content/StoredFileContentUploaderTest.java
@@ -43,7 +43,7 @@ public class StoredFileContentUploaderTest extends AbstractDbTest implements Cor
 		this.database = Mockito.mock(IStoredFileDatabase.class);
 		this.store = Mockito.mock(IStoredFileContentStore.class);
 		this.storedFile = insertStoredFile(FILE_ID);
-		this.uploader = new StoredFileContentUploader(database, store, storedFile);
+		this.uploader = new StoredFileContentUploader(database, storedFile, store);
 
 		setupMocking();
 	}
@@ -51,8 +51,7 @@ public class StoredFileContentUploaderTest extends AbstractDbTest implements Cor
 	@SuppressWarnings("resource")
 	private void setupMocking() {
 
-		Mockito.when(store.isEnabled()).thenReturn(true);
-		Mockito.when(store.isReady()).thenReturn(true);
+		Mockito.when(store.isAvailable()).thenReturn(true);
 		Mockito.when(store.getFreeDiskSpace()).thenReturn(Long.MAX_VALUE);
 		Mockito.when(store.getFileOutputStream(ArgumentMatchers.anyString())).thenReturn(output);
 		Mockito.when(database.createChunksOutputStream(storedFile)).thenReturn(output);
@@ -129,7 +128,7 @@ public class StoredFileContentUploaderTest extends AbstractDbTest implements Cor
 	public void usesDatabaseOutputStreamIfFileStoreNotAvailable() {
 
 		setupPanicLogging();
-		Mockito.when(store.isReady()).thenReturn(false);
+		Mockito.when(store.isAvailable()).thenReturn(false);
 
 		upload();
 
@@ -137,33 +136,11 @@ public class StoredFileContentUploaderTest extends AbstractDbTest implements Cor
 		DbAssertUtils.assertOne(AGLogMessage.TABLE);
 	}
 
-	@SuppressWarnings("resource")
-	@Test
-	public void usesDatabaseOutputStreamIfFileStoreDisabled() {
-
-		Mockito.when(store.isEnabled()).thenReturn(false);
-
-		upload();
-
-		Mockito.verify(database).createChunksOutputStream(ArgumentMatchers.same(storedFile));
-	}
-
-	@Test
-	public void doesNotSendPanicIfFileStoreNotEnabled() {
-
-		setupPanicLogging();
-		Mockito.when(store.isEnabled()).thenReturn(false);
-
-		upload();
-
-		DbAssertUtils.assertNone(AGLogMessage.TABLE);
-	}
-
 	@Test
 	public void sendsPanicIfFileStoreNotAvailable() {
 
 		setupPanicLogging();
-		Mockito.when(store.isReady()).thenReturn(false);
+		Mockito.when(store.isAvailable()).thenReturn(false);
 
 		upload();
 
@@ -185,7 +162,7 @@ public class StoredFileContentUploaderTest extends AbstractDbTest implements Cor
 	public void doesNotSaveHashIfFileStoreNotAvailable() {
 
 		setupPanicLogging();
-		Mockito.when(store.isReady()).thenReturn(false);
+		Mockito.when(store.isAvailable()).thenReturn(false);
 
 		upload();
 

--- a/platform-core-module/src/test/java/com/softicar/platform/core/module/file/stored/content/StoredFileTestStore.java
+++ b/platform-core-module/src/test/java/com/softicar/platform/core/module/file/stored/content/StoredFileTestStore.java
@@ -29,13 +29,7 @@ class StoredFileTestStore implements IStoredFileContentStore {
 	}
 
 	@Override
-	public boolean isReady() {
-
-		return true;
-	}
-
-	@Override
-	public boolean isEnabled() {
+	public boolean isAvailable() {
 
 		return true;
 	}

--- a/platform-core-module/src/test/java/com/softicar/platform/core/module/file/stored/content/StoredFileTestStore.java
+++ b/platform-core-module/src/test/java/com/softicar/platform/core/module/file/stored/content/StoredFileTestStore.java
@@ -29,7 +29,7 @@ class StoredFileTestStore implements IStoredFileContentStore {
 	}
 
 	@Override
-	public boolean isAvailable() {
+	public boolean isAccessible() {
 
 		return true;
 	}

--- a/platform-core-module/src/test/java/com/softicar/platform/core/module/file/stored/content/store/StoredFileContentStoreFactoryTest.java
+++ b/platform-core-module/src/test/java/com/softicar/platform/core/module/file/stored/content/store/StoredFileContentStoreFactoryTest.java
@@ -1,0 +1,58 @@
+package com.softicar.platform.core.module.file.stored.content.store;
+
+import com.softicar.platform.core.module.file.stored.repository.AGStoredFileRepository;
+import com.softicar.platform.core.module.test.AbstractCoreTest;
+import java.util.Optional;
+import org.junit.Test;
+
+public class StoredFileContentStoreFactoryTest extends AbstractCoreTest {
+
+	private final StoredFileContentStoreFactory factory;
+
+	public StoredFileContentStoreFactoryTest() {
+
+		this.factory = new StoredFileContentStoreFactory();
+	}
+
+	@Test
+	public void testWithFileUrlAbsolute() {
+
+		var repository = insertRepository("file:///dir/subdir");
+		Optional<IStoredFileContentStore> store = factory.create(repository);
+		assertTrue(store.isPresent());
+		assertTrue(StoredFileFileSystemContentStore.class.isInstance(store.get()));
+	}
+
+	@Test
+	public void testWithFileUrlAbsoluteShort() {
+
+		var repository = insertRepository("file:/dir/subdir");
+		Optional<IStoredFileContentStore> store = factory.create(repository);
+		assertTrue(store.isPresent());
+		assertTrue(StoredFileFileSystemContentStore.class.isInstance(store.get()));
+	}
+
+	@Test
+	public void testWithFileUrlRelative() {
+
+		var repository = insertRepository("file://dir/subdir");
+		assertException(//
+			IllegalArgumentException.class,
+			"Expected an absolute path but encountered: 'dir/subdir'",
+			() -> factory.create(repository));
+	}
+
+	@Test
+	public void testWithSmbUrl() {
+
+		var repository = insertRepository("smb://host/share");
+		Optional<IStoredFileContentStore> store = factory.create(repository);
+		assertTrue(store.isPresent());
+		assertTrue(StoredFileSmbContentStore.class.isInstance(store.get()));
+	}
+
+	private AGStoredFileRepository insertRepository(String url) {
+
+		return new AGStoredFileRepository().setUrl(url).save();
+	}
+}

--- a/platform-core-module/src/test/java/com/softicar/platform/core/module/file/stored/content/store/StoredFileContentStoresTest.java
+++ b/platform-core-module/src/test/java/com/softicar/platform/core/module/file/stored/content/store/StoredFileContentStoresTest.java
@@ -23,72 +23,39 @@ public class StoredFileContentStoresTest extends AbstractCoreTest {
 	}
 
 	@Test
-	public void testGetAvailableContentStoresWithoutRepositories() {
+	public void testGetAccessibleContentStoresWithoutRepositories() {
 
-		var stores = StoredFileContentStores.getAvailableContentStores();
+		var stores = StoredFileContentStores.getAccessibleContentStores();
 		assertTrue(stores.isEmpty());
 	}
 
 	@Test
-	public void testGetAvailableContentStoresWithValidPrimaryRepository() {
+	public void testGetAccessibleContentStoresWithValidPrimaryRepository() {
 
 		insertValidPrimaryRepository(getDirectoryUrl(directory1));
-		var stores = StoredFileContentStores.getAvailableContentStores();
+		var stores = StoredFileContentStores.getAccessibleContentStores();
 		assertEquals(1, stores.size());
 		assertTrue(StoredFileFileSystemContentStore.class.isInstance(stores.iterator().next()));
 		assertEquals(directory1.getPath(), stores.iterator().next().getLocation());
 	}
 
 	@Test
-	public void testGetAvailableContentStoresWithInvalidPrimaryRepository() {
+	public void testGetAccessibleContentStoresWithInvalidPrimaryRepository() {
 
 		insertInvalidPrimaryRepository();
-		var stores = StoredFileContentStores.getAvailableContentStores();
+		var stores = StoredFileContentStores.getAccessibleContentStores();
 		assertTrue(stores.isEmpty());
 	}
 
 	@Test
-	public void testGetAvailableContentStoresWithMultipleRepositories() {
+	public void testGetAccessibleContentStoresWithMultipleRepositories() {
 
 		insertMultipleRepositories();
-		var stores = new ArrayList<>(StoredFileContentStores.getAvailableContentStores());
+		var stores = new ArrayList<>(StoredFileContentStores.getAccessibleContentStores());
 		assertEquals(3, stores.size());
 		assertEquals(directory2.getPath(), stores.get(0).getLocation());
 		assertEquals(directory1.getPath(), stores.get(1).getLocation());
 		assertEquals(directory3.getPath(), stores.get(2).getLocation());
-	}
-
-	@Test
-	public void testGetPreferredAvailableContentStoreWithoutRepositories() {
-
-		var store = StoredFileContentStores.getPreferredAvailableContentStore();
-		assertTrue(store.isEmpty());
-	}
-
-	@Test
-	public void testGetPreferredAvailableContentStoreWithValidPrimaryRepository() {
-
-		insertValidPrimaryRepository(getDirectoryUrl(directory1));
-		var store = StoredFileContentStores.getPreferredAvailableContentStore();
-		assertTrue(store.isPresent());
-		assertTrue(StoredFileFileSystemContentStore.class.isInstance(store.get()));
-		assertEquals(directory1.getPath(), store.get().getLocation());
-	}
-
-	@Test
-	public void testGetPreferredAvailableContentStoreWithInvalidPrimaryRepository() {
-
-		insertInvalidPrimaryRepository();
-		var store = StoredFileContentStores.getPreferredAvailableContentStore();
-		assertTrue(store.isEmpty());
-	}
-
-	@Test
-	public void testGetPreferredAvailableContentStoreWithMultipleRepositories() {
-
-		insertMultipleRepositories();
-		var store = StoredFileContentStores.getPreferredAvailableContentStore();
-		assertEquals(directory2.getPath(), store.get().getLocation());
 	}
 
 	@Test
@@ -142,16 +109,16 @@ public class StoredFileContentStoresTest extends AbstractCoreTest {
 
 	private void insertMultipleRepositories() {
 
-		// available secondary
+		// accessible secondary
 		insertRepository(getDirectoryUrl(directory1));
 
-		// unavailable secondary
+		// inaccessible secondary
 		insertRepository("file:///nonexistent");
 
-		// available primary
+		// accessible primary
 		makePrimary(insertRepository(getDirectoryUrl(directory2)));
 
-		// available secondary
+		// accessible secondary
 		insertRepository(getDirectoryUrl(directory3));
 	}
 

--- a/platform-core-module/src/test/java/com/softicar/platform/core/module/file/stored/content/store/StoredFileContentStoresTest.java
+++ b/platform-core-module/src/test/java/com/softicar/platform/core/module/file/stored/content/store/StoredFileContentStoresTest.java
@@ -1,0 +1,181 @@
+package com.softicar.platform.core.module.file.stored.content.store;
+
+import com.softicar.platform.core.module.AGCoreModuleInstance;
+import com.softicar.platform.core.module.file.stored.repository.AGStoredFileRepository;
+import com.softicar.platform.core.module.test.AbstractCoreTest;
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.util.ArrayList;
+import org.junit.Test;
+
+public class StoredFileContentStoresTest extends AbstractCoreTest {
+
+	private final File directory1;
+	private final File directory2;
+	private final File directory3;
+
+	public StoredFileContentStoresTest() {
+
+		this.directory1 = createTempDirectory();
+		this.directory2 = createTempDirectory();
+		this.directory3 = createTempDirectory();
+	}
+
+	@Test
+	public void testGetAvailableContentStoresWithoutRepositories() {
+
+		var stores = StoredFileContentStores.getAvailableContentStores();
+		assertTrue(stores.isEmpty());
+	}
+
+	@Test
+	public void testGetAvailableContentStoresWithValidPrimaryRepository() {
+
+		insertValidPrimaryRepository(getDirectoryUrl(directory1));
+		var stores = StoredFileContentStores.getAvailableContentStores();
+		assertEquals(1, stores.size());
+		assertTrue(StoredFileFileSystemContentStore.class.isInstance(stores.iterator().next()));
+		assertEquals(directory1.getPath(), stores.iterator().next().getLocation());
+	}
+
+	@Test
+	public void testGetAvailableContentStoresWithInvalidPrimaryRepository() {
+
+		insertInvalidPrimaryRepository();
+		var stores = StoredFileContentStores.getAvailableContentStores();
+		assertTrue(stores.isEmpty());
+	}
+
+	@Test
+	public void testGetAvailableContentStoresWithMultipleRepositories() {
+
+		insertMultipleRepositories();
+		var stores = new ArrayList<>(StoredFileContentStores.getAvailableContentStores());
+		assertEquals(3, stores.size());
+		assertEquals(directory2.getPath(), stores.get(0).getLocation());
+		assertEquals(directory1.getPath(), stores.get(1).getLocation());
+		assertEquals(directory3.getPath(), stores.get(2).getLocation());
+	}
+
+	@Test
+	public void testGetPreferredAvailableContentStoreWithoutRepositories() {
+
+		var store = StoredFileContentStores.getPreferredAvailableContentStore();
+		assertTrue(store.isEmpty());
+	}
+
+	@Test
+	public void testGetPreferredAvailableContentStoreWithValidPrimaryRepository() {
+
+		insertValidPrimaryRepository(getDirectoryUrl(directory1));
+		var store = StoredFileContentStores.getPreferredAvailableContentStore();
+		assertTrue(store.isPresent());
+		assertTrue(StoredFileFileSystemContentStore.class.isInstance(store.get()));
+		assertEquals(directory1.getPath(), store.get().getLocation());
+	}
+
+	@Test
+	public void testGetPreferredAvailableContentStoreWithInvalidPrimaryRepository() {
+
+		insertInvalidPrimaryRepository();
+		var store = StoredFileContentStores.getPreferredAvailableContentStore();
+		assertTrue(store.isEmpty());
+	}
+
+	@Test
+	public void testGetPreferredAvailableContentStoreWithMultipleRepositories() {
+
+		insertMultipleRepositories();
+		var store = StoredFileContentStores.getPreferredAvailableContentStore();
+		assertEquals(directory2.getPath(), store.get().getLocation());
+	}
+
+	@Test
+	public void testGetPrimaryContentStore() {
+
+		insertMultipleRepositories();
+		var store = StoredFileContentStores.getPrimaryContentStore();
+		assertTrue(store.isPresent());
+		assertTrue(StoredFileFileSystemContentStore.class.isInstance(store.get()));
+		assertEquals(directory2.getPath(), store.get().getLocation());
+	}
+
+	@Test
+	public void testGetPrimaryContentStoreWithInactivePrimary() {
+
+		insertInactivePrimaryRepository(getDirectoryUrl(directory2));
+		var store = StoredFileContentStores.getPrimaryContentStore();
+		assertTrue(store.isEmpty());
+	}
+
+	@Test
+	public void testGetPrimaryContentStoreWithUndefinedPrimary() {
+
+		var store = StoredFileContentStores.getPrimaryContentStore();
+		assertTrue(store.isEmpty());
+	}
+
+	private void insertValidPrimaryRepository(String url) {
+
+		makePrimary(insertRepository(url));
+	}
+
+	private void insertInactivePrimaryRepository(String url) {
+
+		var repository = insertRepository(url);
+		repository.setActive(false).save();
+		makePrimary(repository);
+	}
+
+	private AGStoredFileRepository insertRepository(String url) {
+
+		return new AGStoredFileRepository()//
+			.setUrl(url)
+			.save();
+	}
+
+	private void insertInvalidPrimaryRepository() {
+
+		makePrimary(insertRepository("file:///nonexistent"));
+	}
+
+	private void insertMultipleRepositories() {
+
+		// available secondary
+		insertRepository(getDirectoryUrl(directory1));
+
+		// unavailable secondary
+		insertRepository("file:///nonexistent");
+
+		// available primary
+		makePrimary(insertRepository(getDirectoryUrl(directory2)));
+
+		// available secondary
+		insertRepository(getDirectoryUrl(directory3));
+	}
+
+	private void makePrimary(AGStoredFileRepository repository) {
+
+		AGCoreModuleInstance//
+			.getInstance()
+			.setPrimaryFileRepository(repository)
+			.save();
+	}
+
+	private String getDirectoryUrl(File directory) {
+
+		return "file://" + directory.getPath();
+	}
+
+	private File createTempDirectory() {
+
+		try {
+			File directory = Files.createTempDirectory(getClass().getSimpleName()).toFile();
+			directory.deleteOnExit();
+			return directory;
+		} catch (IOException exception) {
+			throw new RuntimeException(exception);
+		}
+	}
+}

--- a/platform-core-module/src/test/java/com/softicar/platform/core/module/file/stored/content/store/StoredFileFileSystemContentStoreTest.java
+++ b/platform-core-module/src/test/java/com/softicar/platform/core/module/file/stored/content/store/StoredFileFileSystemContentStoreTest.java
@@ -57,25 +57,25 @@ public class StoredFileFileSystemContentStoreTest extends Asserts {
 	}
 
 	@Test
-	public void testIsAvailable() {
+	public void testIsAccessible() {
 
 		var store = createStore();
-		assertTrue(store.isAvailable());
+		assertTrue(store.isAccessible());
 	}
 
 	@Test
-	public void testIsAvailableWithNonexistentDirectory() {
+	public void testIsAccessibleWithNonexistentDirectory() {
 
 		var store = createStore("/nowhere");
-		assertFalse(store.isAvailable());
+		assertFalse(store.isAccessible());
 	}
 
 	@Test
-	public void testIsAvailableWithFileInsteadOfDirectory() {
+	public void testIsAccessibleWithFileInsteadOfDirectory() {
 
 		var file = createTempFile();
 		var store = createStore(file.getPath());
-		assertFalse(store.isAvailable());
+		assertFalse(store.isAccessible());
 	}
 
 	@Test

--- a/platform-core-module/src/test/java/com/softicar/platform/core/module/file/stored/content/store/StoredFileFileSystemContentStoreTest.java
+++ b/platform-core-module/src/test/java/com/softicar/platform/core/module/file/stored/content/store/StoredFileFileSystemContentStoreTest.java
@@ -1,6 +1,7 @@
 package com.softicar.platform.core.module.file.stored.content.store;
 
 import com.softicar.platform.common.core.exceptions.SofticarIOException;
+import com.softicar.platform.common.core.utils.DevNull;
 import com.softicar.platform.common.date.DayTime;
 import com.softicar.platform.common.testing.Asserts;
 import java.io.File;
@@ -35,6 +36,12 @@ public class StoredFileFileSystemContentStoreTest extends Asserts {
 		FileUtils.deleteDirectory(storeRootDirectory);
 	}
 
+	@Test(expected = IllegalArgumentException.class)
+	public void testConstructorWithRelativePath() {
+
+		DevNull.swallow(new StoredFileFileSystemContentStore("foo/bar"));
+	}
+
 	@Test
 	public void testGetLocation() {
 
@@ -45,37 +52,30 @@ public class StoredFileFileSystemContentStoreTest extends Asserts {
 	@Test
 	public void testGetLocationWithNonexistentDirectory() {
 
-		var store = createStore(new File("/nowhere"));
+		var store = createStore("/nowhere");
 		assertEquals("/nowhere", store.getLocation());
 	}
 
 	@Test
-	public void testIsEnabled() {
+	public void testIsAvailable() {
 
 		var store = createStore();
-		assertTrue(store.isEnabled());
+		assertTrue(store.isAvailable());
 	}
 
 	@Test
-	public void testIsReady() {
+	public void testIsAvailableWithNonexistentDirectory() {
 
-		var store = createStore();
-		assertTrue(store.isReady());
+		var store = createStore("/nowhere");
+		assertFalse(store.isAvailable());
 	}
 
 	@Test
-	public void testIsReadyWithNonexistentDirectory() {
-
-		var store = createStore(new File("/nowhere"));
-		assertFalse(store.isReady());
-	}
-
-	@Test
-	public void testIsReadyWithFileInsteadOfDirectory() {
+	public void testIsAvailableWithFileInsteadOfDirectory() {
 
 		var file = createTempFile();
-		var store = createStore(file);
-		assertFalse(store.isReady());
+		var store = createStore(file.getPath());
+		assertFalse(store.isAvailable());
 	}
 
 	@Test
@@ -90,6 +90,14 @@ public class StoredFileFileSystemContentStoreTest extends Asserts {
 
 		var store = createStore();
 		store.createDirectories("foo");
+		assertTrue(storeRootPath.resolve("foo").toFile().isDirectory());
+	}
+
+	@Test
+	public void testCreateDirectoriesInStoreRootWithLeadingSlash() {
+
+		var store = createStore();
+		store.createDirectories("/foo");
 		assertTrue(storeRootPath.resolve("foo").toFile().isDirectory());
 	}
 
@@ -477,12 +485,12 @@ public class StoredFileFileSystemContentStoreTest extends Asserts {
 
 	private StoredFileFileSystemContentStore createStore() {
 
-		return createStore(storeRootDirectory);
+		return createStore(storeRootDirectory.getPath());
 	}
 
-	private StoredFileFileSystemContentStore createStore(File directory) {
+	private StoredFileFileSystemContentStore createStore(String absolutePath) {
 
-		return new StoredFileFileSystemContentStore(directory);
+		return new StoredFileFileSystemContentStore(absolutePath);
 	}
 
 	private File createTempFile() {

--- a/platform-dom/src/main/java/com/softicar/platform/dom/DomCssClasses.java
+++ b/platform-dom/src/main/java/com/softicar/platform/dom/DomCssClasses.java
@@ -112,6 +112,7 @@ public interface DomCssClasses {
 	ICssClass DOM_VERTICAL_TEXT_BOX = new CssClass("DomVerticalTextBox", DomCssFiles.DOM_VERTICAL_TEXT_BOX_STYLE);
 
 	ICssClass DOM_WIKI_HEADLINE = new CssClass("DomWikiHeadline", DomCssFiles.DOM_WIKI_ELEMENTS_STYLE);
+	ICssClass DOM_WIKI_LIST = new CssClass("DomWikiList", DomCssFiles.DOM_WIKI_ELEMENTS_STYLE);
 	ICssClass DOM_WIKI_MONOSPACE = new CssClass("DomWikiMonospace", DomCssFiles.DOM_WIKI_ELEMENTS_STYLE);
 	ICssClass DOM_WIKI_RAW_TEXT = new CssClass("DomWikiRawText", DomCssFiles.DOM_WIKI_ELEMENTS_STYLE);
 	ICssClass DOM_WIKI_RAW_TEXT_CODE = new CssClass("DomWikiRawTextCode", DomCssFiles.DOM_WIKI_ELEMENTS_STYLE);

--- a/platform-dom/src/main/java/com/softicar/platform/dom/elements/wiki/DomWikiDivBuilder.java
+++ b/platform-dom/src/main/java/com/softicar/platform/dom/elements/wiki/DomWikiDivBuilder.java
@@ -36,6 +36,8 @@ import com.softicar.platform.dom.elements.DomRow;
 import com.softicar.platform.dom.elements.DomTable;
 import com.softicar.platform.dom.elements.wiki.box.DomWikiBox;
 import com.softicar.platform.dom.parent.IDomParentElement;
+import com.softicar.platform.dom.style.ICssClass;
+import java.util.Arrays;
 import java.util.Map;
 import java.util.Stack;
 import java.util.TreeMap;
@@ -147,7 +149,7 @@ public class DomWikiDivBuilder implements IWikiBuilderMethods<DomWikiDivBuilder>
 		public void visit(WikiList list) {
 
 			DomElementTag tag = list.getListType() == WikiListType.ORDERED? DomElementTag.OL : DomElementTag.UL;
-			appendElementAndChildren(tag, list);
+			appendElementAndChildren(tag, list, DomCssClasses.DOM_WIKI_LIST);
 		}
 
 		@Override
@@ -242,9 +244,11 @@ public class DomWikiDivBuilder implements IWikiBuilderMethods<DomWikiDivBuilder>
 			appendElement(anchor);
 		}
 
-		private void appendElementAndChildren(DomElementTag elementTag, IWikiParentElement wikiElement) {
+		private void appendElementAndChildren(DomElementTag elementTag, IWikiParentElement wikiElement, ICssClass...cssClasses) {
 
-			appendElementAndChildren(new DomSimpleElement(elementTag), wikiElement);
+			var element = new DomSimpleElement(elementTag);
+			Arrays.asList(cssClasses).forEach(element::addCssClass);
+			appendElementAndChildren(element, wikiElement);
 		}
 
 		private void appendElementAndChildren(IDomParentElement domElement, IWikiParentElement wikiElement) {

--- a/platform-dom/src/main/resources/com/softicar/platform/dom/dom-wiki-elements-style.css
+++ b/platform-dom/src/main/resources/com/softicar/platform/dom/dom-wiki-elements-style.css
@@ -4,12 +4,16 @@ h6.DomWikiHeadline {
 	border-bottom: 1px solid var(--LABEL_BORDER_COLOR);
 }
 
+.DomWikiList {
+	margin-top: 0;
+}
+
 .DomWikiMonospace {
 	display: inline;
 	color: #880000;
 	background-color: #f0f0f0;
 	border-radius: var(--BORDER_RADIUS);
-	box-sahdow: 0 0 0 1px #cccccc inset;
+	box-shadow: 0 0 0 1px #cccccc inset;
 	padding: 0 5px;
 	font-family: monospace;
 }

--- a/platform-integration/src/main/resources/com/softicar/platform/integration/database/structure/version/v40-migration.sql
+++ b/platform-integration/src/main/resources/com/softicar/platform/integration/database/structure/version/v40-migration.sql
@@ -30,3 +30,11 @@ ALTER TABLE `Core`.`CoreModuleInstanceLog`
 	ADD KEY `primaryFileRepository` (`primaryFileRepository`),
 	ADD CONSTRAINT `CoreModuleInstanceLog_ibfk_4` FOREIGN KEY (`primaryFileRepository`) REFERENCES `Core`.`StoredFileRepository` (`id`)
 ;
+
+-- PLAT-1331-3
+
+ALTER TABLE `Core`.`StoredFileRepository`
+	CHANGE COLUMN `domain` `domain` VARCHAR(255) NOT NULL DEFAULT '',
+	CHANGE COLUMN `username` `username` VARCHAR(255) NOT NULL DEFAULT '',
+	CHANGE COLUMN `password` `password` VARCHAR(255) NOT NULL DEFAULT ''
+;

--- a/platform-integration/src/main/resources/com/softicar/platform/integration/database/structure/version/v40-structure.json
+++ b/platform-integration/src/main/resources/com/softicar/platform/integration/database/structure/version/v40-structure.json
@@ -185,7 +185,7 @@
   },
   {
     "tableName": "`Core`.`StoredFileRepository`",
-    "createStatement": "CREATE TABLE `Core`.`StoredFileRepository` (`id` INT NOT NULL AUTO_INCREMENT,`active` BOOL NOT NULL DEFAULT '1',`url` VARCHAR(255) NOT NULL,`domain` VARCHAR(255) NOT NULL,`username` VARCHAR(255) NOT NULL,`password` VARCHAR(255) NOT NULL,PRIMARY KEY (`id`));"
+    "createStatement": "CREATE TABLE `Core`.`StoredFileRepository` (`id` INT NOT NULL AUTO_INCREMENT,`active` BOOL NOT NULL DEFAULT '1',`url` VARCHAR(255) NOT NULL,`domain` VARCHAR(255) NOT NULL DEFAULT '',`username` VARCHAR(255) NOT NULL DEFAULT '',`password` VARCHAR(255) NOT NULL DEFAULT '',PRIMARY KEY (`id`));"
   },
   {
     "tableName": "`Core`.`StoredFileSetItem`",


### PR DESCRIPTION
- Stored Files can now be saved to either SMB shares or local file system directories.
  - An appropriate `IStoredFileContentStore` implementation is chosen according to the protocol part of the repository URL, as defined in `Core`.`StoredFileRepository`.
  - e.g. `StoredFileSmbContentStore` will be used for URLs like `smb://host/share`
  - e.g. `StoredFileFileSystemContentStore` will be used for URLs like `file:///dir/subdir`
- Established `StoredFileContentStores` as a central place to retrieve (SMB-based or file-system-based) `IStoredFileContentStore` instances.
  - This puts an end to seemingly-random calls to file store implementation constructors throughout the code base.
- `IStoredFileContentStore`: merged `isEnabled`, `isReady` and `isAvailable` to just one method, `isAvailable`.
  - All existing implementations of `isEnabled` were either trivial or nonsensically-arbitrary.
- `StoredFileContentInputStreamCreator` now checks whether a file store is available before trying to access it.
