### PR TITLE
EXP-2827 Worfklow: Make finalized versions editable

### DIFF
--- a/platform-workflow-module/src/main/java/com/softicar/platform/workflow/module/workflow/WorkflowPredicates.java
+++ b/platform-workflow-module/src/main/java/com/softicar/platform/workflow/module/workflow/WorkflowPredicates.java
@@ -11,9 +11,6 @@ public interface WorkflowPredicates {
 		WorkflowI18n.DRAFT,
 		AGWorkflowVersion::isDraft);
 
-	// FIXME strange, not-draft implies finalized?
-	IEmfPredicate<AGWorkflowVersion> WORKFLOW_VERSION_FINALIZED = WORKFLOW_VERSION_DRAFT.not();
-
 	IEmfPredicate<AGWorkflow> WORKFLOW_VERSION_PRESENT = new EmfPredicate<>(//
 		WorkflowI18n.WORKFLOW_VERSION_PRESENT,
 		it -> !it.getWorkflowVersions().isEmpty());

--- a/platform-workflow-module/src/main/java/com/softicar/platform/workflow/module/workflow/management/WorkflowVersionManagementDiv.java
+++ b/platform-workflow-module/src/main/java/com/softicar/platform/workflow/module/workflow/management/WorkflowVersionManagementDiv.java
@@ -15,7 +15,6 @@ import com.softicar.platform.emf.object.table.IEmfObjectTable;
 import com.softicar.platform.workflow.module.WorkflowCssClasses;
 import com.softicar.platform.workflow.module.WorkflowI18n;
 import com.softicar.platform.workflow.module.WorkflowPermissions;
-import com.softicar.platform.workflow.module.workflow.WorkflowPredicates;
 import com.softicar.platform.workflow.module.workflow.management.display.element.AbstractDisplayElement;
 import com.softicar.platform.workflow.module.workflow.management.display.element.WorkflowEndCircleDisplayElement;
 import com.softicar.platform.workflow.module.workflow.management.display.element.WorkflowNodeDisplayElement;
@@ -47,8 +46,7 @@ public class WorkflowVersionManagementDiv extends DomDiv {
 	private void repaint() {
 
 		removeChildren();
-		if (!WorkflowPredicates.WORKFLOW_VERSION_FINALIZED.test(workflowVersion)
-				&& WorkflowPermissions.ADMINISTRATION.test(workflowVersion.getWorkflow().getModuleInstance(), CurrentBasicUser.get())) {
+		if (WorkflowPermissions.ADMINISTRATION.test(workflowVersion.getWorkflow().getModuleInstance(), CurrentBasicUser.get())) {
 			var actionBar = appendChild(new DomActionBar());
 			actionBar.appendChild(new CreateEntityButton<>(AGWorkflowNode.TABLE, WorkflowI18n.ADD_NEW_NODE));
 			actionBar.appendChild(new CreateEntityButton<>(AGWorkflowTransition.TABLE, WorkflowI18n.ADD_NEW_TRANSITION));

--- a/platform-workflow-module/src/main/java/com/softicar/platform/workflow/module/workflow/node/AGWorkflowNodeTable.java
+++ b/platform-workflow-module/src/main/java/com/softicar/platform/workflow/module/workflow/node/AGWorkflowNodeTable.java
@@ -11,7 +11,6 @@ import com.softicar.platform.emf.table.configuration.EmfTableConfiguration;
 import com.softicar.platform.workflow.module.WorkflowI18n;
 import com.softicar.platform.workflow.module.WorkflowImages;
 import com.softicar.platform.workflow.module.WorkflowPermissions;
-import com.softicar.platform.workflow.module.workflow.WorkflowPredicates;
 import com.softicar.platform.workflow.module.workflow.node.action.AGWorkflowNodeAction;
 import com.softicar.platform.workflow.module.workflow.node.precondition.AGWorkflowNodePrecondition;
 import com.softicar.platform.workflow.module.workflow.version.AGWorkflowVersion;
@@ -52,9 +51,6 @@ public class AGWorkflowNodeTable extends EmfObjectTable<AGWorkflowNode, AGWorkfl
 		attributes//
 			.editAttribute(AGWorkflowNode.Y_COORDINATE)
 			.setPredicateMandatory(EmfPredicates.always());
-		attributes//
-			.editAttribute(AGWorkflowNode.ACTIVE)
-			.setPredicateEditable(WorkflowPredicates.WORKFLOW_VERSION_DRAFT.of(AGWorkflowNode.WORKFLOW_VERSION));
 	}
 
 	@Override

--- a/platform-workflow-module/src/main/java/com/softicar/platform/workflow/module/workflow/node/AGWorkflowNodeTable.java
+++ b/platform-workflow-module/src/main/java/com/softicar/platform/workflow/module/workflow/node/AGWorkflowNodeTable.java
@@ -36,8 +36,6 @@ public class AGWorkflowNodeTable extends EmfObjectTable<AGWorkflowNode, AGWorkfl
 	public void customizeEmfTableConfiguration(EmfTableConfiguration<AGWorkflowNode, Integer, AGWorkflowVersion> configuration) {
 
 		configuration.setScopeField(AGWorkflowNode.WORKFLOW_VERSION);
-		configuration.setCreationPredicate(WorkflowPredicates.WORKFLOW_VERSION_FINALIZED.not());
-		configuration.setEditPredicate(WorkflowPredicates.WORKFLOW_VERSION_FINALIZED.of(AGWorkflowNode.WORKFLOW_VERSION).not());
 		configuration.addValidator(WorkflowNodeValidator::new);
 		configuration.setIcon(WorkflowImages.WORKFLOW_NODE);
 	}
@@ -56,7 +54,7 @@ public class AGWorkflowNodeTable extends EmfObjectTable<AGWorkflowNode, AGWorkfl
 			.setPredicateMandatory(EmfPredicates.always());
 		attributes//
 			.editAttribute(AGWorkflowNode.ACTIVE)
-			.setPredicateEditable(WorkflowPredicates.WORKFLOW_VERSION_FINALIZED.of(AGWorkflowNode.WORKFLOW_VERSION).not());
+			.setPredicateEditable(WorkflowPredicates.WORKFLOW_VERSION_DRAFT.of(AGWorkflowNode.WORKFLOW_VERSION));
 	}
 
 	@Override

--- a/platform-workflow-module/src/main/java/com/softicar/platform/workflow/module/workflow/node/action/AGWorkflowNodeActionTable.java
+++ b/platform-workflow-module/src/main/java/com/softicar/platform/workflow/module/workflow/node/action/AGWorkflowNodeActionTable.java
@@ -12,7 +12,6 @@ import com.softicar.platform.emf.predicate.EmfPredicates;
 import com.softicar.platform.emf.table.configuration.EmfTableConfiguration;
 import com.softicar.platform.workflow.module.WorkflowI18n;
 import com.softicar.platform.workflow.module.WorkflowPermissions;
-import com.softicar.platform.workflow.module.workflow.WorkflowPredicates;
 import com.softicar.platform.workflow.module.workflow.node.AGWorkflowNode;
 import com.softicar.platform.workflow.module.workflow.node.action.permission.AGWorkflowNodeActionPermission;
 
@@ -50,17 +49,6 @@ public class AGWorkflowNodeActionTable extends EmfObjectTable<AGWorkflowNodeActi
 	public void customizeEmfTableConfiguration(EmfTableConfiguration<AGWorkflowNodeAction, Integer, AGWorkflowNode> configuration) {
 
 		configuration.setScopeField(AGWorkflowNodeAction.WORKFLOW_NODE);
-		configuration
-			.setCreationPredicate(
-				WorkflowPredicates.WORKFLOW_VERSION_FINALIZED
-					.not()
-					.of(IEmfTableRowMapper.nonOptional(WorkflowI18n.WORKFLOW_VERSION, AGWorkflowNode::getWorkflowVersion)));
-		configuration
-			.setEditPredicate(
-				WorkflowPredicates.WORKFLOW_VERSION_FINALIZED
-					.not()
-					.of(IEmfTableRowMapper.nonOptional(WorkflowI18n.WORKFLOW_VERSION, it -> it.getWorkflowNode().getWorkflowVersion())));
-
 		configuration.addValidator(WorkflowNodeActionValidator::new);
 	}
 

--- a/platform-workflow-module/src/main/java/com/softicar/platform/workflow/module/workflow/node/precondition/AGWorkflowNodePreconditionTable.java
+++ b/platform-workflow-module/src/main/java/com/softicar/platform/workflow/module/workflow/node/precondition/AGWorkflowNodePreconditionTable.java
@@ -11,7 +11,6 @@ import com.softicar.platform.emf.predicate.EmfPredicates;
 import com.softicar.platform.emf.table.configuration.EmfTableConfiguration;
 import com.softicar.platform.workflow.module.WorkflowI18n;
 import com.softicar.platform.workflow.module.WorkflowPermissions;
-import com.softicar.platform.workflow.module.workflow.WorkflowPredicates;
 import com.softicar.platform.workflow.module.workflow.node.AGWorkflowNode;
 
 public class AGWorkflowNodePreconditionTable extends EmfObjectTable<AGWorkflowNodePrecondition, AGWorkflowNode> {
@@ -48,17 +47,6 @@ public class AGWorkflowNodePreconditionTable extends EmfObjectTable<AGWorkflowNo
 	public void customizeEmfTableConfiguration(EmfTableConfiguration<AGWorkflowNodePrecondition, Integer, AGWorkflowNode> configuration) {
 
 		configuration.setScopeField(AGWorkflowNodePrecondition.WORKFLOW_NODE);
-		configuration
-			.setCreationPredicate(
-				WorkflowPredicates.WORKFLOW_VERSION_FINALIZED
-					.not()
-					.of(IEmfTableRowMapper.nonOptional(WorkflowI18n.WORKFLOW_VERSION, AGWorkflowNode::getWorkflowVersion)));
-		configuration
-			.setEditPredicate(
-				WorkflowPredicates.WORKFLOW_VERSION_FINALIZED
-					.not()
-					.of(IEmfTableRowMapper.nonOptional(WorkflowI18n.WORKFLOW_VERSION, it -> it.getWorkflowNode().getWorkflowVersion())));
-
 		configuration.addValidator(WorkflowNodePreconditionValidator::new);
 	}
 

--- a/platform-workflow-module/src/main/java/com/softicar/platform/workflow/module/workflow/transition/AGWorkflowTransitionTable.java
+++ b/platform-workflow-module/src/main/java/com/softicar/platform/workflow/module/workflow/transition/AGWorkflowTransitionTable.java
@@ -12,7 +12,6 @@ import com.softicar.platform.emf.table.configuration.EmfTableConfiguration;
 import com.softicar.platform.workflow.module.WorkflowI18n;
 import com.softicar.platform.workflow.module.WorkflowImages;
 import com.softicar.platform.workflow.module.WorkflowPermissions;
-import com.softicar.platform.workflow.module.workflow.WorkflowPredicates;
 import com.softicar.platform.workflow.module.workflow.image.AGWorkflowIcon;
 import com.softicar.platform.workflow.module.workflow.transition.permission.AGWorkflowTransitionPermission;
 import com.softicar.platform.workflow.module.workflow.transition.side.effect.WorkflowTransitionSideEffects;
@@ -46,8 +45,6 @@ public class AGWorkflowTransitionTable extends EmfObjectTable<AGWorkflowTransiti
 	public void customizeEmfTableConfiguration(EmfTableConfiguration<AGWorkflowTransition, Integer, AGWorkflowVersion> configuration) {
 
 		configuration.setScopeField(AGWorkflowTransition.WORKFLOW_VERSION);
-		configuration.setCreationPredicate(WorkflowPredicates.WORKFLOW_VERSION_FINALIZED.not());
-		configuration.setEditPredicate(WorkflowPredicates.WORKFLOW_VERSION_FINALIZED.of(AGWorkflowTransition.WORKFLOW_VERSION).not());
 		configuration.addValidator(WorkflowTransitionValidator::new);
 		configuration.setIcon(WorkflowImages.WORKFLOW_TRANSITION);
 	}

--- a/platform-workflow-module/src/main/java/com/softicar/platform/workflow/module/workflow/transition/permission/AGWorkflowTransitionPermissionTable.java
+++ b/platform-workflow-module/src/main/java/com/softicar/platform/workflow/module/workflow/transition/permission/AGWorkflowTransitionPermissionTable.java
@@ -15,7 +15,6 @@ import com.softicar.platform.emf.predicate.EmfPredicates;
 import com.softicar.platform.emf.table.configuration.EmfTableConfiguration;
 import com.softicar.platform.workflow.module.WorkflowI18n;
 import com.softicar.platform.workflow.module.WorkflowPermissions;
-import com.softicar.platform.workflow.module.workflow.WorkflowPredicates;
 import com.softicar.platform.workflow.module.workflow.transition.AGWorkflowTransition;
 import com.softicar.platform.workflow.module.workflow.transition.WorkflowTransitionPredicates;
 import java.util.Collection;
@@ -55,17 +54,7 @@ public class AGWorkflowTransitionPermissionTable extends EmfObjectTable<AGWorkfl
 	public void customizeEmfTableConfiguration(EmfTableConfiguration<AGWorkflowTransitionPermission, Integer, AGWorkflowTransition> configuration) {
 
 		configuration.setScopeField(AGWorkflowTransitionPermission.TRANSITION);
-		//TODO .not() wouldn't work on predicate WORKFLOW_VERSION_FINALIZED, because it then returns predicate of type object when using a IEmfTableRowMapper
-		configuration
-			.setEditPredicate(
-				WorkflowPredicates.WORKFLOW_VERSION_DRAFT
-					.of(IEmfTableRowMapper.nonOptional(WorkflowI18n.WORKFLOW_VERSION, it -> it.getTransition().getWorkflowVersion())));
-		configuration//
-			.setCreationPredicate(
-				WorkflowPredicates.WORKFLOW_VERSION_FINALIZED
-					.of(AGWorkflowTransition.WORKFLOW_VERSION)
-					.not()
-					.and(WorkflowTransitionPredicates.AUTO_TRANSITION.not()));
+		configuration.setCreationPredicate(WorkflowTransitionPredicates.AUTO_TRANSITION.not());
 	}
 
 	@Override

--- a/platform-workflow-module/src/main/java/com/softicar/platform/workflow/module/workflow/version/AGWorkflowVersionTable.java
+++ b/platform-workflow-module/src/main/java/com/softicar/platform/workflow/module/workflow/version/AGWorkflowVersionTable.java
@@ -59,7 +59,6 @@ public class AGWorkflowVersionTable extends EmfObjectTable<AGWorkflowVersion, AG
 
 		configuration.setScopeField(AGWorkflowVersion.WORKFLOW);
 		configuration.setCreationPredicate(WorkflowPredicates.WORKFLOW_VERSION_PRESENT.not());
-		configuration.setEditPredicate(WorkflowPredicates.WORKFLOW_VERSION_FINALIZED.not());
 		configuration.setIcon(WorkflowImages.WORKFLOW);
 		configuration.addCommitHook(WorkflowVersionCommitHook::new);
 	}

--- a/platform-workflow-module/src/main/java/com/softicar/platform/workflow/module/workflow/version/AGWorkflowVersionTable.java
+++ b/platform-workflow-module/src/main/java/com/softicar/platform/workflow/module/workflow/version/AGWorkflowVersionTable.java
@@ -74,6 +74,9 @@ public class AGWorkflowVersionTable extends EmfObjectTable<AGWorkflowVersion, AG
 		attributes//
 			.editAttribute(AGWorkflowVersion.DRAFT)
 			.setPredicateEditable(EmfPredicates.never());
+		attributes//
+			.editAttribute(AGWorkflowVersion.ROOT_NODE)
+			.setPredicateEditable(WorkflowPredicates.WORKFLOW_VERSION_DRAFT);
 	}
 
 	@Override

--- a/platform-workflow-module/src/main/java/com/softicar/platform/workflow/module/workflow/version/AGWorkflowVersionTable.java
+++ b/platform-workflow-module/src/main/java/com/softicar/platform/workflow/module/workflow/version/AGWorkflowVersionTable.java
@@ -74,9 +74,6 @@ public class AGWorkflowVersionTable extends EmfObjectTable<AGWorkflowVersion, AG
 		attributes//
 			.editAttribute(AGWorkflowVersion.DRAFT)
 			.setPredicateEditable(EmfPredicates.never());
-		attributes//
-			.editAttribute(AGWorkflowVersion.ROOT_NODE)
-			.setPredicateEditable(WorkflowPredicates.WORKFLOW_VERSION_DRAFT);
 	}
 
 	@Override


### PR DESCRIPTION
Removed the nuance that "finalized" workflows cant be edited in any way.
Reasoning: Permissions to edit and create are already set to Administrators, and they should know what to do.