### PR TITLE
EXP-3130: Fix OutOfMemoryError in ProgramExecutionPage

### DIFF
--- a/platform-core-module/src/main/java/com/softicar/platform/core/module/program/execution/AGProgramExecution.java
+++ b/platform-core-module/src/main/java/com/softicar/platform/core/module/program/execution/AGProgramExecution.java
@@ -4,6 +4,7 @@ import com.softicar.platform.common.core.i18n.IDisplayString;
 import com.softicar.platform.common.date.DayTime;
 import com.softicar.platform.core.module.program.AGProgram;
 import com.softicar.platform.core.module.program.Programs;
+import com.softicar.platform.core.module.program.execution.status.ProgramExecutionStatus;
 import com.softicar.platform.core.module.program.execution.status.ProgramExecutionStatusField;
 import com.softicar.platform.core.module.uuid.AGUuid;
 import com.softicar.platform.emf.object.IEmfObject;
@@ -101,5 +102,10 @@ public class AGProgramExecution extends AGProgramExecutionGenerated implements I
 			.ofNullable(getTerminatedAt())
 			.orElse(DayTime.now())
 			.toInstant();
+	}
+
+	public ProgramExecutionStatus getStatus() {
+
+		return STATUS_FIELD.getValue(this);
 	}
 }

--- a/platform-core-module/src/main/java/com/softicar/platform/core/module/program/execution/AGProgramExecution.java
+++ b/platform-core-module/src/main/java/com/softicar/platform/core/module/program/execution/AGProgramExecution.java
@@ -104,6 +104,11 @@ public class AGProgramExecution extends AGProgramExecutionGenerated implements I
 			.toInstant();
 	}
 
+	public Duration getRuntime() {
+
+		return RUNTIME_FIELD.getValue(this);
+	}
+
 	public ProgramExecutionStatus getStatus() {
 
 		return STATUS_FIELD.getValue(this);

--- a/platform-core-module/src/main/java/com/softicar/platform/core/module/program/execution/IProgramExecutionsQuery.java
+++ b/platform-core-module/src/main/java/com/softicar/platform/core/module/program/execution/IProgramExecutionsQuery.java
@@ -33,6 +33,7 @@ public interface IProgramExecutionsQuery extends IDbQuery<IProgramExecutionsQuer
 	IDbQueryColumn<IRow, Long> ID_COLUMN = new DbQueryColumn<>(IRow::getId, "id", SqlValueTypes.LONG, CoreI18n.ID);
 	IDbQueryTableColumn<IRow, AGProgram> PROGRAM_COLUMN = new DbQueryTableStubColumn<>(IRow::getProgram, "program", AGProgram.TABLE, CoreI18n.PROGRAM);
 	IDbQueryColumn<IRow, Long> STATUS_COLUMN = new DbQueryColumn<>(IRow::getStatus, "status", SqlValueTypes.LONG, CoreI18n.STATUS);
+	IDbQueryColumn<IRow, Boolean> FAILED_COLUMN = new DbQueryColumn<>(IRow::getFailed, "failed", SqlValueTypes.BOOLEAN, CoreI18n.FAILED);
 	IDbQueryColumn<IRow, Long> RUNTIME_COLUMN = new DbQueryColumn<>(IRow::getRuntime, "runtime", SqlValueTypes.LONG, CoreI18n.RUNTIME);
 	IDbQueryColumn<IRow, DayTime> STARTED_AT_COLUMN = new DbQueryColumn<>(IRow::getStartedAt, "startedAt", SqlValueTypes.DAY_TIME, CoreI18n.STARTED_AT);
 	IDbQueryColumn<IRow, DayTime> TERMINATED_AT_COLUMN = new DbQueryColumn<>(IRow::getTerminatedAt, "terminatedAt", SqlValueTypes.DAY_TIME, CoreI18n.TERMINATED_AT);
@@ -47,6 +48,7 @@ public interface IProgramExecutionsQuery extends IDbQuery<IProgramExecutionsQuer
 		Long getId();
 		AGProgram getProgram();
 		Long getStatus();
+		Boolean getFailed();
 		Long getRuntime();
 		DayTime getStartedAt();
 		DayTime getTerminatedAt();
@@ -65,13 +67,14 @@ public interface IProgramExecutionsQuery extends IDbQuery<IProgramExecutionsQuer
 
 		private static class Factory implements IFactory {
 
-			private List<IDbQueryColumn<IRow, ?>> columns = new ArrayList<>(8);
+			private List<IDbQueryColumn<IRow, ?>> columns = new ArrayList<>(9);
 
 			public Factory() {
 
 				this.columns.add(ID_COLUMN);
 				this.columns.add(PROGRAM_COLUMN);
 				this.columns.add(STATUS_COLUMN);
+				this.columns.add(FAILED_COLUMN);
 				this.columns.add(RUNTIME_COLUMN);
 				this.columns.add(STARTED_AT_COLUMN);
 				this.columns.add(TERMINATED_AT_COLUMN);
@@ -128,6 +131,10 @@ public interface IProgramExecutionsQuery extends IDbQuery<IProgramExecutionsQuer
 					addIdentifier("programExecution", AGProgramExecution.ID);
 					addToken(SqlKeyword.AS);
 					addIdentifier("status");
+					SELECT(FAILED_COLUMN);
+					addIdentifier("programExecution", AGProgramExecution.FAILED);
+					addToken(SqlKeyword.AS);
+					addIdentifier("failed");
 					SELECT(RUNTIME_COLUMN);
 					addIdentifier("programExecution", AGProgramExecution.ID);
 					addToken(SqlKeyword.AS);
@@ -177,6 +184,7 @@ public interface IProgramExecutionsQuery extends IDbQuery<IProgramExecutionsQuer
 			private final Long id;
 			private final AGProgram program;
 			private final Long status;
+			private final Boolean failed;
 			private final Long runtime;
 			private final DayTime startedAt;
 			private final DayTime terminatedAt;
@@ -190,6 +198,7 @@ public interface IProgramExecutionsQuery extends IDbQuery<IProgramExecutionsQuer
 				this.id = ID_COLUMN.loadValue(select, resultSet);
 				this.program = PROGRAM_COLUMN.loadValue(select, resultSet);
 				this.status = STATUS_COLUMN.loadValue(select, resultSet);
+				this.failed = FAILED_COLUMN.loadValue(select, resultSet);
 				this.runtime = RUNTIME_COLUMN.loadValue(select, resultSet);
 				this.startedAt = STARTED_AT_COLUMN.loadValue(select, resultSet);
 				this.terminatedAt = TERMINATED_AT_COLUMN.loadValue(select, resultSet);
@@ -219,6 +228,12 @@ public interface IProgramExecutionsQuery extends IDbQuery<IProgramExecutionsQuer
 			public Long getStatus() {
 
 				return this.status;
+			}
+
+			@Override
+			public Boolean getFailed() {
+
+				return this.failed;
 			}
 
 			@Override

--- a/platform-core-module/src/main/java/com/softicar/platform/core/module/program/execution/IProgramExecutionsQuery.java
+++ b/platform-core-module/src/main/java/com/softicar/platform/core/module/program/execution/IProgramExecutionsQuery.java
@@ -1,0 +1,163 @@
+package com.softicar.platform.core.module.program.execution;
+
+import com.softicar.platform.common.core.annotations.Generated;
+import com.softicar.platform.core.module.program.AGProgram;
+import com.softicar.platform.core.module.uuid.AGUuid;
+import com.softicar.platform.db.core.DbResultSet;
+import com.softicar.platform.db.runtime.query.AbstractDbQuery;
+import com.softicar.platform.db.runtime.query.AbstractDbQueryRow;
+import com.softicar.platform.db.runtime.query.DbQueryColumn;
+import com.softicar.platform.db.runtime.query.DbQueryTableStubColumn;
+import com.softicar.platform.db.runtime.query.IDbQuery;
+import com.softicar.platform.db.runtime.query.IDbQueryColumn;
+import com.softicar.platform.db.runtime.query.IDbQueryFactory;
+import com.softicar.platform.db.runtime.query.IDbQueryRow;
+import com.softicar.platform.db.runtime.query.IDbQueryTableColumn;
+import com.softicar.platform.db.runtime.query.builder.AbstractDbQuerySqlBuilder;
+import com.softicar.platform.db.runtime.select.IDbSqlSelect;
+import com.softicar.platform.db.sql.token.SqlKeyword;
+import com.softicar.platform.db.sql.token.SqlSymbol;
+import com.softicar.platform.db.sql.type.SqlValueTypes;
+import java.util.ArrayList;
+import java.util.List;
+
+@Generated
+@SuppressWarnings("all")
+public interface IProgramExecutionsQuery extends IDbQuery<IProgramExecutionsQuery.IRow> {
+
+	// -------------------------------- CONSTANTS -------------------------------- //
+
+	IDbQueryColumn<IRow, Long> ID_COLUMN = new DbQueryColumn<>(IRow::getId, "id", SqlValueTypes.LONG);
+	IDbQueryTableColumn<IRow, AGProgram> PROGRAM_COLUMN = new DbQueryTableStubColumn<>(IRow::getProgram, "program", AGProgram.TABLE);
+	IFactory FACTORY = new Implementation.Factory();
+
+	// -------------------------------- INTERFACES -------------------------------- //
+
+	interface IRow extends IDbQueryRow<IRow> {
+
+		Long getId();
+		AGProgram getProgram();
+	}
+
+	interface IFactory extends IDbQueryFactory<IRow> {
+
+		IProgramExecutionsQuery createQuery();
+	}
+
+	// -------------------------------- IMPLEMENTATION -------------------------------- //
+
+	class Implementation {
+
+		private static class Factory implements IFactory {
+
+			private List<IDbQueryColumn<IRow, ?>> columns = new ArrayList<>(2);
+
+			public Factory() {
+
+				this.columns.add(ID_COLUMN);
+				this.columns.add(PROGRAM_COLUMN);
+			}
+
+			@Override
+			public IProgramExecutionsQuery createQuery() {
+
+				return new Query();
+			}
+
+			@Override
+			public List<IDbQueryColumn<IRow, ?>> getColumns() {
+
+				return columns;
+			}
+		}
+
+		private static class Query extends AbstractDbQuery<IRow> implements IProgramExecutionsQuery {
+
+			@Override
+			public IRow createRow(IDbSqlSelect select, DbResultSet resultSet) {
+
+				return new Row(this, select, resultSet);
+			}
+
+			@Override
+			public List<IDbQueryColumn<IRow, ?>> getColumns() {
+
+				return FACTORY.getColumns();
+			}
+
+			@Override
+			public QuerySqlBuilder createSqlBuilder() {
+
+				return new QuerySqlBuilder();
+			}
+
+			private class QuerySqlBuilder extends AbstractDbQuerySqlBuilder {
+
+				public void buildOriginalSelect() {
+
+					SELECT(ID_COLUMN);
+					addIdentifier("programExecution", AGProgramExecution.ID);
+					addToken(SqlKeyword.AS);
+					addIdentifier("id");
+					SELECT(PROGRAM_COLUMN);
+					addIdentifier("program", AGProgram.ID);
+					addToken(SqlKeyword.AS);
+					addIdentifier("program");
+					FROM();
+					addIdentifier(AGProgramExecution.TABLE);
+					addToken(SqlKeyword.AS);
+					addIdentifier("programExecution");
+					JOIN(null);
+					addIdentifier(AGUuid.TABLE);
+					addToken(SqlKeyword.AS);
+					addIdentifier("programUuid");
+					ON();
+					addIdentifier("programExecution", AGProgramExecution.PROGRAM_UUID);
+					addToken(SqlSymbol.EQUAL);
+					addIdentifier("programUuid", AGUuid.ID);
+					JOIN(null);
+					addIdentifier(AGProgram.TABLE);
+					addToken(SqlKeyword.AS);
+					addIdentifier("program");
+					ON();
+					addIdentifier("program", AGProgram.PROGRAM_UUID);
+					addToken(SqlSymbol.EQUAL);
+					addIdentifier("programUuid", AGUuid.ID);
+				}
+			}
+		}
+
+		private static class Row extends AbstractDbQueryRow<IRow> implements IRow {
+
+			private final Long id;
+			private final AGProgram program;
+
+			private Row(IProgramExecutionsQuery query, IDbSqlSelect select, DbResultSet resultSet) {
+
+				super(query);
+
+				this.id = ID_COLUMN.loadValue(select, resultSet);
+				this.program = PROGRAM_COLUMN.loadValue(select, resultSet);
+			}
+
+			@Override
+			public Row getThis() {
+
+				return this;
+			}
+
+			@Override
+			public Long getId() {
+
+				return this.id;
+			}
+
+			@Override
+			public AGProgram getProgram() {
+
+				return this.program;
+			}
+		}
+	}
+}
+

--- a/platform-core-module/src/main/java/com/softicar/platform/core/module/program/execution/IProgramExecutionsQuery.java
+++ b/platform-core-module/src/main/java/com/softicar/platform/core/module/program/execution/IProgramExecutionsQuery.java
@@ -1,7 +1,10 @@
 package com.softicar.platform.core.module.program.execution;
 
 import com.softicar.platform.common.core.annotations.Generated;
+import com.softicar.platform.common.date.DayTime;
+import com.softicar.platform.core.module.CoreI18n;
 import com.softicar.platform.core.module.program.AGProgram;
+import com.softicar.platform.core.module.user.AGUser;
 import com.softicar.platform.core.module.uuid.AGUuid;
 import com.softicar.platform.db.core.DbResultSet;
 import com.softicar.platform.db.runtime.query.AbstractDbQuery;
@@ -27,8 +30,14 @@ public interface IProgramExecutionsQuery extends IDbQuery<IProgramExecutionsQuer
 
 	// -------------------------------- CONSTANTS -------------------------------- //
 
-	IDbQueryColumn<IRow, Long> ID_COLUMN = new DbQueryColumn<>(IRow::getId, "id", SqlValueTypes.LONG);
-	IDbQueryTableColumn<IRow, AGProgram> PROGRAM_COLUMN = new DbQueryTableStubColumn<>(IRow::getProgram, "program", AGProgram.TABLE);
+	IDbQueryColumn<IRow, Long> ID_COLUMN = new DbQueryColumn<>(IRow::getId, "id", SqlValueTypes.LONG, CoreI18n.ID);
+	IDbQueryTableColumn<IRow, AGProgram> PROGRAM_COLUMN = new DbQueryTableStubColumn<>(IRow::getProgram, "program", AGProgram.TABLE, CoreI18n.PROGRAM);
+	IDbQueryColumn<IRow, Long> STATUS_COLUMN = new DbQueryColumn<>(IRow::getStatus, "status", SqlValueTypes.LONG, CoreI18n.STATUS);
+	IDbQueryColumn<IRow, Long> RUNTIME_COLUMN = new DbQueryColumn<>(IRow::getRuntime, "runtime", SqlValueTypes.LONG, CoreI18n.RUNTIME);
+	IDbQueryColumn<IRow, DayTime> STARTED_AT_COLUMN = new DbQueryColumn<>(IRow::getStartedAt, "startedAt", SqlValueTypes.DAY_TIME, CoreI18n.STARTED_AT);
+	IDbQueryColumn<IRow, DayTime> TERMINATED_AT_COLUMN = new DbQueryColumn<>(IRow::getTerminatedAt, "terminatedAt", SqlValueTypes.DAY_TIME, CoreI18n.TERMINATED_AT);
+	IDbQueryColumn<IRow, Long> OUTPUT_COLUMN = new DbQueryColumn<>(IRow::getOutput, "output", SqlValueTypes.LONG, CoreI18n.OUTPUT);
+	IDbQueryTableColumn<IRow, AGUser> QUEUED_BY_COLUMN = new DbQueryTableStubColumn<>(IRow::getQueuedBy, "queuedBy", AGUser.TABLE, CoreI18n.QUEUED_BY);
 	IFactory FACTORY = new Implementation.Factory();
 
 	// -------------------------------- INTERFACES -------------------------------- //
@@ -37,6 +46,12 @@ public interface IProgramExecutionsQuery extends IDbQuery<IProgramExecutionsQuer
 
 		Long getId();
 		AGProgram getProgram();
+		Long getStatus();
+		Long getRuntime();
+		DayTime getStartedAt();
+		DayTime getTerminatedAt();
+		Long getOutput();
+		AGUser getQueuedBy();
 	}
 
 	interface IFactory extends IDbQueryFactory<IRow> {
@@ -50,12 +65,18 @@ public interface IProgramExecutionsQuery extends IDbQuery<IProgramExecutionsQuer
 
 		private static class Factory implements IFactory {
 
-			private List<IDbQueryColumn<IRow, ?>> columns = new ArrayList<>(2);
+			private List<IDbQueryColumn<IRow, ?>> columns = new ArrayList<>(8);
 
 			public Factory() {
 
 				this.columns.add(ID_COLUMN);
 				this.columns.add(PROGRAM_COLUMN);
+				this.columns.add(STATUS_COLUMN);
+				this.columns.add(RUNTIME_COLUMN);
+				this.columns.add(STARTED_AT_COLUMN);
+				this.columns.add(TERMINATED_AT_COLUMN);
+				this.columns.add(OUTPUT_COLUMN);
+				this.columns.add(QUEUED_BY_COLUMN);
 			}
 
 			@Override
@@ -103,6 +124,30 @@ public interface IProgramExecutionsQuery extends IDbQuery<IProgramExecutionsQuer
 					addIdentifier("program", AGProgram.ID);
 					addToken(SqlKeyword.AS);
 					addIdentifier("program");
+					SELECT(STATUS_COLUMN);
+					addIdentifier("programExecution", AGProgramExecution.ID);
+					addToken(SqlKeyword.AS);
+					addIdentifier("status");
+					SELECT(RUNTIME_COLUMN);
+					addIdentifier("programExecution", AGProgramExecution.ID);
+					addToken(SqlKeyword.AS);
+					addIdentifier("runtime");
+					SELECT(STARTED_AT_COLUMN);
+					addIdentifier("programExecution", AGProgramExecution.STARTED_AT);
+					addToken(SqlKeyword.AS);
+					addIdentifier("startedAt");
+					SELECT(TERMINATED_AT_COLUMN);
+					addIdentifier("programExecution", AGProgramExecution.TERMINATED_AT);
+					addToken(SqlKeyword.AS);
+					addIdentifier("terminatedAt");
+					SELECT(OUTPUT_COLUMN);
+					addIdentifier("programExecution", AGProgramExecution.ID);
+					addToken(SqlKeyword.AS);
+					addIdentifier("output");
+					SELECT(QUEUED_BY_COLUMN);
+					addIdentifier("programExecution", AGProgramExecution.QUEUED_BY);
+					addToken(SqlKeyword.AS);
+					addIdentifier("queuedBy");
 					FROM();
 					addIdentifier(AGProgramExecution.TABLE);
 					addToken(SqlKeyword.AS);
@@ -131,6 +176,12 @@ public interface IProgramExecutionsQuery extends IDbQuery<IProgramExecutionsQuer
 
 			private final Long id;
 			private final AGProgram program;
+			private final Long status;
+			private final Long runtime;
+			private final DayTime startedAt;
+			private final DayTime terminatedAt;
+			private final Long output;
+			private final AGUser queuedBy;
 
 			private Row(IProgramExecutionsQuery query, IDbSqlSelect select, DbResultSet resultSet) {
 
@@ -138,6 +189,12 @@ public interface IProgramExecutionsQuery extends IDbQuery<IProgramExecutionsQuer
 
 				this.id = ID_COLUMN.loadValue(select, resultSet);
 				this.program = PROGRAM_COLUMN.loadValue(select, resultSet);
+				this.status = STATUS_COLUMN.loadValue(select, resultSet);
+				this.runtime = RUNTIME_COLUMN.loadValue(select, resultSet);
+				this.startedAt = STARTED_AT_COLUMN.loadValue(select, resultSet);
+				this.terminatedAt = TERMINATED_AT_COLUMN.loadValue(select, resultSet);
+				this.output = OUTPUT_COLUMN.loadValue(select, resultSet);
+				this.queuedBy = QUEUED_BY_COLUMN.loadValue(select, resultSet);
 			}
 
 			@Override
@@ -156,6 +213,42 @@ public interface IProgramExecutionsQuery extends IDbQuery<IProgramExecutionsQuer
 			public AGProgram getProgram() {
 
 				return this.program;
+			}
+
+			@Override
+			public Long getStatus() {
+
+				return this.status;
+			}
+
+			@Override
+			public Long getRuntime() {
+
+				return this.runtime;
+			}
+
+			@Override
+			public DayTime getStartedAt() {
+
+				return this.startedAt;
+			}
+
+			@Override
+			public DayTime getTerminatedAt() {
+
+				return this.terminatedAt;
+			}
+
+			@Override
+			public Long getOutput() {
+
+				return this.output;
+			}
+
+			@Override
+			public AGUser getQueuedBy() {
+
+				return this.queuedBy;
 			}
 		}
 	}

--- a/platform-core-module/src/main/java/com/softicar/platform/core/module/program/execution/ProgramExecutionPage.java
+++ b/platform-core-module/src/main/java/com/softicar/platform/core/module/program/execution/ProgramExecutionPage.java
@@ -1,20 +1,17 @@
 package com.softicar.platform.core.module.program.execution;
 
 import com.softicar.platform.common.code.reference.point.SourceCodeReferencePointUuid;
+import com.softicar.platform.common.core.i18n.IDisplayString;
 import com.softicar.platform.core.module.AGCoreModuleInstance;
 import com.softicar.platform.core.module.CoreI18n;
 import com.softicar.platform.core.module.CoreModule;
 import com.softicar.platform.core.module.CorePermissions;
-import com.softicar.platform.core.module.program.ProgramMaintenanceMessageBar;
-import com.softicar.platform.dom.elements.DomDiv;
 import com.softicar.platform.dom.node.IDomNode;
-import com.softicar.platform.emf.management.page.AbstractEmfManagementPage;
-import com.softicar.platform.emf.module.permission.IEmfModulePermission;
-import com.softicar.platform.emf.page.EmfPagePath;
-import com.softicar.platform.emf.table.IEmfTable;
+import com.softicar.platform.emf.page.IEmfPage;
+import com.softicar.platform.emf.permission.IEmfPermission;
 
 @SourceCodeReferencePointUuid("5ff82872-cd52-46ec-a76a-f35ca142322a")
-public class ProgramExecutionPage extends AbstractEmfManagementPage<AGCoreModuleInstance> {
+public class ProgramExecutionPage implements IEmfPage<AGCoreModuleInstance> {
 
 	@Override
 	public Class<CoreModule> getModuleClass() {
@@ -23,29 +20,20 @@ public class ProgramExecutionPage extends AbstractEmfManagementPage<AGCoreModule
 	}
 
 	@Override
-	protected IEmfTable<?, ?, AGCoreModuleInstance> getTable() {
+	public IDisplayString getTitle(AGCoreModuleInstance moduleInstance) {
 
-		return AGProgramExecution.TABLE;
-	}
-
-	@Override
-	public IEmfModulePermission<AGCoreModuleInstance> getRequiredPermission() {
-
-		return CorePermissions.OPERATION;
-	}
-
-	@Override
-	public EmfPagePath getPagePath(EmfPagePath modulePath) {
-
-		return modulePath.append(CoreI18n.PROGRAMS);
+		return CoreI18n.PROGRAM_EXECUTIONS;
 	}
 
 	@Override
 	public IDomNode createContentNode(AGCoreModuleInstance moduleInstance) {
 
-		var div = new DomDiv();
-		div.appendChild(new ProgramMaintenanceMessageBar());
-		div.appendChild(super.createContentNode(moduleInstance));
-		return div;
+		return new ProgramExecutionsDiv();
+	}
+
+	@Override
+	public IEmfPermission<AGCoreModuleInstance> getRequiredPermission() {
+
+		return CorePermissions.OPERATION;
 	}
 }

--- a/platform-core-module/src/main/java/com/softicar/platform/core/module/program/execution/ProgramExecutionPage.java
+++ b/platform-core-module/src/main/java/com/softicar/platform/core/module/program/execution/ProgramExecutionPage.java
@@ -6,9 +6,12 @@ import com.softicar.platform.core.module.AGCoreModuleInstance;
 import com.softicar.platform.core.module.CoreI18n;
 import com.softicar.platform.core.module.CoreModule;
 import com.softicar.platform.core.module.CorePermissions;
+import com.softicar.platform.core.module.program.ProgramMaintenanceMessageBar;
+import com.softicar.platform.dom.elements.DomDiv;
 import com.softicar.platform.dom.node.IDomNode;
+import com.softicar.platform.emf.module.permission.IEmfModulePermission;
+import com.softicar.platform.emf.page.EmfPagePath;
 import com.softicar.platform.emf.page.IEmfPage;
-import com.softicar.platform.emf.permission.IEmfPermission;
 
 @SourceCodeReferencePointUuid("5ff82872-cd52-46ec-a76a-f35ca142322a")
 public class ProgramExecutionPage implements IEmfPage<AGCoreModuleInstance> {
@@ -26,14 +29,23 @@ public class ProgramExecutionPage implements IEmfPage<AGCoreModuleInstance> {
 	}
 
 	@Override
-	public IDomNode createContentNode(AGCoreModuleInstance moduleInstance) {
+	public IEmfModulePermission<AGCoreModuleInstance> getRequiredPermission() {
 
-		return new ProgramExecutionsDiv();
+		return CorePermissions.OPERATION;
 	}
 
 	@Override
-	public IEmfPermission<AGCoreModuleInstance> getRequiredPermission() {
+	public EmfPagePath getPagePath(EmfPagePath modulePath) {
 
-		return CorePermissions.OPERATION;
+		return modulePath.append(CoreI18n.PROGRAMS);
+	}
+
+	@Override
+	public IDomNode createContentNode(AGCoreModuleInstance moduleInstance) {
+
+		DomDiv div = new DomDiv();
+		div.appendChild(new ProgramMaintenanceMessageBar());
+		div.appendChild(new ProgramExecutionsDiv());
+		return div;
 	}
 }

--- a/platform-core-module/src/main/java/com/softicar/platform/core/module/program/execution/ProgramExecutionsDiv.java
+++ b/platform-core-module/src/main/java/com/softicar/platform/core/module/program/execution/ProgramExecutionsDiv.java
@@ -2,15 +2,16 @@ package com.softicar.platform.core.module.program.execution;
 
 import com.softicar.platform.core.module.CoreI18n;
 import com.softicar.platform.core.module.program.execution.IProgramExecutionsQuery.IRow;
+import com.softicar.platform.core.module.program.execution.status.ProgramExecutionStatusDisplay;
 import com.softicar.platform.dom.elements.DomDiv;
 import com.softicar.platform.dom.elements.bar.DomActionBar;
 import com.softicar.platform.dom.elements.button.DomButton;
 import com.softicar.platform.emf.EmfImages;
+import com.softicar.platform.emf.attribute.field.duration.EmfDurationDisplay;
 import com.softicar.platform.emf.data.table.EmfDataTableDivBuilder;
 import com.softicar.platform.emf.data.table.IEmfDataTableCell;
 import com.softicar.platform.emf.data.table.IEmfDataTableDiv;
-import com.softicar.platform.emf.data.table.column.IEmfDataTableColumn;
-import com.softicar.platform.emf.data.table.column.handler.EmfDataTableValueBasedColumnHandler;
+import com.softicar.platform.emf.data.table.column.handler.AbstractEmfDataTableColumnHandler;
 
 class ProgramExecutionsDiv extends DomDiv {
 
@@ -20,6 +21,8 @@ class ProgramExecutionsDiv extends DomDiv {
 
 		table = new EmfDataTableDivBuilder<>(IProgramExecutionsQuery.FACTORY.createQuery())//
 			.setColumnHandler(IProgramExecutionsQuery.STATUS_COLUMN, new StatusColumnHandler())
+			.setColumnHandler(IProgramExecutionsQuery.RUNTIME_COLUMN, new RuntimeColumnHandler())
+			.setColumnHandler(IProgramExecutionsQuery.OUTPUT_COLUMN, new OutputColumnHandler())
 			.build();
 
 		appendChild(new DomActionBar(new RefreshButton()));
@@ -36,19 +39,33 @@ class ProgramExecutionsDiv extends DomDiv {
 		}
 	}
 
-	private static class StatusColumnHandler extends EmfDataTableValueBasedColumnHandler<Long> {
+	private static class StatusColumnHandler extends AbstractEmfDataTableColumnHandler<Long> {
 
 		@Override
 		public void buildCell(IEmfDataTableCell<?, Long> cell, Long value) {
 
 			AGProgramExecution programExecution = AGProgramExecution.get(value.intValue());
-			cell.appendText(programExecution.getStatus().toDisplay());
+			cell.appendChild(new ProgramExecutionStatusDisplay(programExecution.getStatus()));
 		}
+	}
+
+	private static class RuntimeColumnHandler extends AbstractEmfDataTableColumnHandler<Long> {
 
 		@Override
-		public boolean isSortable(IEmfDataTableColumn<?, Long> column) {
+		public void buildCell(IEmfDataTableCell<?, Long> cell, Long value) {
 
-			return super.isSortable(column);
+			AGProgramExecution programExecution = AGProgramExecution.get(value.intValue());
+			cell.appendChild(new EmfDurationDisplay(programExecution.getRuntime()));
+		}
+	}
+
+	private static class OutputColumnHandler extends AbstractEmfDataTableColumnHandler<Long> {
+
+		@Override
+		public void buildCell(IEmfDataTableCell<?, Long> cell, Long value) {
+
+			AGProgramExecution programExecution = AGProgramExecution.get(value.intValue());
+			cell.appendChild(new ProgramExecutionOutputDisplay(programExecution));
 		}
 	}
 }

--- a/platform-core-module/src/main/java/com/softicar/platform/core/module/program/execution/ProgramExecutionsDiv.java
+++ b/platform-core-module/src/main/java/com/softicar/platform/core/module/program/execution/ProgramExecutionsDiv.java
@@ -7,7 +7,10 @@ import com.softicar.platform.dom.elements.bar.DomActionBar;
 import com.softicar.platform.dom.elements.button.DomButton;
 import com.softicar.platform.emf.EmfImages;
 import com.softicar.platform.emf.data.table.EmfDataTableDivBuilder;
+import com.softicar.platform.emf.data.table.IEmfDataTableCell;
 import com.softicar.platform.emf.data.table.IEmfDataTableDiv;
+import com.softicar.platform.emf.data.table.column.IEmfDataTableColumn;
+import com.softicar.platform.emf.data.table.column.handler.EmfDataTableValueBasedColumnHandler;
 
 class ProgramExecutionsDiv extends DomDiv {
 
@@ -16,9 +19,7 @@ class ProgramExecutionsDiv extends DomDiv {
 	public ProgramExecutionsDiv() {
 
 		table = new EmfDataTableDivBuilder<>(IProgramExecutionsQuery.FACTORY.createQuery())//
-//			.setActionColumnHandler(this::buildActionCell)
-//			.setColumnHandler(IProgramExecutionsQuery.FILE_COLUMN, new StoredFileColumnHandler())
-//			.setColumnHandler(IProgramExecutionsQuery.JSON_COLUMN, new JsonColumnHandler())
+			.setColumnHandler(IProgramExecutionsQuery.STATUS_COLUMN, new StatusColumnHandler())
 			.build();
 
 		appendChild(new DomActionBar(new RefreshButton()));
@@ -35,20 +36,19 @@ class ProgramExecutionsDiv extends DomDiv {
 		}
 	}
 
-//	private static class JsonColumnHandler extends EmfDataTableRowBasedColumnHandler<IParashiftDocumentsQuery.IRow, String> {
-//
-//		@Override
-//		public void buildCell(IEmfDataTableCell<IParashiftDocumentsQuery.IRow, String> cell, IParashiftDocumentsQuery.IRow row) {
-//
-//			DomActionBar actionBar = new DomActionBar();
-//			actionBar.appendChild(new JsonDisplayPopupButtonDiv(row.getJson()));
-//			cell.appendChild(actionBar);
-//		}
-//
-//		@Override
-//		public boolean isSortable(IEmfDataTableColumn<?, String> column) {
-//
-//			return false;
-//		}
-//	}
+	private static class StatusColumnHandler extends EmfDataTableValueBasedColumnHandler<Long> {
+
+		@Override
+		public void buildCell(IEmfDataTableCell<?, Long> cell, Long value) {
+
+			AGProgramExecution programExecution = AGProgramExecution.get(value.intValue());
+			cell.appendText(programExecution.getStatus().toDisplay());
+		}
+
+		@Override
+		public boolean isSortable(IEmfDataTableColumn<?, Long> column) {
+
+			return super.isSortable(column);
+		}
+	}
 }

--- a/platform-core-module/src/main/java/com/softicar/platform/core/module/program/execution/ProgramExecutionsDiv.java
+++ b/platform-core-module/src/main/java/com/softicar/platform/core/module/program/execution/ProgramExecutionsDiv.java
@@ -1,0 +1,54 @@
+package com.softicar.platform.core.module.program.execution;
+
+import com.softicar.platform.core.module.CoreI18n;
+import com.softicar.platform.core.module.program.execution.IProgramExecutionsQuery.IRow;
+import com.softicar.platform.dom.elements.DomDiv;
+import com.softicar.platform.dom.elements.bar.DomActionBar;
+import com.softicar.platform.dom.elements.button.DomButton;
+import com.softicar.platform.emf.EmfImages;
+import com.softicar.platform.emf.data.table.EmfDataTableDivBuilder;
+import com.softicar.platform.emf.data.table.IEmfDataTableDiv;
+
+class ProgramExecutionsDiv extends DomDiv {
+
+	private final IEmfDataTableDiv<IRow> table;
+
+	public ProgramExecutionsDiv() {
+
+		table = new EmfDataTableDivBuilder<>(IProgramExecutionsQuery.FACTORY.createQuery())//
+//			.setActionColumnHandler(this::buildActionCell)
+//			.setColumnHandler(IProgramExecutionsQuery.FILE_COLUMN, new StoredFileColumnHandler())
+//			.setColumnHandler(IProgramExecutionsQuery.JSON_COLUMN, new JsonColumnHandler())
+			.build();
+
+		appendChild(new DomActionBar(new RefreshButton()));
+		appendChild(table);
+	}
+
+	private class RefreshButton extends DomButton {
+
+		public RefreshButton() {
+
+			setLabel(CoreI18n.REFRESH);
+			setIcon(EmfImages.REFRESH.getResource());
+			setClickCallback(table::refresh);
+		}
+	}
+
+//	private static class JsonColumnHandler extends EmfDataTableRowBasedColumnHandler<IParashiftDocumentsQuery.IRow, String> {
+//
+//		@Override
+//		public void buildCell(IEmfDataTableCell<IParashiftDocumentsQuery.IRow, String> cell, IParashiftDocumentsQuery.IRow row) {
+//
+//			DomActionBar actionBar = new DomActionBar();
+//			actionBar.appendChild(new JsonDisplayPopupButtonDiv(row.getJson()));
+//			cell.appendChild(actionBar);
+//		}
+//
+//		@Override
+//		public boolean isSortable(IEmfDataTableColumn<?, String> column) {
+//
+//			return false;
+//		}
+//	}
+}

--- a/platform-core-module/src/main/java/com/softicar/platform/core/module/program/execution/ProgramExecutionsQuery.sqml
+++ b/platform-core-module/src/main/java/com/softicar/platform/core/module/program/execution/ProgramExecutionsQuery.sqml
@@ -4,8 +4,14 @@ IMPORT com.softicar.platform.core.module.program.AGProgram
 
 QUERY ProgramExecutionsQuery {
 	
-	SELECT programExecution.id
-	SELECT program
+	SELECT programExecution.id TITLE 'ID'
+	SELECT program TITLE 'Program'
+	SELECT programExecution.id AS status TITLE 'Status'
+	SELECT programExecution.id AS runtime TITLE 'Runtime'
+	SELECT programExecution.startedAt TITLE 'Started at'
+	SELECT programExecution.terminatedAt TITLE 'Terminated at'
+	SELECT programExecution.id AS output TITLE 'Output'
+	SELECT programExecution.queuedBy TITLE 'Queued by'
 	
 	FROM AGProgramExecution programExecution
 	JOIN programExecution.programUuid programUuid

--- a/platform-core-module/src/main/java/com/softicar/platform/core/module/program/execution/ProgramExecutionsQuery.sqml
+++ b/platform-core-module/src/main/java/com/softicar/platform/core/module/program/execution/ProgramExecutionsQuery.sqml
@@ -1,0 +1,13 @@
+PACKAGE com.softicar.platform.core.module.program.execution
+
+IMPORT com.softicar.platform.core.module.program.AGProgram
+
+QUERY ProgramExecutionsQuery {
+	
+	SELECT programExecution.id
+	SELECT program
+	
+	FROM AGProgramExecution programExecution
+	JOIN programExecution.programUuid programUuid
+	JOIN AGProgram program ON program.programUuid = programUuid		
+}

--- a/platform-core-module/src/main/java/com/softicar/platform/core/module/program/execution/ProgramExecutionsQuery.sqml
+++ b/platform-core-module/src/main/java/com/softicar/platform/core/module/program/execution/ProgramExecutionsQuery.sqml
@@ -2,11 +2,18 @@ PACKAGE com.softicar.platform.core.module.program.execution
 
 IMPORT com.softicar.platform.core.module.program.AGProgram
 
+
+FUNCTION String getInt(String value) {
+	SQL {CONCAT($value, ' :-)')}
+}
+
+
 QUERY ProgramExecutionsQuery {
 	
 	SELECT programExecution.id TITLE 'ID'
 	SELECT program TITLE 'Program'
 	SELECT programExecution.id AS status TITLE 'Status'
+	SELECT programExecution.failed TITLE 'Failed'
 	SELECT programExecution.id AS runtime TITLE 'Runtime'
 	SELECT programExecution.startedAt TITLE 'Started at'
 	SELECT programExecution.terminatedAt TITLE 'Terminated at'

--- a/platform-core-module/src/main/java/com/softicar/platform/core/module/program/execution/ProgramExecutionsQuery.sqml
+++ b/platform-core-module/src/main/java/com/softicar/platform/core/module/program/execution/ProgramExecutionsQuery.sqml
@@ -3,11 +3,6 @@ PACKAGE com.softicar.platform.core.module.program.execution
 IMPORT com.softicar.platform.core.module.program.AGProgram
 
 
-FUNCTION String getInt(String value) {
-	SQL {CONCAT($value, ' :-)')}
-}
-
-
 QUERY ProgramExecutionsQuery {
 	
 	SELECT programExecution.id TITLE 'ID'


### PR DESCRIPTION
If there are too many records or the records consume too much memory (column `ProgramExecution.output` is of type "longtext"!), you will get `OutOfMemoryError`!


**Stacktrace:**
```
java.lang.OutOfMemoryError: Java heap space
	at java.base/java.lang.String.<init>(String.java:568)
	at org.mariadb.jdbc.internal.com.read.resultset.rowprotocol.TextRowProtocol.getInternalString(TextRowProtocol.java:240)
	at org.mariadb.jdbc.internal.com.read.resultset.SelectResultSet.getString(SelectResultSet.java:948)
	at com.softicar.platform.db.core.DbResultSet.getString(DbResultSet.java:267)
	at com.softicar.platform.db.sql.type.SqlStringType.getValue(SqlStringType.java:16)
	at com.softicar.platform.db.sql.type.SqlStringType.getValue(SqlStringType.java:11)
	at com.softicar.platform.db.runtime.table.logic.DbTableRowResultSetReader.setFieldFromResultSet(DbTableRowResultSetReader.java:65)
	at com.softicar.platform.db.runtime.table.logic.DbTableRowResultSetReader.setDataFieldsFromResultSet(DbTableRowResultSetReader.java:57)
	at com.softicar.platform.db.runtime.table.logic.DbTableRowResultSetReader.read(DbTableRowResultSetReader.java:42)
	at com.softicar.platform.db.runtime.table.DbTable.getValue(DbTable.java:139)
	at com.softicar.platform.db.runtime.table.DbTable.getValue(DbTable.java:52)
	at com.softicar.platform.db.runtime.table.statements.DbTableSelect.lambda$createResultSetIterator$1(DbTableSelect.java:55)
	at com.softicar.platform.db.runtime.table.statements.DbTableSelect$$Lambda$459/0x00000008012b4b00.apply(Unknown Source)
	at com.softicar.platform.db.core.DbResultSetIterator.fetchNext(DbResultSetIterator.java:55)
	at com.softicar.platform.db.core.DbResultSetIterator.next(DbResultSetIterator.java:41)
	at java.base/java.util.Iterator.forEachRemaining(Iterator.java:133)
	at java.base/java.util.Spliterators$IteratorSpliterator.forEachRemaining(Spliterators.java:1845)
	at java.base/java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:509)
	at java.base/java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:499)
	at java.base/java.util.stream.ReduceOps$ReduceOp.evaluateSequential(ReduceOps.java:921)
	at java.base/java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234)
	at java.base/java.util.stream.ReferencePipeline.collect(ReferencePipeline.java:682)
	at com.softicar.platform.db.sql.statement.base.AbstractSqlSelectOrJoin.list(AbstractSqlSelectOrJoin.java:66)
	at com.softicar.platform.db.sql.statement.base.AbstractSqlSelectOrJoin.list(AbstractSqlSelectOrJoin.java:53)
	at com.softicar.platform.emf.management.EmfManagementDataTable.getAuthorizedEntities(EmfManagementDataTable.java:119)
	at com.softicar.platform.emf.management.EmfManagementDataTable.getTableRows(EmfManagementDataTable.java:97)
	at com.softicar.platform.common.container.data.table.in.memory.AbstractInMemoryDataTable$$Lambda$4391/0x00000008019eedb8.get(Unknown Source)
	at com.softicar.platform.common.container.data.table.in.memory.InMemoryCachingRowProvider.filterRows(InMemoryCachingRowProvider.java:139)
	at com.softicar.platform.common.container.data.table.in.memory.InMemoryCachingRowProvider.filterAndSortAllRows(InMemoryCachingRowProvider.java:131)
	at com.softicar.platform.common.container.data.table.in.memory.InMemoryCachingRowProvider.getRowCount(InMemoryCachingRowProvider.java:66)
	at com.softicar.platform.common.container.data.table.in.memory.AbstractInMemoryDataTable.count(AbstractInMemoryDataTable.java:81)
	at com.softicar.platform.emf.data.table.EmfDataTable.loadRowCount(EmfDataTable.java:255)
```


