### PR TITLE
PLAT-1363 Set SMTP properties as String

### DIFF
--- a/platform-core-module/src/main/java/com/softicar/platform/core/module/email/buffer/BufferedEmailSendProgram.java
+++ b/platform-core-module/src/main/java/com/softicar/platform/core/module/email/buffer/BufferedEmailSendProgram.java
@@ -26,10 +26,11 @@ public class BufferedEmailSendProgram implements IProgram {
 	@Override
 	public void executeProgram() {
 
-		Log.finfo("Sending emails...");
+		Log.finfo("Sending emails for all servers...");
 		new Retrier(this::sendForAllServers)//
 			.setRetryDelay(RETRY_DELAY_MILLIS)
 			.apply();
+		Log.finfo("Done sending emails for all servers.");
 
 		Log.finfo("Cleaning emails...");
 		new BufferedEmailCleaner().cleanAll();

--- a/platform-core-module/src/main/java/com/softicar/platform/core/module/email/buffer/BufferedEmailSender.java
+++ b/platform-core-module/src/main/java/com/softicar/platform/core/module/email/buffer/BufferedEmailSender.java
@@ -61,6 +61,7 @@ public class BufferedEmailSender {
 				MimeMessage mimeMessage = createMimeMessage(email);
 				// send email
 				if (EmailSystemProperties.SENDING_ENABLED.getValue()) {
+					Log.finfo("Sending email #%s...", email.getId());
 					Transport.send(mimeMessage);
 					Log.finfo("Sent email #%s.", email.getId());
 				}

--- a/platform-core-module/src/main/java/com/softicar/platform/core/module/email/buffer/BufferedEmailSenderSessionManager.java
+++ b/platform-core-module/src/main/java/com/softicar/platform/core/module/email/buffer/BufferedEmailSenderSessionManager.java
@@ -35,7 +35,7 @@ public class BufferedEmailSenderSessionManager {
 	 */
 	private static class SessionProperties extends Properties {
 
-		private static final long SMTP_TIMEOUT = Duration.ofSeconds(30).toMillis();
+		private static final String SMTP_TIMEOUT = Duration.ofSeconds(30).toMillis() + "";
 
 		public SessionProperties(AGServer server) {
 


### PR DESCRIPTION
- Before this PR, we set SMTP timeout properties as `long` values.
- A literal interpretation of the documentation at (https://javaee.github.io/javamail/docs/api/com/sun/mail/smtp/package-summary.html) implies that properties need to be set as String:
  > The SMTP protocol provider supports the following properties, which may be set in the JavaMail Session object. The properties are always set as strings; the Type column describes how the string is interpreted.

Unrelated:
- Slightly improved log output.
