### PR TITLE
PLAT-1359 BufferedEmailSenderSessionManager: Use finite timeouts

### DIFF
--- a/platform-core-module/src/main/java/com/softicar/platform/core/module/email/buffer/BufferedEmailSender.java
+++ b/platform-core-module/src/main/java/com/softicar/platform/core/module/email/buffer/BufferedEmailSender.java
@@ -41,7 +41,7 @@ public class BufferedEmailSender {
 
 	public void sendAll() {
 
-		Log.finfo("Sending e-mails...");
+		Log.finfo("Sending emails...");
 		AGBufferedEmail.TABLE//
 			.createSelect()
 			.where(AGBufferedEmail.ACTIVE)
@@ -49,7 +49,7 @@ public class BufferedEmailSender {
 			.where(AGBufferedEmail.EMAIL_SERVER.isEqual(emailServer))
 			.orderBy(AGBufferedEmail.ID)
 			.forEach(this::send);
-		Log.finfo("done");
+		Log.finfo("Done sending emails.");
 		exceptionsCollector.throwIfNotEmpty();
 	}
 

--- a/platform-core-module/src/main/java/com/softicar/platform/core/module/email/buffer/BufferedEmailSenderSessionManager.java
+++ b/platform-core-module/src/main/java/com/softicar/platform/core/module/email/buffer/BufferedEmailSenderSessionManager.java
@@ -37,21 +37,21 @@ public class BufferedEmailSenderSessionManager {
 
 		public SessionProperties(AGServer server) {
 
-			// basics
+			// connection
 			put("mail.smtp.host", server.getAddress());
 			put("mail.smtp.port", server.getPort());
 			put("mail.smtp.user", server.getUsername());
 			put("mail.transport.protocol", "smtp");
 
-			// timeouts
-			put("mail.smtp.connectiontimeout", Duration.ofSeconds(30).toMillis());
-			put("mail.smtp.timeout", Duration.ofSeconds(30).toMillis());
-			put("mail.smtp.writetimeout", Duration.ofSeconds(30).toMillis());
-
 			// security
 			put("mail.smtp.auth", "true");
 			put("mail.smtp.ssl.trust", "*");
 			put("mail.smtp.starttls.enable", "true");
+
+			// timeouts
+			put("mail.smtp.connectiontimeout", Duration.ofSeconds(30).toMillis());
+			put("mail.smtp.timeout", Duration.ofSeconds(30).toMillis());
+			put("mail.smtp.writetimeout", Duration.ofSeconds(30).toMillis());
 		}
 	}
 

--- a/platform-core-module/src/main/java/com/softicar/platform/core/module/email/buffer/BufferedEmailSenderSessionManager.java
+++ b/platform-core-module/src/main/java/com/softicar/platform/core/module/email/buffer/BufferedEmailSenderSessionManager.java
@@ -4,6 +4,7 @@ import com.softicar.platform.core.module.server.AGServer;
 import jakarta.mail.Authenticator;
 import jakarta.mail.PasswordAuthentication;
 import jakarta.mail.Session;
+import java.time.Duration;
 import java.util.Map;
 import java.util.Properties;
 import java.util.TreeMap;
@@ -27,18 +28,30 @@ public class BufferedEmailSenderSessionManager {
 		return Session.getInstance(new SessionProperties(server), new PasswordAuthenticator(server));
 	}
 
+	/**
+	 * See <a href=
+	 * "https://javaee.github.io/javamail/docs/api/index.html?com/sun/mail/smtp/package-summary.html">com.sun.mail.smtp
+	 * properties documentation</a>.
+	 */
 	private static class SessionProperties extends Properties {
 
 		public SessionProperties(AGServer server) {
 
-			put("mail.transport.protocol", "smtp");
-			put("mail.smtp.starttls.enable", "true");
-//			put("mail.smtp.starttls.required", "true");
+			// basics
 			put("mail.smtp.host", server.getAddress());
 			put("mail.smtp.port", server.getPort());
 			put("mail.smtp.user", server.getUsername());
+			put("mail.transport.protocol", "smtp");
+
+			// timeouts
+			put("mail.smtp.connectiontimeout", Duration.ofSeconds(30).toMillis());
+			put("mail.smtp.timeout", Duration.ofSeconds(30).toMillis());
+			put("mail.smtp.writetimeout", Duration.ofSeconds(30).toMillis());
+
+			// security
 			put("mail.smtp.auth", "true");
 			put("mail.smtp.ssl.trust", "*");
+			put("mail.smtp.starttls.enable", "true");
 		}
 	}
 

--- a/platform-core-module/src/main/java/com/softicar/platform/core/module/email/buffer/BufferedEmailSenderSessionManager.java
+++ b/platform-core-module/src/main/java/com/softicar/platform/core/module/email/buffer/BufferedEmailSenderSessionManager.java
@@ -35,6 +35,8 @@ public class BufferedEmailSenderSessionManager {
 	 */
 	private static class SessionProperties extends Properties {
 
+		private static final long SMTP_TIMEOUT = Duration.ofSeconds(30).toMillis();
+
 		public SessionProperties(AGServer server) {
 
 			// connection
@@ -49,9 +51,9 @@ public class BufferedEmailSenderSessionManager {
 			put("mail.smtp.starttls.enable", "true");
 
 			// timeouts
-			put("mail.smtp.connectiontimeout", Duration.ofSeconds(30).toMillis());
-			put("mail.smtp.timeout", Duration.ofSeconds(30).toMillis());
-			put("mail.smtp.writetimeout", Duration.ofSeconds(30).toMillis());
+			put("mail.smtp.connectiontimeout", SMTP_TIMEOUT);
+			put("mail.smtp.timeout", SMTP_TIMEOUT);
+			put("mail.smtp.writetimeout", SMTP_TIMEOUT);
 		}
 	}
 


### PR DESCRIPTION
Added 30s timeouts:
- `mail.smtp.connectiontimeout`
- `mail.smtp.timeout`
- `mail.smtp.writetimeout`
