### PR TITLE
PLAT-1398 Add en-overwrite for I18n-Keys

### DIFF
--- a/platform-common/src/main/java/com/softicar/platform/common/core/i18n/I18nKeyDisplayString.java
+++ b/platform-common/src/main/java/com/softicar/platform/common/core/i18n/I18nKeyDisplayString.java
@@ -35,6 +35,6 @@ class I18nKeyDisplayString implements IDisplayString {
 
 	private String getFallbackTranslation() {
 
-		return InternalI18nTranslator.translate(key.toEnglish(), arguments);
+		return InternalI18nTranslator.translate(key.getDefault(), arguments);
 	}
 }

--- a/platform-common/src/main/java/com/softicar/platform/common/core/i18n/key/AbstractI18nKey.java
+++ b/platform-common/src/main/java/com/softicar/platform/common/core/i18n/key/AbstractI18nKey.java
@@ -19,6 +19,8 @@ public abstract class AbstractI18nKey<T extends AbstractI18nKey<T>> implements I
 
 	private final Map<LanguageEnum, String> texts;
 
+	private final String defaultEnglish;
+
 	/**
 	 * Constructs this object with the English text as key.
 	 *
@@ -28,7 +30,14 @@ public abstract class AbstractI18nKey<T extends AbstractI18nKey<T>> implements I
 	protected AbstractI18nKey(String english) {
 
 		this.texts = new HashMap<>();
+		this.defaultEnglish = english;
 		put(LanguageEnum.ENGLISH, english);
+	}
+
+	@Override
+	public String getDefault() {
+
+		return defaultEnglish;
 	}
 
 	@Override
@@ -58,6 +67,18 @@ public abstract class AbstractI18nKey<T extends AbstractI18nKey<T>> implements I
 	public String toString() {
 
 		return toEnglish();
+	}
+
+	/**
+	 * Overwrites the English text.
+	 *
+	 * @param english
+	 *            the new English text (never <i>null</i>)
+	 * @return this
+	 */
+	public T en(String english) {
+
+		return put(LanguageEnum.ENGLISH, english);
 	}
 
 	/**

--- a/platform-common/src/main/java/com/softicar/platform/common/core/i18n/key/II18nKey.java
+++ b/platform-common/src/main/java/com/softicar/platform/common/core/i18n/key/II18nKey.java
@@ -16,6 +16,13 @@ import java.util.Optional;
 public interface II18nKey {
 
 	/**
+	 * Returns the default {@link String} of this {@link II18nKey}.
+	 *
+	 * @return the default {@link String} (never null)
+	 */
+	String getDefault();
+
+	/**
 	 * Returns the English {@link String} of this {@link II18nKey}.
 	 *
 	 * @return the English {@link String} (never null)

--- a/platform-common/src/main/java/com/softicar/platform/common/core/i18n/key/container/validator/I18nKeyContainerFieldValueValidator.java
+++ b/platform-common/src/main/java/com/softicar/platform/common/core/i18n/key/container/validator/I18nKeyContainerFieldValueValidator.java
@@ -24,7 +24,7 @@ import java.util.Optional;
 class I18nKeyContainerFieldValueValidator extends AbstractConstantContainerFieldValueValidator<II18nKey> {
 
 	private final Collection<LanguageEnum> mandatoryLanguages;
-	private String englishString;
+	private String defaultEnglishString;
 	private int formatSpecifierCount;
 	private ConstantContainerValidatorResult<II18nKey> result;
 	private II18nKey fieldValue;
@@ -41,8 +41,8 @@ class I18nKeyContainerFieldValueValidator extends AbstractConstantContainerField
 		this.result = result;
 		this.fieldValue = fieldValue;
 
-		this.englishString = fieldValue.toEnglish();
-		this.formatSpecifierCount = new I18nKeyComputer(englishString).computeArgumentCount();
+		this.defaultEnglishString = fieldValue.getDefault();
+		this.formatSpecifierCount = new I18nKeyComputer(defaultEnglishString).computeArgumentCount();
 
 		validateEnglishString();
 		validateMandatoryTranslations();
@@ -53,12 +53,12 @@ class I18nKeyContainerFieldValueValidator extends AbstractConstantContainerField
 
 	private void validateEnglishString() {
 
-		if (englishString.isEmpty()) {
-			result.addError(new I18nKeyContainerFieldIllegalEnglishStringError(field, "English string is empty."));
-		} else if (!englishString.trim().equals(englishString)) {
-			result.addError(new I18nKeyContainerFieldIllegalEnglishStringError(field, "English string has leading or trailing whitespace."));
-		} else if (isMoreThanOneSentence(englishString)) {
-			result.addError(new I18nKeyContainerFieldIllegalEnglishStringError(field, "English string contains more than one sentence."));
+		if (defaultEnglishString.isEmpty()) {
+			result.addError(new I18nKeyContainerFieldIllegalEnglishStringError(field, "Default English string is empty."));
+		} else if (!defaultEnglishString.trim().equals(defaultEnglishString)) {
+			result.addError(new I18nKeyContainerFieldIllegalEnglishStringError(field, "Default English string has leading or trailing whitespace."));
+		} else if (isMoreThanOneSentence(defaultEnglishString)) {
+			result.addError(new I18nKeyContainerFieldIllegalEnglishStringError(field, "Default English string contains more than one sentence."));
 		}
 	}
 
@@ -109,7 +109,7 @@ class I18nKeyContainerFieldValueValidator extends AbstractConstantContainerField
 
 	private void validateFieldName() {
 
-		String expectedName = new I18nKeyComputer(englishString).compute();
+		String expectedName = new I18nKeyComputer(defaultEnglishString).compute();
 		if (!field.getName().equals(expectedName)) {
 			result.addError(new ConstantContainerFieldUnexpectedNameError<>(field, expectedName));
 		}


### PR DESCRIPTION
  - added new `default` translation thats set when creating the key
  - the `default` value is used as a basis for checking I18n-Field-Names in the validator
  - added `.en` method to enable changing of English translation