### PR TITLE
PLAT-1402 Module Data Prefetching by PageNavigationEntriesLoader

### DIFF
--- a/platform-core-module/src/main/java/com/softicar/platform/core/module/page/navigation/entry/PageNavigationEntriesLoader.java
+++ b/platform-core-module/src/main/java/com/softicar/platform/core/module/page/navigation/entry/PageNavigationEntriesLoader.java
@@ -42,7 +42,10 @@ public class PageNavigationEntriesLoader<I extends IEmfModuleInstance<I>> {
 
 	private void loadEntriesForModule(IEmfModule<I> module) {
 
-		for (I moduleInstance: module.getActiveModuleInstances()) {
+		var activeModuleInstances = module.getActiveModuleInstances();
+		module.prefetchPageLinkGenerationData(activeModuleInstances);
+
+		for (I moduleInstance: activeModuleInstances) {
 			EmfPagePath moduleFolderPath = module.getDefaultPagePath(moduleInstance);
 			for (IEmfPage<I> page: EmfPages.getPages(module)) {
 				if (isAccessGranted(page, moduleInstance)) {


### PR DESCRIPTION
**Test Plan**: Connect EAS and observe reduced number of executed SELECT statements.

Before:
```
[   149ms,    7x] SELECT t.`id`, t.`moduleInstance`, t.`name`, t.`active` FROM `Invoice`.`InvoiceGroup` t WHERE t.`active` AND (t.`moduleInstance` IN (?)) ORDER BY t.`id`
```

After:
```
[    23ms,    1x] SELECT t.`id`, t.`moduleInstance`, t.`name`, t.`active` FROM `Invoice`.`InvoiceGroup` t WHERE t.`active` AND (t.`moduleInstance` IN (?,?,?,?,?,?,?)) ORDER BY t.`id`
```