### PR TITLE
EXP-2818 Remove EmfForm-directEditing nuances

### DIFF
--- a/platform-emf/src/main/java/com/softicar/platform/emf/form/EmfFormBody.java
+++ b/platform-emf/src/main/java/com/softicar/platform/emf/form/EmfFormBody.java
@@ -95,7 +95,7 @@ class EmfFormBody<R extends IEmfTableRow<R, ?>> extends DomDiv implements IEmfFo
 	public void cancelEditMode() {
 
 		if (upperPart.isEditMode()) {
-			if (creationMode) {
+			if (form.isDirectEditingEnabled() || creationMode) {
 				form.closeFrame();
 			} else {
 				enterViewMode();

--- a/platform-emf/src/main/java/com/softicar/platform/emf/form/EmfFormBody.java
+++ b/platform-emf/src/main/java/com/softicar/platform/emf/form/EmfFormBody.java
@@ -95,7 +95,7 @@ class EmfFormBody<R extends IEmfTableRow<R, ?>> extends DomDiv implements IEmfFo
 	public void cancelEditMode() {
 
 		if (upperPart.isEditMode()) {
-			if (form.isDirectEditingEnabled() || creationMode) {
+			if (creationMode) {
 				form.closeFrame();
 			} else {
 				enterViewMode();

--- a/platform-emf/src/main/java/com/softicar/platform/emf/form/EmfFormSaveOrCancelActionsInput.java
+++ b/platform-emf/src/main/java/com/softicar/platform/emf/form/EmfFormSaveOrCancelActionsInput.java
@@ -25,15 +25,13 @@ class EmfFormSaveOrCancelActionsInput<R extends IEmfTableRow<R, ?>> extends DomD
 
 		addCssClass(EmfCssClasses.EMF_FORM_SAVE_OR_CANCEL_ACTIONS_INPUT);
 
-		if (!formBody.getForm().isDirectEditingEnabled()) {
-			buttonContainer
-				.appendChild(
-					new DomButton()//
-						.setIcon(EmfImages.ENTITY_SAVE.getResource())
-						.setLabel(EmfI18n.SAVE)
-						.addMarker(EmfTestMarker.FORM_SAVE)
-						.setClickCallback(() -> save(false)));
-		}
+		buttonContainer
+			.appendChild(
+				new DomButton()//
+					.setIcon(EmfImages.ENTITY_SAVE.getResource())
+					.setLabel(EmfI18n.SAVE)
+					.addMarker(EmfTestMarker.FORM_SAVE)
+					.setClickCallback(() -> save(false)));
 		buttonContainer
 			.appendChild(
 				new DomButton()//


### PR DESCRIPTION
When using the Edit-Management-Action, the EmfFormPopup behaved slightly different
  - There was no Save-Button, only Save & Close
  
  Added the normal save button to direct editing mode